### PR TITLE
Adds spacing between fields for mobile in session-speaker form

### DIFF
--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -29,11 +29,11 @@
     <div class="field">
       <label>Tracks</label>
       {{#each sessionsSpeakers.tracks as |track|}}
-        <div class="fields">
-          <div class="three wide field">
+        <div class="{{if device.isMobile 'grouped'}} fields">
+          <div class="{{unless device.isMobile 'three wide'}} field">
             {{input type='text' value=track.name placeholder='Name'}}
           </div>
-          <div class="four wide field">
+          <div class="{{unless device.isMobile 'four wide'}} field">
             {{#widgets/forms/color-picker value=track.color}}
               {{#if (gt sessionsSpeakers.tracks.length 1)}}
                 <button class="ui icon red button" type="button" {{action 'removeItem' track 'track'}}>
@@ -45,7 +45,7 @@
               </button>
             {{/widgets/forms/color-picker}}
           </div>
-          <div class="two wide field">
+          <div class="{{unless device.isMobile 'two wide'}} field">
             <input title="Preview"
                    class="preview"
                    value="{{if track.name track.name (t 'Preview Text')}}"
@@ -59,11 +59,11 @@
     <div class="field">
       <label>{{t 'Microlocations'}}</label>
       {{#each sessionsSpeakers.microlocations as |microlocation|}}
-        <div class="fields">
-          <div class="three wide field">
+        <div class="{{if device.isMobile 'grouped'}} fields">
+          <div class="{{unless device.isMobile 'three wide'}} field">
             {{input type='text' value=microlocation.name placeholder='Name'}}
           </div>
-          <div class="four wide field">
+          <div class="{{unless device.isMobile 'four wide'}} field">
             <div class="ui action input fluid">
               {{input type='text' value=microlocation.floor placeholder='Floor'}}
               {{#if (gt sessionsSpeakers.microlocations.length 1)}}
@@ -82,11 +82,11 @@
     <div class="field">
       <label>{{t 'Session Types'}}</label>
       {{#each sessionsSpeakers.sessionTypes as |sessionType|}}
-        <div class="fields">
-          <div class="three wide field">
+        <div class="{{if device.isMobile 'grouped'}} fields">
+          <div class="{{unless device.isMobile 'three wide'}} field">
             {{input type='text' value=sessionType.name placeholder='Name'}}
           </div>
-          <div class="four wide field">
+          <div class="{{unless device.isMobile 'four wide'}} field">
             <div class="ui action input fluid">
               {{widgets/forms/time-picker value=sessionType.length placeholder='HH:MM' icon=false}}
               {{#if (gt sessionsSpeakers.sessionTypes.length 1)}}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Adds spacing between fields in mobile view.

Proposed design
![screenshot from 2017-06-30 14-22-14](https://user-images.githubusercontent.com/12807846/27728415-8e94581c-5d9f-11e7-9501-5a1a6f4ce336.png)


Fixes #383 

Deployment link: 
https://open-event-frontend-app.herokuapp.com/login
