### PR TITLE
Create modal for add system role on admin/permissions

### DIFF
--- a/app/components/modals/add-system-role-modal.js
+++ b/app/components/modals/add-system-role-modal.js
@@ -1,0 +1,42 @@
+import FormMixin from 'open-event-frontend/mixins/form';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend(FormMixin, {
+  isSmall            : true,
+  autoScrollToErrors : false,
+
+  actions: {
+    addRole() {
+      this.onValid(() => {
+        this.sendAction('addSystemRole');
+      });
+    }
+  },
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        email: {
+          identifier : 'role_name',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter a role name')
+            }
+          ]
+        },
+        selectedPanels: {
+          identifier : 'selected_panels',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please select atleast one panel')
+            }
+          ]
+        }
+      }
+    };
+  }
+});

--- a/app/controllers/admin/permissions/system-roles.js
+++ b/app/controllers/admin/permissions/system-roles.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+export default Controller.extend({
+  actions: {
+    openAddSystemrRoleModal() {
+      this.set('isAddSystemRoleModalOpen', true);
+    },
+    addSystemRole() {
+      this.set('isAddSystemRoleModalOpen', false);
+    }
+  }
+});

--- a/app/templates/admin/permissions/system-roles.hbs
+++ b/app/templates/admin/permissions/system-roles.hbs
@@ -75,7 +75,7 @@
     </tr>
     <tr>
       <td>
-        <button class="ui basic button">{{t 'Add new Role'}}</button>
+        <button class="ui basic button" {{action 'openAddSystemrRoleModal'}}>{{t 'Add new Role'}}</button>
       </td>
       <td></td>
       <td></td>
@@ -123,3 +123,5 @@
 <div>
   <button class="ui teal button">{{t 'Save'}}</button>
 </div>
+
+{{modals/add-system-role-modal  isOpen=isAddSystemRoleModalOpen addSystemRole=(action 'addSystemRole')}}

--- a/app/templates/components/modals/add-system-role-modal.hbs
+++ b/app/templates/components/modals/add-system-role-modal.hbs
@@ -1,0 +1,66 @@
+<div class="header">
+  {{t 'Add New System Role'}}
+</div>
+<div class="content">
+  <form class="ui form" id="add-system-role-form" autocomplete="off" {{action 'addRole' on='submit' preventDefault=true}}>
+    <div class="field">
+      <label class="required">
+        {{t 'Name'}}
+      </label>
+      {{input type='text' name='role_name' placeholder=(t 'Enter Role name')}}
+    </div>
+    <div class="field">
+      <label class="required">
+        {{t 'Panels'}}
+      </label>
+      {{#ui-dropdown class="fluid multiple selection" selected=selectedPanels}}
+        {{input type='hidden' name='selected_panels' value=selectedPanels}}
+        <i class="dropdown icon"></i>
+        <div class="default text">
+          {{t 'Please select Panel(s)'}}
+        </div>
+        <div class="menu">
+          <div class="item" data-value="admin">
+            {{t 'Admin Panel'}}
+          </div>
+          <div class="item" data-value="events">
+            {{t 'Events Panel'}}
+          </div>
+          <div class="item" data-value="sales">
+            {{t 'Sales Panel'}}
+          </div>
+          <div class="item" data-value="sessions">
+            {{t 'Sessions Panel'}}
+          </div>
+          <div class="item" data-value="users">
+            {{t 'Users Panel'}}
+          </div>
+          <div class="item" data-value="permissions">
+            {{t 'Permissions Panel'}}
+          </div>
+          <div class="item" data-value="messages">
+            {{t 'Messages Panel'}}
+          </div>
+          <div class="item" data-value="reports">
+            {{t 'Reports Panel'}}
+          </div>
+          <div class="item" data-value="settings">
+            {{t 'Settings Panel'}}
+          </div>
+          <div class="item" data-value="content">
+            {{t 'Content Panel'}}
+          </div>
+        </div>
+      {{/ui-dropdown}}
+    </div>
+  </form>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="submit" form="add-system-role-form" class="ui green right labeled icon button">
+    {{t 'Add Role'}}
+    <i class="checkmark icon"></i>
+  </button>
+</div>

--- a/tests/integration/components/modals/add-system-role-modal-test.js
+++ b/tests/integration/components/modals/add-system-role-modal-test.js
@@ -1,0 +1,11 @@
+import {  test } from 'ember-qunit';
+import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('modals/add-system-role-modal', 'Integration | Component | modals/add system role modal');
+
+test('it renders', function(assert) {
+  this.set('isOpen', false);
+  this.render(hbs`{{modals/add-system-role-modal isOpen=isOpen}}`);
+  assert.ok(this.$().html().trim().includes('Add New System Role'));
+});

--- a/tests/unit/controllers/admin/permissions/system-roles-test.js
+++ b/tests/unit/controllers/admin/permissions/system-roles-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('controller:admin/permissions/system-roles', 'Unit | Controller | admin/permissions/system roles', []);
+
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds the add system role modal to admin/permission/system-roles
#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/17252805/27767307-07fd700e-5f11-11e7-8632-ca672a869dab.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #379 
