### PR TITLE
resolve: sliderbox label overflowing to next line

### DIFF
--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -1,6 +1,6 @@
 <form class="ui form" autocomplete="off" {{action 'moveForward' on='submit' preventDefault=true}}>
 
-  <div class="ui three column centered grid">
+  <div class="ui centered grid">
     <div class="column">
       <div class="ui {{if sessionsSpeakers.enabled 'basic'}} segment">
         <div class="center aligned text">

--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -1,6 +1,6 @@
 <form class="ui form" autocomplete="off" {{action 'moveForward' on='submit' preventDefault=true}}>
 
-  <div class="ui four column centered grid">
+  <div class="ui centered grid">
     <div class="column">
       <div class="ui {{if data.sponsors.enabled 'basic'}} segment">
         <div class="center aligned text">


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR resolves the slider box's label going to next line for all the screens lesser than laptop.

#### Changes proposed in this pull request:
Removing the column size and letting the label take whatever the require width is. 

Fixes #366 

Deployment Link: https://open-event-frontend-harshita.herokuapp.com/events/963d3ba5/edit/sponsors


