### PR TITLE
splits events/<event-id>/sessions into proper pages

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -45,7 +45,9 @@ router.map(function() {
         this.route('sessions-speakers');
       });
       this.route('export');
-      this.route('sessions');
+      this.route('sessions', function() {
+        this.route('list', { path: '/:session_status' });
+      });
       this.route('tickets', function() {
         this.route('orders');
         this.route('attendees');

--- a/app/routes/events/view/sessions/index.js
+++ b/app/routes/events/view/sessions/index.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  templateName: 'events/view/sessions/list',
+  model() {
+    return [{
+      title          : 'Test Session 1',
+      speakers       : [{ name: 'speaker 1', id: 1, organization: 'fossasia' }, { name: 'speaker 2', id: 1, organization: 'fossasia' }],
+      track          : 'sample track',
+      shortAbstract  : 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      submissionDate : new Date(),
+      lastModified   : new Date(),
+      emailSent      : 'No',
+      state          : 'confirmed'
+    },
+    {
+      title          : 'Test Session 2',
+      speakers       : [{ name: 'speaker 3', id: 1, organization: 'fossasia' }, { name: 'speaker 4', id: 1, organization: 'fossasia' }],
+      track          : 'sample track',
+      shortAbstract  : 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      submissionDate : new Date(),
+      lastModified   : new Date(),
+      emailSent      : 'Yes',
+      state          : 'confirmed'
+    }];
+  }
+});

--- a/app/routes/events/view/sessions/list.js
+++ b/app/routes/events/view/sessions/list.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  titleToken() {
+    switch (this.get('params.session_status')) {
+      case 'pending':
+        return this.i18n.t('Pending');
+      case 'accepted':
+        return this.i18n.t('Accepted');
+      case 'confirmed':
+        return this.i18n.t('Confirmed');
+      case 'rejected':
+        return this.i18n.t('Rejected');
+    }
+  },
+  model(params) {
+    this.set('params', params);
+    return [{
+      title          : 'Test Session 1',
+      speakers       : [{ name: 'speaker 1', id: 1, organization: 'fossasia' }, { name: 'speaker 2', id: 1, organization: 'fossasia' }],
+      track          : 'sample track',
+      shortAbstract  : 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      submissionDate : new Date(),
+      lastModified   : new Date(),
+      emailSent      : 'No',
+      state          : 'confirmed'
+    },
+    {
+      title          : 'Test Session 2',
+      speakers       : [{ name: 'speaker 3', id: 1, organization: 'fossasia' }, { name: 'speaker 4', id: 1, organization: 'fossasia' }],
+      track          : 'sample track',
+      shortAbstract  : 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      submissionDate : new Date(),
+      lastModified   : new Date(),
+      emailSent      : 'Yes',
+      state          : 'confirmed'
+    }];
+  }
+});

