### PR TITLE
Refactor to display events on public page via New API

### DIFF
--- a/app/components/event-card.js
+++ b/app/components/event-card.js
@@ -8,7 +8,7 @@ export default Component.extend({
   classNames: ['column'],
 
   tags: computed('event.type', 'event.topic', 'event.subTopic', function() {
-    const tagsOriginal = this.get('event').getProperties('type', 'topic', 'subTopic');
+    const tagsOriginal = this.getProperties('event.topic.name', 'event.type.name', 'event.subTopic.name');
     let tags = [];
     forOwn(tagsOriginal, value => {
       if (value && value.trim() !== '') {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,20 +1,20 @@
 import Ember from 'ember';
-import moment from 'moment';
 
 const { Controller, computed } = Ember;
 
 export default Controller.extend({
 
   callForSpeakersEvents: computed('model.[]', function() {
-    return this.get('model').filter(event => {
-      const callForPapers = event.get('callForPapers');
-      if (callForPapers === null || !callForPapers.get('startDate') || !callForPapers.get('timezone') || !callForPapers.get('endDate')) {
-        return false;
-      }
-      const startDateTime = moment.tz(callForPapers.get('startDate'), callForPapers.get('timezone'));
-      const endDateTime = moment.tz(callForPapers.get('endDate'), callForPapers.get('timezone'));
-      return moment().isBetween(startDateTime, endDateTime);
-    });
+    // return this.get('model').filter(event => {
+    //   const callForPapers = event.get('speakersCall');
+    //   // console.log(callForPapers);
+    // if (!callForPapers|| !callForPapers.get('startDate') || !callForPapers.get('timezone') || !callForPapers.get('endDate')) {
+    //   return false;
+    // }
+    // const startDateTime = moment.tz(callForPapers.get('startDate'), callForPapers.get('timezone'));
+    // const endDateTime = moment.tz(callForPapers.get('endDate'), callForPapers.get('timezone'));
+    // return moment().isBetween(startDateTime, endDateTime);
+  // });
   }),
 
   actions: {

--- a/app/models/discount-code.js
+++ b/app/models/discount-code.js
@@ -24,7 +24,11 @@ export default Model.extend({
   createdAt     : attr('date'),
 
   tickets : hasMany('ticket'),
-  event   : belongsTo('event'), // The event that this discount code belongs to [Form (2)]
-  events  : hasMany('event')    // The events that this discount code has been applied to [Form (1)]
+  event   : belongsTo('event', {
+    inverse: 'discountCodes'
+  }), // The event that this discount code belongs to [Form (2)]
+  events: hasMany('event', {
+    inverse: 'discountCode'
+  })    // The events that this discount code has been applied to [Form (1)]
 });
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,6 +5,20 @@ const { Route } = Ember;
 
 export default Route.extend({
   model() {
-    return this.store.query('event', { end_time_gt: moment.utc().format('YYYY-MM-DDTHH:mm:ss'), state: 'Published' });
+    return this.store.query('event', {
+      include : 'event_topic,event_sub_topic,event_type',
+      filter  : [
+        {
+          name : 'starts_at',
+          op   : 'ge',
+          val  : moment().toISOString()
+        },
+        {
+          name : 'state',
+          op   : 'eq',
+          val  : 'Published'
+        }
+      ]
+    });
   }
 });

--- a/app/serializers/event-topic.js
+++ b/app/serializers/event-topic.js
@@ -2,6 +2,6 @@ import ApplicationSerializer from 'open-event-frontend/serializers/application';
 
 export default ApplicationSerializer.extend({
   attrs: {
-    subTopics: 'eventSubTopics'
+    subTopics: 'event-sub-topics'
   }
 });

--- a/app/serializers/event.js
+++ b/app/serializers/event.js
@@ -1,12 +1,11 @@
 import ApplicationSerializer from 'open-event-frontend/serializers/application';
 
 export default ApplicationSerializer.extend({
-  primaryKey : 'identifier',
-  attrs      : {
-    type             : 'eventType',
-    topic            : 'eventTopic',
-    subTopic         : 'eventSubTopic',
-    copyright        : 'eventCopyright',
-    externalEventUrl : 'eventUrl'
+  attrs: {
+    type             : 'event-type',
+    topic            : 'event-topic',
+    subTopic         : 'event-sub-topic',
+    copyright        : 'event-copyright',
+    externalEventUrl : 'event-url'
   }
 });

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -3,7 +3,7 @@
     {{#unless device.isMobile}}
       <div class="ui card three wide computer six wide tablet column">
         <a class="image" href="{{href-to 'public' event.identifier}}">
-          {{widgets/safe-image src=(if event.large event.large event.placeholderUrl)}}
+          {{widgets/safe-image src=(if event.originalImageUrl event.originalImageUrl event.originalImageUrl)}}
         </a>
       </div>
     {{/unless}}
@@ -11,7 +11,7 @@
   <div class="ui card {{unless isWide 'event fluid' 'thirteen wide computer ten wide tablet sixteen wide mobile column'}}">
     {{#unless isWide}}
       <a class="image" href="{{href-to 'public' event.identifier}}">
-        {{widgets/safe-image src=(if event.large event.large event.placeholderUrl)}}
+        {{widgets/safe-image src=(if event.originalImageUrl event.originalImageUrl event.originalImageUr)}}
       </a>
     {{/unless}}
     <a class="main content" href="{{href-to 'public' event.identifier}}">
@@ -20,7 +20,7 @@
       {{/smart-overflow}}
       <div class="meta">
         <span class="date">
-          {{moment-format event.startTime 'ddd, MMM DD HH:mm A'}}
+          {{moment-format event.startsAt 'ddd, MMM DD HH:mm A'}}
         </span>
       </div>
       {{#smart-overflow class='description'}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,8 +3538,8 @@
       "dev": true
     },
     "ember-data": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.14.3.tgz",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.13.2.tgz",
       "integrity": "sha512-x1k+7tpcZH3tDxeOAFFvqMAXKa2VpOtfRQYki8qmzRbF4lWWHqaKkEj2bZibRQA4jZx9/lfA+Mvf4GnD7uqdyA==",
       "dev": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "^2.0.0",
     "ember-config-service": "^0.1.6",
-    "ember-data": "^2.14.3",
+    "ember-data": "^2.13.2",
     "ember-exam": "^0.7.0",
     "ember-export-application-global": "^2.0.0",
     "ember-g-map": "0.0.25",


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Refactors the models and app to display events on public page via new API.

#### Changes proposed in this pull request:

- Lock ember data to 2.13.2
- temporarily disable speakersCall
- Refactor to display events on public page via new API

![image](https://user-images.githubusercontent.com/17252805/27771897-a34b39ba-5f75-11e7-8c81-3581cf61d06a.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

