### PR TITLE
Adds speaker layout for events page

### DIFF
--- a/app/components/public/speaker-item.js
+++ b/app/components/public/speaker-item.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  classNames: ['column', 'four', 'wide']
+});

--- a/app/components/public/speaker-list.js
+++ b/app/components/public/speaker-list.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+});

--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -4,6 +4,12 @@ const { Controller, computed, String } = Ember;
 
 export default Controller.extend({
 
+  speakers: [{  name: 'Speaker 1', organisation: 'Org 1' },
+  { name: 'Speaker 2', organisation: 'Org 2', socialLinks: [{ name: 'facebook', url: '#' }] },
+  { name: 'Speaker 3', organisation: 'Org 3', socialLinks: [{ name: 'linkedin', url: '#' }] },
+  { name: 'Speaker 4', organisation: 'Org 4', socialLinks: [{ name: 'twitter', url: '#' }] },
+  { name: 'Speaker 5', organisation: 'Org 5', socialLinks: [{ name: 'home', url: '#' }] }],
+
   htmlSafeDescription: computed('model.event.description', function() {
     return String.htmlSafe(this.get('model.event.description'));
   })

--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -84,7 +84,7 @@
     }
   }
 
-  .event.description {
+  .description {
     text-align: justify;
   }
 }

--- a/app/styles/partials/all.scss
+++ b/app/styles/partials/all.scss
@@ -11,3 +11,4 @@
 @import "form";
 @import "buttons";
 @import "notifications";
+@import "speaker";

--- a/app/styles/partials/speaker.scss
+++ b/app/styles/partials/speaker.scss
@@ -1,0 +1,16 @@
+.speaker-item {
+  margin: 0;
+
+  .speaker-name {
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .social-links {
+    margin-top: 5px;
+
+    i{
+      margin: 0;
+    }
+  }
+}

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -1,0 +1,12 @@
+<div class="speaker-item">
+
+  <img alt="{{speaker.name}}" class="ui image" src="{{if speaker.image speaker.image '/images/placeholders/avatar.png'}}">
+  <br>
+  <div class="speaker-name">{{speaker.name}}</div>
+  <div class="speaker-organisation">{{speaker.organisation}}</div>
+  <div class="social-links">
+    {{#each speaker.socialLinks as |link|}}
+      <a href="{{link.url}}" target="_blank" rel="noopener noreferrer"><i class="bordered {{link.name}} colored inverted icon"></i></a>
+    {{/each}}
+  </div>
+</div>

--- a/app/templates/components/public/speaker-list.hbs
+++ b/app/templates/components/public/speaker-list.hbs
@@ -1,0 +1,6 @@
+<h3>{{t 'Speakers'}}</h3>
+<div class="speaker-list ui grid">
+  {{#each speakers as |speaker|}}
+    {{public/speaker-item speaker=speaker}}
+  {{/each}}
+</div>

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -1,3 +1,10 @@
-<div class="event description">
-  {{sanitize model.event.description}}
+<div class='event'>
+  <div class='description'>
+    {{sanitize model.event.description}}
+  </div>
+  <div class='speakers'>
+    <div class="row">
+      {{public/speaker-list speakers=speakers}}
+    </div>
+  </div>
 </div>

--- a/tests/integration/components/public/speaker-item-test.js
+++ b/tests/integration/components/public/speaker-item-test.js
@@ -1,0 +1,15 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('public/speaker-item', 'Integration | Component | public/speaker item');
+
+const speaker = { name: 'USER 1', organisation: 'FOSSASIA', socialLinks: [{ name: 'facebook', url: '#' }] };
+
+test('it renders', function(assert) {
+
+  this.set('speaker', speaker);
+  this.render(hbs `{{public/speaker-item speaker=speaker}}`);
+
+  assert.ok(this.$().html().trim().includes('FOSSASIA'));
+});

--- a/tests/integration/components/public/speaker-list-test.js
+++ b/tests/integration/components/public/speaker-list-test.js
@@ -1,0 +1,18 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('public/speaker-list', 'Integration | Component | public/speaker list');
+
+const speakers = [
+  { name: 'USER 1', organisation: 'FOSSASIA', socialLinks: [{ name: 'facebook', url: '#' }] },
+  { name: 'USER 2', organisation: 'FOSSASIA', socialLinks: [{ name: 'linkedin', url: '#' }] }
+];
+
+test('it renders', function(assert) {
+
+  this.set('speakers', speakers);
+  this.render(hbs `{{public/speaker-list speakers=speakers}}`);
+
+  assert.ok(this.$().html().trim().includes('FOSSASIA'));
+});


### PR DESCRIPTION
Adds layout for speakers to the public event page. 

**Screenshot**
![screenshot from 2017-05-08 16-08-23](https://cloud.githubusercontent.com/assets/12807846/25800911/db01d348-3408-11e7-9ed1-c11473d61f1d.png)

Fixes #13  
@niranjan94 Please review this. Thanks 
