### PR TITLE
resolve: overflow of popup on event overview page

### DIFF
--- a/app/templates/components/events/view/overview/event-sponsors.hbs
+++ b/app/templates/components/events/view/overview/event-sponsors.hbs
@@ -3,7 +3,7 @@
   <div class="header">{{t 'Event sponsors'}}</div>
 </div>
 <div class="content">
-  <table class="ui very basic table">
+  <table class="ui very basic compact table">
     <thead>
       <tr>
         <th>{{t 'Logo'}}</th>
@@ -20,7 +20,7 @@
         <td>ABC</td>
         <td>1</td>
         <td>
-          <div class="ui horizontal compact basic buttons">
+          <div class="ui vertical compact basic buttons">
             {{#ui-popup content=(t 'Edit') class='ui icon button'}}
               <i class="edit icon"></i>
             {{/ui-popup}}


### PR DESCRIPTION
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This PR resolves the issue of pop-up overflowing in the sponsors' block under event overview page.

Deployment Link: https://open-event-frontend-harshita.herokuapp.com/events/963d3ba5
Fixes #325 