### PR TITLE
Adds confirm modal before deleting event

### DIFF
--- a/app/components/modals/event-delete-modal.js
+++ b/app/components/modals/event-delete-modal.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+const { computed } = Ember;
+
+export default ModalBase.extend({
+  isSmall         : true,
+  confirmName     : '',
+  isNameDifferent : computed('confirmName', function() {
+    return this.get('confirmName').toLowerCase() !== this.get('eventName').toLowerCase();
+  })
+});

--- a/app/controllers/events/view.js
+++ b/app/controllers/events/view.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  actions: {
+    openDeleteEventModal() {
+      this.set('isEventDeleteModalOpen', true);
+    },
+
+    deleteEvent() {
+      this.set('isEventDeleteModalOpen', false);
+    }
+  }
+});

--- a/app/templates/components/modals/event-delete-modal.hbs
+++ b/app/templates/components/modals/event-delete-modal.hbs
@@ -1,0 +1,24 @@
+<div class="header">
+  {{t 'Are you sure you would like to delete this event?'}}
+  <div class="muted small text">
+    {{t 'Deleting the event will delete all the data associated with it.'}}
+  </div>
+</div>
+<div class="content">
+  <form class="ui form" autocomplete="off" {{action (optional formSubmit) on='submit' preventDefault=true}}>
+    <div class="field">
+      <div class="label">
+        {{t 'Please enter the full name of the event to continue'}}
+      </div>
+      {{input type='text' name='confirm_name' value=confirmName required=true}}
+    </div>
+  </form>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="submit" class="ui red button" disabled={{isNameDifferent}} {{action deleteEvent}}>
+    {{t 'Delete Event'}}
+  </button>
+</div>

--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -2,7 +2,9 @@
   <div class="ui grid stackable">
     <div class="row">
       <div class="four wide column">
-        <h2 class="ui header">Fossasia Test</h2>
+        <h2 class="ui header">
+          {{model.name}}
+        </h2>
       </div>
       <div class="twelve wide column {{unless device.isMobile 'right aligned'}}">
         {{#if device.isMobile}}
@@ -10,7 +12,7 @@
             <button class="ui button"><i class="unhide icon"></i></button>
             <button class="ui button"><i class="check icon"></i></button>
             <button class="ui button"><i class="copy icon"></i></button>
-            <button class="ui red button"><i class="trash icon"></i></button>
+            <button class="ui red button" {{action 'openDeleteEventModal'}}><i class="trash icon"></i></button>
           </div>
         {{else}}
             <button class="ui button labeled icon small">
@@ -27,7 +29,7 @@
                 {{t 'Copy'}}
               </button>
             </div>
-            <button class="ui red button labeled icon small">
+            <button class="ui red button labeled icon small" {{action 'openDeleteEventModal'}}>
               <i class="trash icon"></i>
               {{t 'Delete'}}
             </button>
@@ -58,7 +60,9 @@
       {{/tabbed-navigation}}
     </div>
   </div>
-  
+
+  {{modals/event-delete-modal isOpen=isEventDeleteModalOpen eventName=model.name deleteEvent=(action 'deleteEvent')}}
+
   <div class="ui segment">
     {{outlet}}
   </div>

--- a/tests/integration/components/modals/event-delete-modal-test.js
+++ b/tests/integration/components/modals/event-delete-modal-test.js
@@ -1,0 +1,13 @@
+import { test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('modals/event-delete-modal', 'Integration | Component | modals/event delete modal');
+
+test('it renders', function(assert) {
+  this.set('isOpen', false);
+  this.set('eventName', 'sample');
+  this.set('deleteEvent', () => {});
+  this.render(hbs`{{modals/event-delete-modal isOpen=isOpen eventName=eventName deleteEvent=(action deleteEvent)}}`);
+  assert.ok(this.$().html().trim().includes('Are you sure'));
+});

--- a/tests/unit/controllers/events/view-test.js
+++ b/tests/unit/controllers/events/view-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('controller:events/view', 'Unit | Controller | events/view');
+
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds the confirm delete modal before deleting an event on event overview page.


#### Changes proposed in this pull request:

![image](https://user-images.githubusercontent.com/17252805/27361589-021c27e4-5646-11e7-8587-fe84e4d8862f.png)
![image](https://user-images.githubusercontent.com/17252805/27361617-35e99106-5646-11e7-9316-d1e50a061297.png)




<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #299 
