### PR TITLE
prevents content overflow the event image on public event page

### DIFF
--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -2,12 +2,37 @@
 
   margin-top: -$page-top-margin;
 
+  @mixin aspect-ratio($width, $height) {
+    position: relative;
+    &:before {
+      display: block;
+      content: "";
+      width: 100%;
+      padding-top: ($height / $width) * 100%;
+    }
+    > .content {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+    > img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+  }
+
   div.lead:not(.with) {
+    @include aspect-ratio(2, 1);
     position: absolute;
     left: 0;
     right: 0;
     width: 100%;
-    height: $event-lead-image-height;
+    max-height: $event-lead-image-height;
     overflow: hidden;
 
     img {
@@ -23,51 +48,70 @@
       left: 0;
       right: 0;
       width: 100%;
-      height: 100%;
       color: #ffffff;
       text-shadow: 0 1px 2px rgba(0,0,0,.6);
 
       .info {
-        position: relative;
-        top: $event-lead-image-height - 270px;
+        position: absolute;
+        bottom: 20%;
 
         .event {
           font-weight: 300;
         }
 
         .event.name {
-          font-size: 50px;
+          font-size: 4.5vh;
           margin-top: 0;
-          margin-bottom: 10px;
+          margin-bottom: 1vh;
         }
         .event.time {
-          font-size: 18px;
+          font-size: 1.5vh;
           margin: 0;
         }
         .event.location {
-          font-size: 18px;
+          font-size: 1.5vh;
           margin: 0;
         }
       }
 
+      @media (max-width: 959px) and (orientation: landscape) {
+        .info {
+          position: absolute;
+          bottom: 20%;
+
+          .event {
+            font-weight: 300;
+          }
+
+          .event.name {
+            font-size: 8.5vh;
+            margin-top: 0;
+            margin-bottom: 1vh;
+          }
+          .event.time {
+            font-size: 3.5vh;
+            margin: 0;
+          }
+          .event.location {
+            font-size: 3.5vh;
+            margin: 0;
+          }
+        }
+      }
     }
   }
 
   div.lead.small:not(.with) {
-    height: $event-lead-image-height-minimum;
+    max-height: $event-lead-image-height-minimum;
     .content {
       .info {
-        top: $event-lead-image-height-minimum - 270px;
+        position: absolute;
+        bottom: 20%;
       }
     }
   }
 
   > .content {
-    padding-top: $event-lead-image-height + 16px;
-
-    &.with.small.lead {
-      padding-top: $event-lead-image-height-minimum + 16px;
-    }
 
     .ui.rail {
       width: 15rem;

--- a/app/styles/partials/footer.scss
+++ b/app/styles/partials/footer.scss
@@ -23,7 +23,7 @@ footer {
 
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .main-container {
-    margin: 20px 0;
+    margin: $page-top-margin 0;
     min-height: 50vh;
   }
 

--- a/app/styles/vars.scss
+++ b/app/styles/vars.scss
@@ -1,3 +1,3 @@
-$page-top-margin: 20px;
+$page-top-margin: 14px;
 $event-lead-image-height: 500px;
 $event-lead-image-height-minimum: 300px;

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -1,11 +1,11 @@
-<div class="public-event">
-  <div class="lead {{if smallLead 'small'}}">
+<div class="public-event ui relaxed grid">
+  <div class="sixteen wide column lead {{if smallLead 'small'}}">
     {{widgets/safe-image src=(if model.largeImageUrl model.largeImageUrl model.originalImageUrl)}}
     <div class="content">
       <div class="ui container">
-        <div class="ui grid">
+        <div class="ui grid info">
           <div class="one wide column"></div>
-          <div class="fifteen wide column info">
+          <div class="fifteen wide column">
             <h4 class="event time">{{moment-format model.startsAt 'ddd, MMM DD \at HH:mm A'}}</h4>
             <h1 class="event name">{{model.name}}</h1>
             <h4 class="event location"><i class="marker icon"></i>{{model.locationName}}</h4>
@@ -14,7 +14,7 @@
       </div>
     </div>
   </div>
-  <div class="content {{if smallLead 'with small lead'}}">
+  <div class="sixteen wide column content {{if smallLead 'with small lead'}}">
     <div class="ui stackable grid" id="public-event-content">
       <div class="three wide column">
         {{#if device.isMobile}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
maintained the aspect ratio of the image and the content container as it scales.

#### Changes proposed in this pull request:
-created a Sass mixin to maintain the aspect ratio of the image and the container 
-used 16:9 as default aspect ratio works fine with higher resolution image but a little bit of overflow still there for low-resolution image
-the height of the content changes according to the height of the content container

demo-http://open-event-frontend-branch5.herokuapp.com/e/963d3ba5

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #328 
