### PR TITLE
Adds form in add-order & ticket-list and disables continue button when there is no order.

### DIFF
--- a/app/controllers/events/view/tickets/add-order.js
+++ b/app/controllers/events/view/tickets/add-order.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
+import { sumBy } from 'lodash';
 
 const { Controller, computed } = Ember;
 
 export default Controller.extend({
+  hasTicketsInOrder: computed('model.@each.quantity', function() {
+    return sumBy(this.get('model'), 'quantity') > 0;
+  }),
   total: computed('model.@each.quantity', function() {
     let sum = 0.0;
     this.get('model').forEach(order => {

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -2,80 +2,86 @@
   <h3 class="ui header">{{t 'Tickets'}}</h3>
 </div>
 <div class="ui segment">
-  <table class="ui ui very basic compact table" style="margin-bottom: 0">
-    <thead class="full-width">
-      <tr>
-        <th>{{t 'Type'}}</th>
-        <th class="four wide">{{t 'Sales Ends'}}</th>
-        <th class="ui right aligned two wide">{{t 'Price'}}</th>
-        <th class="one wide">{{t 'Quantity'}}</th>
-        <th class="ui right aligned two wide">{{t 'Subtotal'}}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each tickets as |ticket|}}
+  <form class="ui form">
+    <table class="ui very basic compact table" style="margin-bottom: 0">
+      <thead class="full-width">
         <tr>
-          <td>
-            <div class="ui small">
-              {{ticket.name}}
-            </div>
-            <small class="ui gray-text tiny">{{ticket.description}}</small>
-          </td>
-          <td>Thu, May 25</td>
-          <td id="{{ticket.id}}_price" class="ui right aligned">$ {{number-format ticket.price}}</td>
-          <td>
-            {{#ui-dropdown class='compact selection' forceSelection=false}}
-              {{input type='hidden' id=(concat ticket.id '_quantity') value=ticket.orderQuantity}}
-              <i class="dropdown icon"></i>
-              <div class="default text">{{ticket.min}}</div>
-              <div class="menu">
-                {{#each (range ticket.min ticket.max) as |count|}}
-                  <div class="item" data-value="{{count}}">{{count}}</div>
-                {{/each}}
-              </div>
-            {{/ui-dropdown}}
-          </td>
-          <td id='{{ticket.id}}_subtotal' class="ui right aligned">
-            $ {{number-format (mult ticket.orderQuantity ticket.price)}}
-          </td>
+          <th>{{t 'Type'}}</th>
+          <th class="four wide">{{t 'Sales Ends'}}</th>
+          <th class="ui two wide">{{t 'Price'}}</th>
+          <th class="one wide">{{t 'Quantity'}}</th>
+          <th class="ui right aligned two wide">{{t 'Subtotal'}}</th>
         </tr>
-      {{/each}}
-    </tbody>
-    <tfoot class="full-width">
-      <tr>
-        <th></th>
-        <th></th>
-        <th></th>
-        <th></th>
-        <th colspan="4">
-          <div class="ui right aligned small primary icon">
-            {{t 'Total'}}: $ {{number-format total}}
-          </div>
-        </th>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-<div class="ui right aligned segment">
-  <a href="#">{{t 'Enter promotional code'}}</a>
-</div>
-<div class="ui segment">
-  <div class="ui grid">
-    <div class="ui row stackable grid">
-      <div class="ui padding less fourteen wide computer twelve wide tablet column right aligned floated payment icons">
-        <i class="colored american express link icon"></i>
-        <i class="colored credit card alternative link icon"></i>
-        <i class="colored diners club link icon"></i>
-        <i class="colored discover link icon"></i>
-        <i class="colored mastercard link icon"></i>
-        <i class="colored paypal card link icon"></i>
-        <i class="colored visa link icon"></i>
-      </div>
-      <div class="ui padding less two wide computer four wide tablet column right aligned floated">
-        <button type="button" id="total" class="ui primary button" disabled={{not hasTicketsInOrder}}>
-          {{t 'Order Now'}}
-        </button>
+      </thead>
+      <tbody>
+        {{#each tickets as |ticket|}}
+          <tr>
+            <td>
+              <div class="ui small">
+                {{ticket.name}}
+              </div>
+              <small class="ui gray-text tiny">{{ticket.description}}</small>
+            </td>
+            <td>Thu, May 25</td>
+            <td id="{{ticket.id}}_price">$ {{number-format ticket.price}}</td>
+            <td>
+              <div class="field">
+                {{#ui-dropdown class='compact selection' forceSelection=false}}
+                  {{input type='hidden' id=(concat ticket.id '_quantity') value=ticket.orderQuantity}}
+                  <i class="dropdown icon"></i>
+                  <div class="default text">{{ticket.min}}</div>
+                  <div class="menu">
+                    {{#each (range ticket.min ticket.max) as |count|}}
+                      <div class="item" data-value="{{count}}">{{count}}</div>
+                    {{/each}}
+                  </div>
+                {{/ui-dropdown}}
+              </div>
+            </td>
+            <td id='{{ticket.id}}_subtotal' class="ui right aligned">
+              $ {{number-format (mult ticket.orderQuantity ticket.price)}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+      <tfoot class="full-width">
+        <tr>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th colspan="4">
+            <div class="ui right aligned small primary icon">
+              {{t 'Total'}}: $ {{number-format total}}
+            </div>
+          </th>
+        </tr>
+      </tfoot>
+    </table>
+    <div class="ui row grid">
+      <div class="column right aligned">
+        <a href="#">{{t 'Enter promotional code'}}</a>
       </div>
     </div>
-  </div>
+    <div class="ui row">
+      <div class="ui grid">
+        <div class="ui row stackable grid">
+          <div class="ui padding less fourteen wide computer twelve wide tablet column right aligned floated payment icons">
+            <i class="colored american express link icon"></i>
+            <i class="colored credit card alternative link icon"></i>
+            <i class="colored diners club link icon"></i>
+            <i class="colored discover link icon"></i>
+            <i class="colored mastercard link icon"></i>
+            <i class="colored paypal card link icon"></i>
+            <i class="colored visa link icon"></i>
+          </div>
+          <div class="ui padding less two wide computer four wide tablet column right aligned floated">
+            <button id="total" class="ui primary button" disabled={{not hasTicketsInOrder}}>
+              {{t 'Order Now'}}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
 </div>

--- a/app/templates/events/view/tickets/add-order.hbs
+++ b/app/templates/events/view/tickets/add-order.hbs
@@ -1,47 +1,59 @@
 <div class="row" style="padding-top: 10px">
   <h2 class="ui header">{{t 'Add Order'}}</h2>
 </div>
-<table class="ui very basic table">
-  <thead>
-    <tr>
-      <th>{{t 'Ticket Type'}}</th>
-      <th class="right aligned">{{t 'Price '}}(US$)</th>
-      <th class="right aligned">{{t 'Quantity'}}</th>
-      <th class="right aligned">{{t 'Item Total'}}</th>
-    </tr>
-    {{#each model as |ticket|}}
+<form class="ui form">
+  <table class="ui very basic table">
+    <thead>
       <tr>
-        <td>{{ticket.ticketType}}</td>
-        <td class="right aligned">US$ {{number-format ticket.price}}</td>
-        <td class="right aligned">{{input value=ticket.quantity type='number' min='0'}}</td>
-        <td class="right aligned">$ {{number-format (mult ticket.quantity ticket.price)}}</td>
+        <th>{{t 'Ticket Type'}}</th>
+        <th class="right aligned">{{t 'Price '}}(US$)</th>
+        <th class="right aligned">{{t 'Quantity'}}</th>
+        <th class="right aligned">{{t 'Item Total'}}</th>
       </tr>
-    {{/each}}
-  </thead>
-</table>
-<div class="ui grid stackable">
-  <div class="row">
-    <div class="sixteen wide column right aligned">
-      <h5 class="ui header">{{t 'Grand Total'}}: $ {{number-format total}}</h5>
+      {{#each model as |ticket|}}
+        <tr>
+          <td>
+            {{ticket.ticketType}}
+          </td>
+          <td class="right aligned">
+            US$ {{number-format ticket.price}}
+          </td>
+          <td class="right aligned">
+            <div class="inline field">
+              {{input value=ticket.quantity type='number' min='0'}}
+            </div>
+          </td>
+          <td class="right aligned">
+            $ {{number-format (mult ticket.quantity ticket.price)}}
+          </td>
+        </tr>
+      {{/each}}
+    </thead>
+  </table>
+  <div class="ui grid stackable">
+    <div class="row">
+      <div class="sixteen wide column right aligned">
+        <h5 class="ui header">{{t 'Grand Total'}}: $ {{number-format total}}</h5>
+      </div>
+    </div>
+    <div class="row" style="padding-top: 20px">
+      <div class="eight wide column">
+        {{#ui-dropdown class='labeled icon button'}}
+          <i class="payment icon"></i>
+          <div class="default text">{{t 'Select Payment Type'}}</div>
+          <div class="menu">
+            <div class="item" data-value="cheque">{{t 'Cheque'}}</div>
+            <div class="item" data-value="telegraphic-transfer">{{t 'Telegraphic Transfer(TT)/Bank Transfer'}}</div>
+            <div class="item" data-value="onsite">{{t 'Onsite/Cash'}}</div>
+            <div class="item" data-value="free-order">{{t 'Free Order'}}</div>
+          </div>
+        {{/ui-dropdown}}
+      </div>
+      <div class="eight wide column right aligned">
+        <button class="ui teal button" disabled={{not hasTicketsInOrder}}>
+          {{t 'Continue'}}
+        </button>
+      </div>
     </div>
   </div>
-  <div class="row" style="padding-top: 20px">
-    <div class="eight wide column">
-      {{#ui-dropdown class='labeled icon button'}}
-        <i class="payment icon"></i>
-        <div class="default text">{{t 'Select Payment Type'}}</div>
-        <div class="menu">
-          <div class="item" data-value="cheque">{{t 'Cheque'}}</div>
-          <div class="item" data-value="telegraphic-transfer">{{t 'Telegraphic Transfer(TT)/Bank Transfer'}}</div>
-          <div class="item" data-value="onsite">{{t 'Onsite/Cash'}}</div>
-          <div class="item" data-value="free-order">{{t 'Free Order'}}</div>
-        </div>
-      {{/ui-dropdown}}
-    </div>
-    <div class="eight wide column right aligned">
-      <button class="ui teal button" disabled={{not hasTicketsInOrder}}>
-        {{t 'Continue'}}
-      </button>
-    </div>
-  </div>
-</div>
+</form>

--- a/app/templates/events/view/tickets/add-order.hbs
+++ b/app/templates/events/view/tickets/add-order.hbs
@@ -39,7 +39,9 @@
       {{/ui-dropdown}}
     </div>
     <div class="eight wide column right aligned">
-      <button class="ui teal button">{{t 'Continue'}}</button>
+      <button class="ui teal button" disabled={{not hasTicketsInOrder}}>
+        {{t 'Continue'}}
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Disables continue button when there is no order. This also wraps the ticket-list & add-order table inside a form element, to follow a common design practice.

**When There is no order made.**
![screenshot from 2017-06-07 13-47-29](https://user-images.githubusercontent.com/12807846/26868843-ed8124a6-4b87-11e7-91d7-b073e210e2f2.png)

**When an order is made.**
![screenshot from 2017-06-07 13-47-43](https://user-images.githubusercontent.com/12807846/26868842-ed7ec4d6-4b87-11e7-8670-37918a529344.png)


Fixes #174 
