### PR TITLE
Adds responsiveness to location-input by hiding label in mobile device

### DIFF
--- a/app/templates/components/widgets/forms/location-input.hbs
+++ b/app/templates/components/widgets/forms/location-input.hbs
@@ -43,9 +43,9 @@
       placeChangedCallback=(action 'placeChanged')
       type='text'
       placeholder=placeholder}}
-    <button class="ui left labeled icon button" type="button" {{action 'showAddressView'}}>
+    <button class="ui left {{unless device.isMobile 'labeled'}} icon button" type="button" {{action 'showAddressView'}}>
       <i class="marker icon"></i>
-      {{t 'Enter address'}}
+      {{unless device.isMobile (t 'Enter address')}}
     </button>
   </div>
 {{/if}}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixes overflowing location-input for mobile devices.
![screen shot 2017-07-05 at 8 30 38 pm](https://user-images.githubusercontent.com/12807846/27870577-d7b31ef0-61c0-11e7-967b-923f6f97afc8.png)

Fixes #414 
Deployment link : https://open-event-frontend-app.herokuapp.com/