### PR TITLE
splits events/<event-id>/speakers into proper pages

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -55,7 +55,9 @@ router.map(function() {
         this.route('discount-codes');
         this.route('access', { path: 'access-codes' });
       });
-      this.route('speakers');
+      this.route('speakers', function() {
+        this.route('list', { path: '/:speakers_status' });
+      });
     });
     this.route('list', { path: '/:event_state' });
     this.route('import');

--- a/app/routes/events/view/speakers/index.js
+++ b/app/routes/events/view/speakers/index.js
@@ -1,0 +1,49 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  templateName: 'events/view/speakers/list',
+  model() {
+    return [{
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name1',
+      email             : 'testname1@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session1', 'session2'],
+      state             : 'confirmed'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name2',
+      email             : 'testname2@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session2'],
+      state             : 'canceled'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name3',
+      email             : 'testname3@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session3'],
+      state             : 'confirmed'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name4',
+      email             : 'testname4@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session4'],
+      state             : 'canceled'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name5',
+      email             : 'testname5@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session5', 'session6'],
+      state             : 'confirmed'
+    }];
+  }
+});

--- a/app/routes/events/view/speakers/list.js
+++ b/app/routes/events/view/speakers/list.js
@@ -1,0 +1,59 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  titleToken() {
+    switch (this.get('params.speakers_status')) {
+      case 'pending':
+        return this.i18n.t('Pending');
+      case 'accepted':
+        return this.i18n.t('Accepted');
+      case 'rejected':
+        return this.i18n.t('Rejected');
+    }
+  },
+  model(params) {
+    this.set('params', params);
+    return [{
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name1',
+      email             : 'testname1@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session1', 'session2'],
+      state             : 'confirmed'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name2',
+      email             : 'testname2@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session2'],
+      state             : 'canceled'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name3',
+      email             : 'testname3@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session3'],
+      state             : 'confirmed'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name4',
+      email             : 'testname4@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session4'],
+      state             : 'canceled'
+    },
+    {
+      image             : '/images/placeholders/avatar.png',
+      name              : 'Test Name5',
+      email             : 'testname5@gmail.com',
+      phone             : '123456789',
+      submitted_session : ['session5', 'session6'],
+      state             : 'confirmed'
+    }];
+  }
+});

--- a/app/templates/events/view/speakers.hbs
+++ b/app/templates/events/view/speakers.hbs
@@ -1,95 +1,37 @@
 <div class="ui grid stackable">
   <div class="row">
