### PR TITLE
resolves : loss of active class of side bar on subroutes of /access-code

### DIFF
--- a/app/templates/events/view/tickets.hbs
+++ b/app/templates/events/view/tickets.hbs
@@ -14,7 +14,7 @@
         {{#link-to 'events.view.tickets.discount-codes' class='item'}}
           {{t 'Discount Codes'}}
         {{/link-to}}
-        {{#link-to 'events.view.tickets.access-codes.index' class='item'}}
+        {{#link-to 'events.view.tickets.access-codes' class='item'}}
           {{t 'Access Codes'}}
         {{/link-to}}
         {{#link-to 'events.view.tickets.add-order' class='item'}}

--- a/app/templates/events/view/tickets/access-codes/list.hbs
+++ b/app/templates/events/view/tickets/access-codes/list.hbs
@@ -16,7 +16,9 @@
         <tr>
           <td>{{inc index}}</td>
           <td>{{entry.accessCode}}</td>
-          <td>{{entry.accessCodeUrl}}</td>
+          <td>
+            <a href='{{entry.accessCodeUrl}}' target='_blank' rel='noopener'>{{entry.accessCodeUrl}}</a>
+          </td>
           <td>{{entry.accessibleTicket}}</td>
           <td>{{entry.validity}}</td>
           {{#if entry.isActive}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
moving on subroutes of access-codes will not remove its active class on sidebar

#### Changes proposed in this pull request:

-resolves active class issue
-convert access code url (a field in access code table) as a link.

demo- https://open-event-frontend-branch3.herokuapp.com/events/963d3ba5/tickets/access-codes

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #390 
