### PR TITLE
resolve: text overflow in event card

### DIFF
--- a/app/components/event-card.js
+++ b/app/components/event-card.js
@@ -16,29 +16,5 @@ export default Component.extend({
       }
     });
     return tags;
-  }),
-
-  didInsertElement() {
-    this._super(...arguments);
-    const $innerSpan = this.$('.header > span');
-    const $header = this.$('.header');
-    while ($innerSpan.outerHeight() > $header.height()) {
-      $header.attr('data-content', $innerSpan.text());
-      $header.attr('data-variation', 'tiny');
-      $innerSpan.text((index, text) => {
-        return text.replace(/\W*\s(\S)*$/, '...');
-      });
-      $header.popup({
-        position: 'top center'
-      });
-      this.set('$header', $header);
-    }
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-    if (this.get('$header')) {
-      this.get('$header').popup('destroy');
-    }
-  }
+  })
 });

--- a/app/components/smart-overflow.js
+++ b/app/components/smart-overflow.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  classNames: ['smart-overflow'],
+  didInsertElement() {
+    this._super(...arguments);
+    var $headerSpan = this.$('span');
+    var $header = this.$();
+    $header.attr('data-content', $headerSpan.text());
+    $header.attr('data-variation', 'tiny');
+    while ($headerSpan.outerHeight() > $header.height()) {
+      $headerSpan.text((index, text) => {
+        return text.replace(/\W*\s(\S)*$/, '...');
+      });
+      $header.popup({
+        position: 'top center'
+      });
+      this.set('$header', $header);
+    }
+  },
+  willDestroyElement() {
+    this._super(...arguments);
+    if (this.get('$header')) {
+      this.get('$header').popup('destroy');
+    }
+  }
+});

--- a/app/styles/partials/event-card.scss
+++ b/app/styles/partials/event-card.scss
@@ -6,6 +6,11 @@
     overflow: hidden;
   }
 
+  .description {
+    height: 28px;
+    overflow: hidden;
+  }
+
   img {
     height: 179px !important;
     object-fit: cover;

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -15,17 +15,17 @@
       </a>
     {{/unless}}
     <a class="main content" href="{{href-to 'public' event.identifier}}">
-      <div class="header">
-        <span>{{event.name}}</span>
-      </div>
+      {{#smart-overflow class='header'}}
+        {{event.name}}
+      {{/smart-overflow}}
       <div class="meta">
         <span class="date">
           {{moment-format event.startTime 'ddd, MMM DD HH:mm A'}}
         </span>
       </div>
-      <div class="description">
+      {{#smart-overflow class='description'}}
         {{event.shortLocationName}}
-      </div>
+      {{/smart-overflow}}
     </a>
     <div class="extra content small text">
       <span class="right floated">

--- a/app/templates/components/smart-overflow.hbs
+++ b/app/templates/components/smart-overflow.hbs
@@ -1,0 +1,1 @@
+<span>{{yield}}</span>

--- a/tests/integration/components/smart-overflow-test.js
+++ b/tests/integration/components/smart-overflow-test.js
@@ -1,0 +1,10 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('smart-overflow', 'Integration | Component | smart overflow');
+
+test('it renders', function(assert) {
+  this.render(hbs`{{smart-overflow}}`);
+  assert.ok(this.$().html().trim().includes('smart-overflow'));
+});


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This PR revolves around resolving the text overflow in the event card for smaller screens of mobile and tablet. 

#### Changes proposed in this pull request:

- I've added 2 conditions for mobile and tablet respectively which do the same styling thing because I could not find the substitution for "OR" condition for helper classes.
- I have not added styling for entire div because it makes no sense to ellipsise the text for larger screens. This issue is only on mobile and tablet devices both in landscape and portrait modes.

Fixes #228 

@niranjan94 @geekyd @CosmicCoder96 @anu-007 @sumedh123 @utkarshnath  Please review 

Deployment Link : https://open-event-frontend-harshita.herokuapp.com/