-    <div class="twelve wide column">
-      <div class="ui basic buttons">
-        <button class="ui button">{{t 'All'}}</button>
-        <button class="ui button">{{t 'Pending'}}</button>
-        <button class="ui button">{{t 'Accepted'}}</button>
-        <button class="ui button">{{t 'Rejected'}}</button>
-      </div>
-      <button class="ui teal button">{{t 'Add Speaker'}}</button>
-      <button class="ui teal button">{{t 'Export as CSV'}}</button>
-      {{#ui-dropdown class='labeled icon button'}}
+    <div class="eight wide column">
+      {{#tabbed-navigation isNonPointing=true}}
+        {{#link-to 'events.view.speakers.index' class='item'}}
+          {{t 'All'}}
+        {{/link-to}}
+        {{#link-to 'events.view.speakers.list' 'pending' class='item'}}
+          {{t 'Pending'}}
+        {{/link-to}}
+        {{#link-to 'events.view.speakers.list' 'accepted' class='item'}}
+          {{t 'Accepted'}}
+        {{/link-to}}
+        {{#link-to 'events.view.speakers.list' 'rejected' class='item'}}
+          {{t 'Rejected'}}
+        {{/link-to}}
+      {{/tabbed-navigation}}
+    </div>
+    <div class="eight wide column">
+      <button class="ui teal button right floated">{{t 'Add Speaker'}}</button>
+      <button class="ui teal button right floated">{{t 'Export as CSV'}}</button>
+      {{#ui-dropdown class='labeled icon button right floated'}}
         <i class="dropdown icon"></i>
         <div class="default text">{{t 'No. of entries'}}</div>
         <div class="menu">
-          <div class="item">{{t '10'}}</div>
-          <div class="item">{{t '25'}}</div>
-          <div class="item">{{t '50'}}</div>
-          <div class="item">{{t '100'}}</div>
+          <div class="item">10</div>
+          <div class="item">25</div>
+          <div class="item">50</div>
+          <div class="item">100</div>
         </div>
       {{/ui-dropdown}}
     </div>
-    <div class="four wide column right aligned">
-      {{#ui-search }}
-        <div class="ui icon input">
-          <input class="prompt" type="text" placeholder="Search Speakers...">
-          <i class="search icon"></i>
-        </div>
-      {{/ui-search}}
-    </div>
   </div>
   <div class="row">
-    <div class="sixteen wide column">
-      <table class="ui stackable very basic table">
-        <thead>
-          <tr>
-            <th>{{t 'Name'}}</th>
-            <th>{{t 'Email'}}</th>
-            <th>{{t 'Phone'}}</th>
-            <th>{{t 'Submitted Sessions'}}</th>
-            <th>{{t 'State'}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each model as |speaker|}}
-            <tr>
-              <td>
-                <a class="ui avatar round image">
-                  {{widgets/safe-image src=speaker.image}}
-                </a>
-                {{speaker.name}}
-              </td>
-              <td>
-                {{speaker.email}}
-              </td>
-              <td>
-                {{speaker.phone}}
-              </td>
-              <td>
-                <div class="ui ordered list">
-                  {{#each speaker.submitted_session as |session|}}
-                    <div class="item">{{session}}</div>
-                  {{/each}}
-                </div>
-              </td>
-              <td>
-                <div>
-                  {{#if (eq speaker.state "confirmed")}}
-                    <div class="ui green label">{{t 'Confirmed'}}</div>
-                  {{else}}
-                    <div class="ui red label">{{t 'Canceled'}}</div>
-                  {{/if}}
-                </div>
-              </td>
-              <td>
-                <div class="ui vertical compact basic buttons">
-                  {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
-                    <i class="unhide icon"></i>
-                  {{/ui-popup}}
-                  {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
-                    <i class="edit icon"></i>
-                  {{/ui-popup}}
-                  {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
-                    <i class="trash outline icon"></i>
-                  {{/ui-popup}}
-                </div>
-              </td>
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
+    {{outlet}}
   </div>
 </div>

--- a/app/templates/events/view/speakers/list.hbs
+++ b/app/templates/events/view/speakers/list.hbs
@@ -1,0 +1,61 @@
+<div class="sixteen wide column">
+  <table class="ui stackable very basic table">
+    <thead>
+      <tr>
+        <th>{{t 'Name'}}</th>
+        <th>{{t 'Email'}}</th>
+        <th>{{t 'Phone'}}</th>
+        <th>{{t 'Submitted Sessions'}}</th>
+        <th>{{t 'State'}}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each model as |speaker|}}
+        <tr>
+          <td>
+            <a class="ui avatar round image">
+              {{widgets/safe-image src=speaker.image}}
+            </a>
+            {{speaker.name}}
+          </td>
+          <td>
+            {{speaker.email}}
+          </td>
+          <td>
+            {{speaker.phone}}
+          </td>
+          <td>
+            <div class="ui ordered list">
+              {{#each speaker.submitted_session as |session|}}
+                <div class="item">{{session}}</div>
+              {{/each}}
+            </div>
+          </td>
+          <td>
+            <div>
+              {{#if (eq speaker.state 'confirmed')}}
+                <div class="ui green label">{{t 'Confirmed'}}</div>
+              {{else}}
+                <div class="ui red label">{{t 'Canceled'}}</div>
+              {{/if}}
+            </div>
+          </td>
+          <td>
+            <div class="ui vertical compact basic buttons">
+              {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
+                <i class="unhide icon"></i>
+              {{/ui-popup}}
+              {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
+                <i class="edit icon"></i>
+              {{/ui-popup}}
+              {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
+                <i class="trash outline icon"></i>
+              {{/ui-popup}}
+            </div>
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/tests/unit/routes/events/view/speakers/list-test.js
+++ b/tests/unit/routes/events/view/speakers/list-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('route:events/view/speakers/list', 'Unit | Route | events/view/speakers/list', []);
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
splits events//sessions into proper pages

#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/20153241/27250393-f1158c76-534b-11e7-9984-7588bc43d444.png)

demo- https://open-event-frontend-branch4.herokuapp.com/events/963d3ba5/speakers/rejected

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #245 
