### PR TITLE
Fixes overflowing pointing menu on tickets page

### DIFF
--- a/app/templates/events/view/tickets.hbs
+++ b/app/templates/events/view/tickets.hbs
@@ -1,15 +1,17 @@
-<div class="row">
-  <div class="{{if device.isMobile 'sixteen' 'three'}} wide column">
-    <div class="ui vertical fluid pointing menu">
-      <a class="active item">{{t 'Overview'}}</a>
-      <a class="item">{{t 'Orders'}}</a>
-      <a class="item">{{t 'Attendees'}}</a>
-      <a class="item">{{t 'Discount Codes'}}</a>
-      <a class="item">{{t 'Access Codes'}}</a>
-      <a class="item">{{t 'Add order'}}</a>
+<div class="ui grid">
+  <div class="row">
+    <div class="{{if device.isMobile 'sixteen' 'three'}} wide column">
+      <div class="ui vertical fluid pointing menu">
+        <a class="active item">{{t 'Overview'}}</a>
+        <a class="item">{{t 'Orders'}}</a>
+        <a class="item">{{t 'Attendees'}}</a>
+        <a class="item">{{t 'Discount Codes'}}</a>
+        <a class="item">{{t 'Access Codes'}}</a>
+        <a class="item">{{t 'Add order'}}</a>
+      </div>
     </div>
-  </div>
-  <div class="{{if device.isMobile 'sixteen' 'thirteen'}} wide column">
-    {{outlet}}
+    <div class="{{if device.isMobile 'sixteen' 'thirteen'}} wide column">
+      {{outlet}}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixes overflowing pointing menu on tickets page caused due to renaming of `grid` to `segment` in `view.hbs`
#### Changes proposed in this pull request:

**Before:**
![image](https://cloud.githubusercontent.com/assets/17252805/26781613/0f78d742-4a0d-11e7-9fa5-6380a1817263.png)

**After**
![image](https://cloud.githubusercontent.com/assets/17252805/26781627/1dfae080-4a0d-11e7-913e-e709e00cf574.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #142 