--- a/app/templates/events/view/sessions.hbs
+++ b/app/templates/events/view/sessions.hbs
@@ -1,106 +1,37 @@
-<div class="ui basic buttons">
-  <button class="ui button">{{t 'All'}}</button>
-  <button class="ui button">{{t 'Pending'}}</button>
-  <button class="ui button">{{t 'Accepted'}}</button>
-  <button class="ui button">{{t 'Confirmed'}}</button>
-  <button class="ui button">{{t 'Rejected'}}</button>
-</div>
-<button class="ui teal button">{{t 'Create Session'}}</button>
-{{#ui-dropdown class='ui icon top right pointing dropdown button'}}
-  {{t 'Export'}}
-  <i class="download icon"></i>
-  <div class="menu">
-    <div class="item">CSV</div>
-    <div class="item">PDF</div>
+<div class="ui grid stackable">
+  <div class="row">
+    <div class="eight wide column">
+      {{#tabbed-navigation isNonPointing=true}}
+        {{#link-to 'events.view.sessions.index' class='item'}}
+          {{t 'All'}}
+        {{/link-to}}
+        {{#link-to 'events.view.sessions.list' 'pending' class='item'}}
+          {{t 'Pending'}}
+        {{/link-to}}
+        {{#link-to 'events.view.sessions.list' 'accepted' class='item'}}
+          {{t 'Accepted'}}
+        {{/link-to}}
+        {{#link-to 'events.view.sessions.list' 'confirmed' class='item'}}
+          {{t 'Confirmed'}}
+        {{/link-to}}
+        {{#link-to 'events.view.sessions.list' 'rejected' class='item'}}
+          {{t 'Rejected'}}
+        {{/link-to}}
+      {{/tabbed-navigation}}
+    </div>
+    <div class="eight wide column">
+      <button class="ui teal button right floated">{{t 'Create Session'}}</button>
+      {{#ui-dropdown class='ui right floated icon top right pointing dropdown button'}}
+        {{t 'Export'}}
+        <i class="download icon"></i>
+        <div class="menu">
+          <div class="item">{{t 'CSV'}}</div>
+          <div class="item">{{t 'PDF'}}</div>
+        </div>
+      {{/ui-dropdown}}
+    </div>
   </div>
-{{/ui-dropdown}}
-<br><br>
-<div class="row">
-  <div class="sixteen wide column">
-    <table class="ui tablet stackable very basic table">
-      <thead>
-        <tr>
-          <th>{{t 'State'}}</th>
-          <th>{{t 'Title'}}</th>
-          <th>{{t 'Speakers'}}</th>
-          <th>{{t 'Track'}}</th>
-          <th>{{t 'Short Abstract'}}</th>
-          <th>{{t 'Submission Date'}}</th>
-          <th>{{t 'Last Modified'}}</th>
-          <th>{{t 'Email Sent'}}</th>
-          <th></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div>
-              <div class="ui green label">{{t 'Confirmed'}}</div>
-            </div>
-          </td>
-          <td>
-            Test Session
-          </td>
-          <td>
-            <div class="ui ordered list">
-              <div class="item">Mario Behling</div>
-              <div class="item">Test</div>
-            </div>
-          </td>
-          <td>
-            Blockchain
-          </td>
-          <td>
-            Get an outlook of the awesome program of the weekend from track organizers and the content team.
-          </td>
-          <td>
-            March 18, 2017
-            <br> 09:30 AM
-          </td>
-          <td>
-            March 25,
-            <br> 09:30 PM
-          </td>
-          <td>
-            No
-          </td>
-          <td>
-            <div class="ui vertical compact basic buttons">
-              {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
-                <i class="unhide icon"></i>
-              {{/ui-popup}}
-              {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
-                <i class="edit icon"></i>
-              {{/ui-popup}}
-              {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
-                <i class="trash outline icon"></i>
-              {{/ui-popup}}
-              {{#ui-popup content=(t 'Browse edit history') class='ui icon button' position='left center'}}
-                <i class="history icon"></i>
-              {{/ui-popup}}
-            </div>
-          </td>
-          <td>
-            <div class="ui vertical compact basic buttons">
-              {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
-                <i class="green checkmark icon"></i>
-                <div class="menu">
-                  <div class="item">{{t 'With email'}}</div>
-                  <div class="item">{{t 'Without email'}}</div>
-                </div>
-              {{/ui-dropdown}}
-              {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
-                <i class="red remove icon"></i>
-                <div class="menu">
-                  <div class="item">{{t 'With email'}}</div>
-                  <div class="item">{{t 'Without email'}}</div>
-                </div>
-              {{/ui-dropdown}}
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <div class="row">
+    {{outlet}}
   </div>
 </div>

--- a/app/templates/events/view/sessions/list.hbs
+++ b/app/templates/events/view/sessions/list.hbs
@@ -1,0 +1,90 @@
+<div class="sixteen wide column">
+  <table class="ui tablet stackable very basic table">
+    <thead>
+      <tr>
+        <th>{{t 'State'}}</th>
+        <th>{{t 'Title'}}</th>
+        <th>{{t 'Speakers'}}</th>
+        <th>{{t 'Track'}}</th>
+        <th>{{t 'Short Abstract'}}</th>
+        <th>{{t 'Submission Date'}}</th>
+        <th>{{t 'Last Modified'}}</th>
+        <th>{{t 'Email Sent'}}</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each model as |session|}}
+        <tr>
+          <td>
+            {{#if (eq session.state "confirmed")}}
+              <div class="ui green label">{{t 'Confirmed'}}</div>
+            {{else}}
+              <div class="ui red label">{{t 'Not Confirmed'}}</div>
+            {{/if}}
+          </td>
+          <td>
+            {{session.title}}
+          </td>
+          <td>
+            <div class="ui ordered list">
+              {{#each session.speakers as |speaker|}}
+                <div class="item">{{speaker.name}}</div>
+              {{/each}}
+            </div>
+          </td>
+          <td>
+            {{session.track}}
+          </td>
+          <td>
+            {{session.shortAbstract}}
+          </td>
+          <td>
+            {{moment-format speaker.submittedAt 'dddd, DD MMMM YYYY'}}
+          </td>
+          <td>
+            {{moment-format speaker.submittedAt 'dddd, DD MMMM YYYY'}}
+          </td>
+          <td>
+            {{session.emailSent}}
+          </td>
+          <td>
+            <div class="ui vertical compact basic buttons">
+              {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
+                <i class="unhide icon"></i>
+              {{/ui-popup}}
+              {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
+                <i class="edit icon"></i>
+              {{/ui-popup}}
+              {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
+                <i class="trash outline icon"></i>
+              {{/ui-popup}}
+              {{#ui-popup content=(t 'Browse edit history') class='ui icon button' position='left center'}}
+                <i class="history icon"></i>
+              {{/ui-popup}}
+            </div>
+          </td>
+          <td>
+            <div class="ui vertical compact basic buttons">
+              {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
+                <i class="green checkmark icon"></i>
+                <div class="menu">
+                  <div class="item">{{t 'With email'}}</div>
+                  <div class="item">{{t 'Without email'}}</div>
+                </div>
+              {{/ui-dropdown}}
+              {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
+                <i class="red remove icon"></i>
+                <div class="menu">
+                  <div class="item">{{t 'With email'}}</div>
+                  <div class="item">{{t 'Without email'}}</div>
+                </div>
+              {{/ui-dropdown}}
+            </div>
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/tests/unit/routes/events/view/sessions/list-test.js
+++ b/tests/unit/routes/events/view/sessions/list-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('route:events/view/sessions/list', 'Unit | Route | events/view/sessions/list', []);
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
added subroutes

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
splits events/<event-id>/sessions into proper pages

#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/20153241/27055271-7a50cf8c-4fe1-11e7-9504-31d95d75afee.png)

demo- https://open-event-frontend-branch3.herokuapp.com/events/963d3ba5/sessions
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #215 
