### PR TITLE
fix: reset the scroll upon tab change on public event menu

### DIFF
--- a/app/mixins/reset-scroll-position.js
+++ b/app/mixins/reset-scroll-position.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const { Mixin } = Ember;
+
+export default Mixin.create({
+  activate() {
+    this._super();
+    window.scrollTo(0, 0);
+  }
+
+});

--- a/app/routes/public/cfs.js
+++ b/app/routes/public/cfs.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import ResetScrollPositionMixin from 'open-event-frontend/mixins/reset-scroll-position';
 
 const { Route, RSVP } = Ember;
 
-export default Route.extend({
+export default Route.extend(ResetScrollPositionMixin, {
   titleToken() {
     return this.i18n.t('Call for Speakers');
   },

--- a/app/routes/public/sessions.js
+++ b/app/routes/public/sessions.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import ResetScrollPositionMixin from 'open-event-frontend/mixins/reset-scroll-position';
 
 const { Route, RSVP } = Ember;
 
-export default Route.extend({
+export default Route.extend(ResetScrollPositionMixin, {
   titleToken() {
     return this.i18n.t('Sessions');
   },

--- a/tests/unit/mixins/reset-scroll-position-test.js
+++ b/tests/unit/mixins/reset-scroll-position-test.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+import ResetScrollPositionMixin from 'open-event-frontend/mixins/reset-scroll-position';
+import { module, test } from 'qunit';
+
+const { Object } = Ember;
+
+module('Unit | Mixin | reset scroll position');
+
+test('it works', function(assert) {
+  let ResetScrollPositionObject = Object.extend(ResetScrollPositionMixin);
+  let subject = ResetScrollPositionObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It resets the scroll position when the user changes tab on public event menu.
#### Changes proposed in this pull request:

It adds a mixin to resolve the issue and add it to sessions and call for speakers sub routes for now.
![image](https://media.giphy.com/media/H0MnDT68YnU4w/giphy.gif)
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #110 
