### PR TITLE
Remove classNames from modal-base

### DIFF
--- a/app/components/modals/modal-base.js
+++ b/app/components/modals/modal-base.js
@@ -5,7 +5,6 @@ const { observer, merge, assign, testing } = Ember;
 
 export default UiModal.extend({
   tagName           : 'div',
-  classNames        : ['ui', 'modal'],
   classNameBindings : ['isFullScreen:fullscreen', 'isSmall:small', 'isLarge:large'],
 
   openObserver: observer('isOpen', function() {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Removes `classNames` from base modal as they are already present in `semantic-ui-ember/components/ui-modal` which the base modal extends.
#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/17252805/27588040-5ffefa08-5b64-11e7-847d-f3a9e1b56248.png)
The class will appear only once as it is supposed to after this.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #362 
