### PR TITLE
Adds UI for settings/password route

### DIFF
--- a/app/components/settings/password-section.js
+++ b/app/components/settings/password-section.js
@@ -1,6 +1,55 @@
 import Ember from 'ember';
+import FormMixin from 'open-event-frontend/mixins/form';
 
 const { Component } = Ember;
 
-export default Component.extend({
+export default Component.extend(FormMixin, {
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        password_current: {
+          identifier : 'password_current',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.i18n.t('Please enter the current password')
+            }
+          ]
+        },
+        password_new: {
+          identifier : 'password_new',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.i18n.t('Please enter a new password')
+            },
+            {
+              type   : 'minLength[6]',
+              prompt : this.i18n.t('Your password must have at least {ruleValue} characters')
+            }
+          ]
+        },
+        password_repeat: {
+          identifier : 'password_repeat',
+          rules      : [
+            {
+              type   : 'match[password_new]',
+              prompt : this.i18n.t('Passwords do not match')
+            }
+          ]
+        }
+      }
+    };
+  },
+
+  actions: {
+    submit() {
+      this.onValid(() => {
+
+      });
+    }
+  }
 });

--- a/app/templates/components/settings/password-section.hbs
+++ b/app/templates/components/settings/password-section.hbs
@@ -1,1 +1,23 @@
-<p>Password page</p>
+<form class="ui form" autocomplete="off" {{action 'submit' on='submit'}}>
+  <div class="field">
+    <label>
+      {{t 'Current Password'}}
+    </label>
+    {{input type='password' name='password_current' placeholder=(t 'Current Password')}}
+  </div>
+  <div class="field">
+    <label>
+      {{t 'New Password'}}
+    </label>
+    {{input type='password' name='password_new' placeholder=(t 'New Password')}}
+  </div>
+  <div class="field">
+    <label>
+      {{t 'Repeat Password'}}
+    </label>
+    {{input type='password' name='password_repeat' placeholder=(t 'Repeat Password')}}
+  </div>
+  <button class="ui blue button" type="submit">
+    {{t 'Save'}}
+  </button>
+</form>

--- a/tests/integration/components/settings/password-page-test.js
+++ b/tests/integration/components/settings/password-page-test.js
@@ -6,5 +6,5 @@ moduleForComponent('settings/password-section', 'Integration | Component | setti
 
 test('it renders', function(assert) {
   this.render(hbs`{{settings/password-section}}`);
-  assert.ok(this.$().html().trim().includes('Password page'));
+  assert.ok(this.$().html().trim().includes('Current Password'));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds UI for settings/password page (with form validation)

#### Changes proposed in this pull request:


![image](https://cloud.githubusercontent.com/assets/17252805/26760072/3bb3fdea-492d-11e7-84f6-16f826119d79.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #126 
