### PR TITLE
Add UI for event export

### DIFF
--- a/app/components/events/view/export/api-response.js
+++ b/app/components/events/view/export/api-response.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+const { Component, computed, String } = Ember;
+
+export default Component.extend({
+  json: computed(function() {
+    var sample = '{\n "name": "Sample event",\n "starts_at" : "2017-03-10T17:00:0",\n "ends_at":"2017-03-12T17:00:0"\n}';
+    return String.htmlSafe(syntaxHighlight(sample));
+  })
+});
+
+function syntaxHighlight(json) {
+  json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function(match) {
+    var cls = 'number';
+    if (/^"/.test(match)) {
+      if (/:$/.test(match)) {
+        cls = 'key';
+      } else {
+        cls = 'string';
+      }
+    } else if (/true|false/.test(match)) {
+      cls = 'boolean';
+    } else if (/null/.test(match)) {
+      cls = 'null';
+    }
+    return `<span class=" ${cls}"> ${match}</span>`;
+  });
+}

--- a/app/components/events/view/export/download-common.js
+++ b/app/components/events/view/export/download-common.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+});

--- a/app/components/events/view/export/download-zip.js
+++ b/app/components/events/view/export/download-zip.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+});

--- a/app/router.js
+++ b/app/router.js
@@ -44,6 +44,7 @@ router.map(function() {
         this.route('sponsors');
         this.route('sessions-speakers');
       });
+      this.route('export');
     });
     this.route('live');
     this.route('draft');

--- a/app/routes/events/view/export.js
+++ b/app/routes/events/view/export.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+});

--- a/app/styles/components/all.scss
+++ b/app/styles/components/all.scss
@@ -2,3 +2,4 @@
 @import 'notification-dropdown';
 @import 'speaker-list';
 @import 'explore/side-bar';
+@import 'events/view/export';

--- a/app/styles/components/events/view/export.scss
+++ b/app/styles/components/events/view/export.scss
@@ -1,0 +1,27 @@
+.response .string {
+  color: green;
+}
+
+.response .number {
+  color: darkorange;
+}
+
+.response .boolean {
+  color: blue;
+}
+
+.response .null {
+  color: magenta;
+}
+
+.response .key {
+  color: red;
+}
+
+.json.response {
+  max-height: 650px;
+}
+
+.url {
+  padding: 0 1em !important;
+}

--- a/app/templates/components/events/view/export/api-response.hbs
+++ b/app/templates/components/events/view/export/api-response.hbs
@@ -1,0 +1,42 @@
+<h3 class="ui header">
+  <div class="content">
+    {{t 'Access event information via REST API'}}
+  </div>
+</h3>
+<div class="ui hidden divider">
+</div>
+<div class="ui form">
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Basic Event Details')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Sessions')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Microlocations')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Tracks')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Speakers')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Sponsors')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Tickets')}}
+  </div>
+</div>
+<div class="ui secondary header">
+  {{t 'You can make a GET request to the following endpoint to access the selected information'}}
+</div>
+<div class="ui secondary segment url">
+  <pre>http://localhost:5000/api/v1/events/7?include=sessions</pre>
+</div>
+<div class="ui secondry header">
+  {{t 'Response'}}
+</div>
+<div class="ui secondry segment json response">
+  <pre>{{json}}</pre>
+</div>

--- a/app/templates/components/events/view/export/download-common.hbs
+++ b/app/templates/components/events/view/export/download-common.hbs
@@ -1,0 +1,12 @@
+<h3 class="ui header">
+  <div class="content">
+    {{t 'Download Event as'}} {{downloadType}}
+  </div>
+  <div class="sub header">
+    {{t 'Once the event is live and the schedule is published,'}} {{downloadType}} {{t ' version of the schedule will be available at:'}}
+  </div>
+</h3>
+<div class="ui secondary segment url">
+  <pre>http://localhost:5000/e/280a30d7/schedule/{{downloadUrl}}</pre>
+</div>
+<a class="ui link" href="#"> {{t 'Alternatively, you can download the'}} {{downloadType}} {{t ' here'}}</a>

--- a/app/templates/components/events/view/export/download-zip.hbs
+++ b/app/templates/components/events/view/export/download-zip.hbs
@@ -1,0 +1,32 @@
+<h3 class="ui header">
+  <div class="content">
+    {{t 'Export and Download Event as Zip'}}
+    <div class="sub header">
+      {{t 'Select the media files you want in the zip'}}
+    </div>
+  </div>
+</h3>
+<div class="ui hidden divider"></div>
+<div class="ui container"></div>
+<div class="ui form">
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Image')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Video')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Audio')}}
+  </div>
+  <div class="field">
+    {{ui-checkbox class="toggle" label=(t 'Document')}}
+  </div>
+  <div class="ui basic segment" style="padding-left:0">
+    <button class="ui blue button">
+      {{t 'Start'}}
+    </button>
+    <button class="ui button">
+      {{t 'Download'}}
+    </button>
+  </div>
+</div>

--- a/app/templates/events/view/export.hbs
+++ b/app/templates/events/view/export.hbs
@@ -1,0 +1,14 @@
+<div class="ui stackable very relaxed container grid">
+  <div class="eight wide column">
+    {{events/view/export/download-zip}}
+    <div class="ui divider"></div>
+    {{events/view/export/download-common downloadType='Pentabarf XML' downloadUrl='pentabarf.xml'}}
+    <div class="ui divider"></div>
+    {{events/view/export/download-common downloadType='iCalendar' downloadUrl='calendar.ics'}}
+    <div class="ui divider"></div>
+    {{events/view/export/download-common downloadType='iCalendar XML (xCal)' downloadUrl='calendar.xcs'}}
+  </div>
+  <div class="eight wide column">
+    {{events/view/export/api-response}}
+  </div>
+</div>

--- a/tests/integration/components/events/view/export/api-response-test.js
+++ b/tests/integration/components/events/view/export/api-response-test.js
@@ -1,0 +1,10 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('events/view/export/api-response', 'Integration | Component | events/view/export/api response');
+
+test('it renders', function(assert) {
+  this.render(hbs`{{events/view/export/api-response i18n=i18n}}`);
+  assert.ok(this.$().html().trim().includes('Access event information'));
+});

--- a/tests/integration/components/events/view/export/download-common-test.js
+++ b/tests/integration/components/events/view/export/download-common-test.js
@@ -1,0 +1,10 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('events/view/export/download-common', 'Integration | Component | events/view/export/download common');
+
+test('it renders', function(assert) {
+  this.render(hbs`{{events/view/export/download-common i18n=i18n}}`);
+  assert.ok(this.$().html().trim().includes('Download Event'));
+});

--- a/tests/integration/components/events/view/export/download-zip-test.js
+++ b/tests/integration/components/events/view/export/download-zip-test.js
@@ -1,0 +1,10 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('events/view/export/download-zip', 'Integration | Component | events/view/export/download zip');
+
+test('it renders', function(assert) {
+  this.render(hbs`{{events/view/export/download-zip i18n=i18n}}`);
+  assert.ok(this.$().html().trim().includes('Zip'));
+});

--- a/tests/unit/routes/events/view/export-test.js
+++ b/tests/unit/routes/events/view/export-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('route:events/view/export', 'Unit | Route | events/view/export', []);
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds the UI for event export page.

#### Changes proposed in this pull request:
![image](https://cloud.githubusercontent.com/assets/17252805/26488666/f97fd208-4221-11e7-844f-263049667412.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #82 
