### PR TITLE
Fixes redirection to events/<id>

### DIFF
--- a/app/routes/events/list.js
+++ b/app/routes/events/list.js
@@ -13,6 +13,12 @@ export default Route.extend({
         return this.l10n.t('Past');
     }
   },
+  beforeModel(transition) {
+    const eventState = transition.params[transition.targetName].event_state;
+    if (!['live', 'draft', 'past'].includes(eventState)) {
+      this.replaceWith('events.view', eventState);
+    }
+  },
   model(params) {
     this.set('params', params);
     return [{


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds redirection to events overview if the route is not live, past, draft.

Fixes #305 
@fossasia/open-event-frontend Please review

Deployment link:
https://open-event-frontend-app2.herokuapp.com