### PR TITLE
Redirects /settings to /settings/contact-info

### DIFF
--- a/app/routes/settings/index.js
+++ b/app/routes/settings/index.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  beforeModel() {
+    this._super(...arguments);
+    this.transitionTo('settings.contact-info');
+  }
+});

--- a/tests/unit/routes/settings/index-test.js
+++ b/tests/unit/routes/settings/index-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('route:settings/index', 'Unit | Route | settings/index', []);
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Earlier visting `/settings` route resulted in no active tabs

#### Changes proposed in this pull request:
`/settings` route now redirects to `/settings/contact-info`


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #130 
