### PR TITLE
makes the browser back button functional on events and settings route

### DIFF
--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -31,11 +31,12 @@
           <div class="menu">
             <a href="{{href-to 'my-tickets'}}" class="item">{{t 'My Tickets'}}</a>
             <div class="item">{{t 'My Sessions'}}</div>
-            <a href="{{href-to 'events'}}" class="item">{{t 'Manage Events'}}</a>
+            <a href="{{href-to 'events.live'}}" class="item">{{t 'Manage Events'}}</a>
             <div class="divider"></div>
             <a href="{{href-to 'profile'}}" class="item">{{t 'Profile'}}</a>
             <a href="{{href-to 'settings'}}" class="item">{{t 'Settings'}}</a>
             <a href="{{href-to 'admin'}}" class="item">{{t 'Admin'}}</a>
+            <a href="{{href-to 'settings.contact-info'}}" class="item">{{t 'Settings'}}</a>
             <div class="divider"></div>
             <a role="button" class="item logout-button" {{action 'logout'}}>{{t 'Logout'}}</a>
           </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
because of `href-to`, the back browser back button is not functional for event and settings route, this PR will resolve that.

#### Changes proposed in this pull request:

**Before:**
![giphy 1](https://user-images.githubusercontent.com/17252805/26855427-83c82414-4b38-11e7-8ae7-ea3ee3b6c84c.gif)

**After:**
![giphy 2](https://user-images.githubusercontent.com/17252805/26855762-86df7772-4b3a-11e7-8d82-6d3a2fcb8626.gif)




<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #165 
