### PR TITLE
Hides divider in settings/system & permissions/system-roles

### DIFF
--- a/app/templates/admin/permissions/system-roles.hbs
+++ b/app/templates/admin/permissions/system-roles.hbs
@@ -82,7 +82,7 @@
     </tr>
   </tbody>
 </table>
-<div class="ui divider"></div>
+<div class="ui hidden divider"></div>
 <div>
   <h3 class="ui left aligned header">
     {{t 'User Permissions'}}

--- a/app/templates/components/forms/admin/settings/system-form.hbs
+++ b/app/templates/components/forms/admin/settings/system-form.hbs
@@ -69,7 +69,7 @@
     </label>
     {{input type='email' name='super_admin_email'}}
   </div>
-  <div class="ui divider"></div>
+  <div class="ui hidden divider"></div>
   <button class="ui teal wide button" type="submit">
     {{t 'Save'}}
   </button>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Hides divider in settings/system & permissions/system-roles form.
![screen shot 2017-07-04 at 5 29 40 am](https://user-images.githubusercontent.com/12807846/27810633-7dfd07be-607a-11e7-9517-cd8caabe653c.png)

Fixes #410 
