### PR TITLE
added map and location on public event page

### DIFF
--- a/app/components/public/event-map.js
+++ b/app/components/public/event-map.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  classNames: ['ui', 'grid']
+});

--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -104,3 +104,12 @@
     margin-top: 15px;
   }
 }
+
+.event-map > .g-map {
+    height: 100%;
+}
+
+.event-map > .g-map > .g-map-canvas {
+   width: 500px;
+   height: 400px;
+}

--- a/app/templates/components/public/event-map.hbs
+++ b/app/templates/components/public/event-map.hbs
@@ -1,0 +1,9 @@
+<div class="eight wide column event-map">
+  {{#g-map lat=event.latitude lng=event.longitude zoom=12 gestureHandling='cooperative' streetView='StreetViewPanorama' as |context|}}
+    {{g-map-marker context lat=event.latitude lng=event.longitude}}
+  {{/g-map}}
+</div>
+<div class="eight wide column address">
+  <h1>{{t 'Address'}}</h1>
+  <p>{{event.locationName}}</p>
+</div>

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -25,6 +25,11 @@
     </div>
   </div>
   <div class="ui hidden divider"></div>
+  <h1>{{t 'Getting Here'}}</h1>
+  <div class="location">
+    {{public/event-map event=model.event}}
+  </div>
+  <div class="ui hidden divider"></div>
   <div class="copyright">
     {{public/copyright-item licenseName='Attribution'}}
   </div>

--- a/tests/integration/components/public/event-map-test.js
+++ b/tests/integration/components/public/event-map-test.js
@@ -1,0 +1,13 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('public/event-map', 'Integration | Component | public/event map');
+
+let event = Object.create({ latitude: 37.7833, longitude: -122.4167, locationName: 'Sample event location address' });
+
+test('it renders', function(assert) {
+  this.set('event', event);
+  this.render(hbs `{{public/event-map event=event}}`);
+  assert.equal(this.$('.address p').text(), 'Sample event location address');
+});


### PR DESCRIPTION
added map and location with the street view two fingers dragging on touchscreen devices on the public event page.

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Added location and address support to public event page.

#### Changes proposed in this pull request:

-Added location and address support



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #14 
