### PR TITLE
Make UI of sponsors in event wizard responsive

### DIFF
--- a/app/styles/partials/wizard.scss
+++ b/app/styles/partials/wizard.scss
@@ -25,3 +25,7 @@
   }
 }
 
+.sponsors-step {
+  padding-top: 58px;
+}
+

--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -49,11 +49,11 @@
         </div>
       </div>
       <div class="fields">
-        <div class="five wide field" style="">
+        <div class="five wide computer eight wide tablet field">
           <label>{{t 'Description'}}</label>
           {{widgets/forms/rich-text-editor value=sponsor.description name='description'}}
         </div>
-        <div class="eleven wide field" style="padding-top: 58px;">
+        <div class="sponsors-step eleven wide computer eight wide tablet field {{if device.isMobile 'less padding'}}">
           {{widgets/forms/image-upload
             label=(t 'Logo')
             imageUrl=sponsor.logoUrl
@@ -66,13 +66,13 @@
         <div class="ui section divider"></div>
       {{/if}}
     {{/each}}
-    <button type="button" class="ui primary button" {{action 'addSponsor'}}>{{t 'Add another sponsor'}}</button>
+    <button type="button" class="ui primary {{if device.isMobile 'small'}} button" {{action 'addSponsor'}}>{{t 'Add another sponsor'}}</button>
     <div class="spacer-50"></div>
   {{else}}
     <div class="spacer-50"></div>
   {{/if}}
 
-  <div class="large ui buttons right floated">
+  <div class="{{if device.isMobile 'mini three' 'large right floated'}} ui buttons">
     <button class="ui right labeled icon button" type="button" {{action 'moveForward'}}>
       {{t 'Forward'}}
       <i class="right chevron icon"></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Makes the UI of sponsors in event wizard responisve

#### Changes proposed in this pull request:

- Prevent buttons overflow
- Give space between fields for mobile
- Make rich text editor accommodate for tablets
![image](https://user-images.githubusercontent.com/17252805/27684572-3f788152-5ce8-11e7-8b05-0ca63b50a562.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #371 
