### PR TITLE
make nav bar scrollable and added margin to label to attendees page

### DIFF
--- a/app/styles/partials/utils.scss
+++ b/app/styles/partials/utils.scss
@@ -7,3 +7,6 @@
 .scrollable-modal {
   max-height: 50vh;
 }
+.attendees-margin {
+  margin: 5px 0 5px 0 !important;
+}

--- a/app/templates/events/view/tickets/attendees.hbs
+++ b/app/templates/events/view/tickets/attendees.hbs
@@ -45,7 +45,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="eight wide column">
+    <div class="x-scrollable sixteen wide column">
       {{#tabbed-navigation isNonPointing=true}}
         {{#link-to 'events.view.tickets.attendees.index' class='item'}}
           {{t 'Completed'}}

--- a/app/templates/events/view/tickets/attendees/list.hbs
+++ b/app/templates/events/view/tickets/attendees/list.hbs
@@ -40,7 +40,7 @@
               <span class="weight-400">
                 {{t 'by'}} {{attendees.buyerName}}
               </span>
-              <div class="ui basic mini green label">
+              <div class="ui basic mini green label attendees-margin">
                 {{attendees.status}}
               </div>
               <div class="sub header">


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This PR resolves the issue of navigation bar overflowing and label misalignment for tablet sized devices.

Fixes #400 

Deployment Link : 
https://open-event-frontend-harshita.herokuapp.com/events/ebaf2dbe/tickets/attendees
@niranjan94 @CosmicCoder96 @geekyd Please review :+1: 