### PR TITLE
Fixes same id assertion error on admin/permissions

### DIFF
--- a/app/components/n-times.js
+++ b/app/components/n-times.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  tagName: ''
+});

--- a/app/templates/admin/permissions/event-roles.hbs
+++ b/app/templates/admin/permissions/event-roles.hbs
@@ -17,20 +17,20 @@
     </tr>
   </thead>
   <tbody>
-    {{#each model.roles as |item|}}
+    {{#each model.roles as |role|}}
       <tr>
-        <td>{{item}}</td>
-        {{#each (range 1 6) as |number|}}
+        <td>{{role}}</td>
+        {{#n-times times=5}}
           <td>
-            {{ui-checkbox label=(t 'Create') id=(concat 'create_' number)}}
+            {{ui-checkbox label=(t 'Create')}}
             <br>
-            {{ui-checkbox label=(t 'Read') id=(concat 'read_' number)}}
+            {{ui-checkbox label=(t 'Read')}}
             <br>
-            {{ui-checkbox label=(t 'Update') id=(concat 'update_' number)}}
+            {{ui-checkbox label=(t 'Update')}}
             <br>
-            {{ui-checkbox label=(t 'Delete') id=(concat 'delete_' number)}}
+            {{ui-checkbox label=(t 'Delete')}}
           </td>
-        {{/each}}
+        {{/n-times}}
       </tr>
     {{/each}}
   </tbody>

--- a/app/templates/components/n-times.hbs
+++ b/app/templates/components/n-times.hbs
@@ -1,0 +1,3 @@
+{{#each (range 0 times) as |number|}}
+  {{yield number}}
+{{/each}}

--- a/tests/integration/components/n-times-test.js
+++ b/tests/integration/components/n-times-test.js
@@ -1,0 +1,16 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('n-times', 'Integration | Component | n times');
+
+test('it renders', function(assert) {
+
+  this.render(hbs`
+    {{#n-times times=1}}
+      test
+    {{/n-times}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'test');
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
visiting `admin/permissions/event-roles` resulted in a same id assertion error because of same id being used for multiple checkboxes.

#### Changes proposed in this pull request:

- Adds the n-times component.
- make the id's (changed to names for better form handling) unique
- make their name more logical, similar to the ones used in orga server 



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #265 
