### PR TITLE
Make rails responsive on public event page

### DIFF
--- a/app/controllers/public.js
+++ b/app/controllers/public.js
@@ -7,5 +7,10 @@ export default Controller.extend({
     if (this.get('session.currentRouteName')) {
       return this.get('session.currentRouteName') !== 'public.index';
     }
-  })
+  }),
+  actions: {
+    toggleMenu() {
+      this.toggleProperty('isMenuOpen');
+    }
+  }
 });

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,4 +1,4 @@
-<div class="ui vertical pointing menu">
+<div class="ui fluid vertical {{unless device.isMobile 'pointing'}} menu">
   <a class="item {{if (eq session.currentRouteName 'public.index') 'active'}}" href="{{href-to 'public.index'}}">
     Info
   </a>

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -1,4 +1,4 @@
-<div class="public-event ui container">
+<div class="public-event">
   <div class="lead {{if smallLead 'small'}}">
     {{widgets/safe-image src=(if model.large model.large model.placeholderUrl)}}
     <div class="content">
@@ -15,18 +15,25 @@
     </div>
   </div>
   <div class="content {{if smallLead 'with small lead'}}">
-    <div class="ui basic segment" id="public-event-content">
-      <div class="left ui rail">
-        <div class="ui basic segment">
+    <div class="ui stackable grid " id="public-event-content">
+      <div class="three wide column">
+        {{#if device.isMobile}}
+          <button {{action "toggleMenu"}} class="ui basic icon button mobile only">
+            <i class="content icon"></i>
+          </button>
+          {{#if isMenuOpen}}
+            {{public/side-menu class='toggle menu'}}
+          {{/if}}
+        {{else}}
           {{#ui-sticky context='#public-event-content' observeChanges=true}}
             {{public/side-menu}}
           {{/ui-sticky}}
-        </div>
+        {{/if}}
       </div>
-      <div>
+      <div class="ten wide column">
         {{outlet}}
       </div>
-      <div class="right ui rail">
+      <div class="three wide column" style="height:100vh;overflow: hidden; !important">
         {{public/social-links eventUrl=model.eventUrl socialLinks=model.socialLinks}}
       </div>
     </div>

--- a/tests/integration/components/public/side-menu-test.js
+++ b/tests/integration/components/public/side-menu-test.js
@@ -6,6 +6,6 @@ moduleForComponent('public/side-menu', 'Integration | Component | public/side me
 
 test('it renders', function(assert) {
   this.render(hbs`{{public/side-menu}}`);
-  assert.ok(this.$().html().trim().includes('ui vertical pointing menu'));
+  assert.ok(this.$().html().trim().includes('ui fluid vertical pointing menu'));
   assert.ok(this.$().html().trim().includes('Getting here'));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Replaces the rails with standard menu to make it stackable and responsive on the mobile
#### Changes proposed in this pull request:

-
-
-
![giphy](https://cloud.githubusercontent.com/assets/17252805/26024475/8393c5c2-37ef-11e7-9cf6-403f4df3e205.gif)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #30 
