### PR TITLE
resolve: wrong tab highlighted in nav bar at /events/event_id/edit page

### DIFF
--- a/app/components/widgets/steps-indicator.js
+++ b/app/components/widgets/steps-indicator.js
@@ -33,5 +33,10 @@ export default Component.extend({
       }
       return step;
     });
-  })
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+    this.notifyPropertyChange('autoSteps');
+  }
 });


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR resolves the issue of wrong tab highlighted in nav bar at /events/event_id/edit page

#### Changes proposed in this pull request:
Added add `this.notifyPropertyChange('autoSteps');` to `didInsertElement()` of `components/widgets/steps-indicator.js`

Fixes #386 
@niranjan94 @geekyd @CosmicCoder96 Please review. Thanks