### PR TITLE
Fixes the small screen overflow of order now button in tickets

### DIFF
--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -61,8 +61,8 @@
 </div>
 <div class="ui segment">
   <div class="ui grid">
-    <div class="ui row grid">
-      <div class="ui padding less fourteen wide column right aligned floated payment icons">
+    <div class="ui row stackable grid">
+      <div class="ui padding less fourteen wide computer twelve wide tablet column right aligned floated payment icons">
         <i class="colored american express link icon"></i>
         <i class="colored credit card alternative link icon"></i>
         <i class="colored diners club link icon"></i>
@@ -71,7 +71,7 @@
         <i class="colored paypal card link icon"></i>
         <i class="colored visa link icon"></i>
       </div>
-      <div class="ui padding less two wide column right aligned floated">
+      <div class="ui padding less two wide computer four wide tablet column right aligned floated">
         <div id="total" class="ui primary button">
           {{t 'Order Now'}}
         </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
On the mobile portrait view, there is an overflow in the row containing order now button.
![image](https://cloud.githubusercontent.com/assets/17252805/26285584/fca33c7a-3e7c-11e7-9a86-2b89ff8fbc8b.png)


#### Changes proposed in this pull request:

**Mobile portrait**
![image](https://cloud.githubusercontent.com/assets/17252805/26285590/0b35ce9c-3e7d-11e7-90dd-9359c034acf8.png)

**Mobile landscape**
![image](https://cloud.githubusercontent.com/assets/17252805/26285592/1bb218a2-3e7d-11e7-83fe-6efae77cc499.png)

**Tablet**
![image](https://cloud.githubusercontent.com/assets/17252805/26285596/2e945ac0-3e7d-11e7-958d-9fc27cd377b4.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #
