### PR TITLE
Make move ticket up/down buttons in create event wizard non floating for tablets

### DIFF
--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -39,6 +39,12 @@ body.dimmable.undetached.dimmed {
   padding: 0 !important;
 }
 
-.padding.less {
-  padding: 0 !important;
+.less {
+  &.padding {
+    padding: 0 !important;
+  }
+  
+  &.padding-right {
+    padding-right: 0 !important;
+  }
 }

--- a/app/templates/components/widgets/forms/ticket-input.hbs
+++ b/app/templates/components/widgets/forms/ticket-input.hbs
@@ -20,13 +20,13 @@
       {{input type='number' name='ticket_quantity' placeholder=(t 'Quantity') value=ticket.quantity}}
     </div>
   </div>
-  <div class="column">
+  <div class="column {{unless device.isLargeMonitor 'padding-right less'}}">
     <div class="field">
       <div class="ui icon buttons">
         <button type="button" class="ui button" {{action 'toggleSettings'}} data-content="Settings"><i class="setting icon"></i></button>
         <button type="button" class="ui button" {{action removeTicket}} data-content="Delete"><i class="trash icon"></i></button>
       </div>
-      <div class="ui icon buttons right floated">
+      <div class="ui icon buttons {{if device.isLargeMonitor 'right floated'}}">
         {{#if canMoveUp}}
           <button type="button" class="ui button" {{action moveTicketUp}} data-content="Move ticket up"><i class="up arrow icon"></i></button>
         {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
In the event create wizard, the move ticket up/down buttons are floated to the right, it works out fine for the mobile, because the grid is stackable, however in tablets for both horizontal and landscape mode, it creates a buggy diamond shaped layout.

#### Changes proposed in this pull request:

Make the buttons float to the right only if the screen is larger than portrait tablet
![image](https://user-images.githubusercontent.com/17252805/27717513-6d5c7382-5d63-11e7-81b4-6599b6262f1b.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #384 
