### PR TITLE
Fix map component overflow on smaller screens

### DIFF
--- a/app/components/public/event-map.js
+++ b/app/components/public/event-map.js
@@ -3,5 +3,5 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  classNames: ['ui', 'grid']
+  classNames: ['ui', 'stackable', 'grid']
 });

--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -107,9 +107,9 @@
 
 .event-map > .g-map {
     height: 100%;
+    width: 100%;
 }
 
 .event-map > .g-map > .g-map-canvas {
-   width: 500px;
-   height: 400px;
+   height: 300px;
 }

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -25,8 +25,8 @@
     </div>
   </div>
   <div class="ui hidden divider"></div>
-  <h1 id="getting-here">{{t 'Getting Here'}}</h1>
   <div class="location">
+    <h1 id="getting-here">{{t 'Getting Here'}}</h1>
     {{public/event-map event=model.event}}
   </div>
   <div class="ui hidden divider"></div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

![image](https://cloud.githubusercontent.com/assets/17252805/26518540/2512b206-42d0-11e7-9de1-719984ba7021.png)
Over flow of map component

#### Changes proposed in this pull request:


![image](https://cloud.githubusercontent.com/assets/17252805/26518516/cdcfd73a-42cf-11e7-916e-142588757f74.png)

![image](https://cloud.githubusercontent.com/assets/17252805/26518522/de4ddd14-42cf-11e7-9ca1-1cbe92234fb7.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #95 
