### PR TITLE
adds dynamic title to events sub routes

### DIFF
--- a/app/routes/events/list.js
+++ b/app/routes/events/list.js
@@ -4,9 +4,17 @@ const { Route } = Ember;
 
 export default Route.extend({
   titleToken() {
-    return this.i18n.t('Live');
+    switch (this.get('params.event_state')) {
+      case 'live':
+        return this.i18n.t('Live');
+      case 'draft':
+        return this.i18n.t('Draft');
+      case 'past':
+        return this.i18n.t('Past');
+    }
   },
-  model() {
+  model(params) {
+    this.set('params', params);
     return [{
       name    : 'Event_Name2',
       startAt : new Date(),


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
subroutes of events now have titles depending on the page selected

demo- https://open-event-frontend-branch5.herokuapp.com/events/past
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #288 
