### PR TITLE
Refactor taxModal,password section to camelcase, add missing validation to tax Modal

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -277,7 +277,7 @@ export default Component.extend(FormMixin, {
       this.get(`data.event.${type}`).removeObject(item);
     },
     openTaxModal() {
-      this.set('taxModelIsOpen', true);
+      this.set('taxModalIsOpen', true);
     },
     deleteTaxInformation() {
       this.set('data.event.hasTaxInfo', false);

--- a/app/components/modals/tax-info-modal.js
+++ b/app/components/modals/tax-info-modal.js
@@ -21,16 +21,18 @@ export default ModalBase.extend(FormMixin, {
       delay  : false,
       on     : 'blur',
       fields : {
-        tax_name: {
-          rules: [
+        taxName: {
+          identifier : 'tax_name',
+          rules      : [
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give a name')
             }
           ]
         },
-        tax_rate: {
-          rules: [
+        taxRate: {
+          identifier : 'tax_rate',
+          rules      : [
             {
               type   : 'empty',
               prompt : this.l10n.t('Please tell us your tax rate (in %)')
@@ -41,26 +43,29 @@ export default ModalBase.extend(FormMixin, {
             }
           ]
         },
-        tax_id: {
-          rules: [
+        taxId: {
+          identifier : 'tax_id',
+          rules      : [
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give us your tax ID')
             }
           ]
         },
-        tax_invoice_company: {
-          depends : 'send_tax_invoices',
-          rules   : [
+        taxInvoiceCompany: {
+          identifier : 'tax_invoice_company',
+          depends    : 'send_tax_invoices',
+          rules      : [
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give us your company name')
             }
           ]
         },
-        tax_invoice_address: {
-          depends : 'send_tax_invoices',
-          rules   : [
+        taxInvoiceAddress: {
+          identifier : 'tax_invoice_address',
+          depends    : 'send_tax_invoices',
+          rules      : [
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give us your address')

--- a/app/components/modals/tax-info-modal.js
+++ b/app/components/modals/tax-info-modal.js
@@ -7,7 +7,7 @@ import { orderBy } from 'lodash';
 const { computed } = Ember;
 
 export default ModalBase.extend(FormMixin, {
-  isSmall : true,
+  isSmall : false,
   options : {
     closable: false
   },
@@ -69,6 +69,36 @@ export default ModalBase.extend(FormMixin, {
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give us your address')
+            }
+          ]
+        },
+
+        taxInvoiceCity: {
+          identifier : 'tax_invoice_city',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please give a city')
+            }
+          ]
+        },
+
+        taxInvoiceState: {
+          identifier : 'tax_invoice_state',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please give a state')
+            }
+          ]
+        },
+
+        taxInvoiceZipCode: {
+          identifier : 'tax_invoice_zipcode',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please provide a zip code')
             }
           ]
         }

--- a/app/components/settings/password-section.js
+++ b/app/components/settings/password-section.js
@@ -10,7 +10,7 @@ export default Component.extend(FormMixin, {
       delay  : false,
       on     : 'blur',
       fields : {
-        password_current: {
+        currentPassword: {
           identifier : 'password_current',
           rules      : [
             {
@@ -19,7 +19,7 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        password_new: {
+        newPassword: {
           identifier : 'password_new',
           rules      : [
             {
@@ -32,7 +32,7 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        password_repeat: {
+        repeatPassword: {
           identifier : 'password_repeat',
           rules      : [
             {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -549,4 +549,4 @@
   </div>
 </form>
 
-{{modals/tax-info-modal isOpen=taxModelIsOpen taxInfo=data.event.taxInfo hasTaxInfo=data.event.hasTaxInfo}}
+{{modals/tax-info-modal isOpen=taxModalIsOpen taxInfo=data.event.taxInfo hasTaxInfo=data.event.hasTaxInfo}}

--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -25,7 +25,7 @@
     </div>
     <div class="field">
       <label class="required">{{t 'Tax rate'}}</label>
-      {{input type='number' id='tax_rate' value=taxInfo.rate}}
+      {{input type='number' id='tax_rate' value=taxInfo.rate min=0}}
     </div>
     <div class="field">
       <label class="required">{{t 'Tax ID'}}</label>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The form validation variables of the files which were missed while previous refactoring are converted to camelcase.

#### Changes proposed in this pull request:

- refactor password section and tax Modal
- rename `isTaxModelOpen` to `isTaxModalOpen`
- Add missing validation to some fields of tax Modal

Since two minor but separate things are being solved by this PR I have split it into two commits.
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #309 
