### PR TITLE
Prevents image upload widget overflow on profile page

### DIFF
--- a/app/components/modals/cropper-modal.js
+++ b/app/components/modals/cropper-modal.js
@@ -6,13 +6,12 @@ export default ModalBase.extend({
     this.$('img').croppie({
       customClass : 'croppie',
       viewport    : {
-        width  : 400,
-        height : 200,
+        width  : 300,
+        height : 150,
         type   : 'square'
       },
       boundary: {
-        width  : 600,
-        height : 300
+        height: 250
       }
     });
   },


### PR DESCRIPTION
resolves button overflow

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
resolves overflow of image upload widget (for mobile devices) on the profile page

#### Changes proposed in this pull request:

-remove width from boundary so that it can take the width of the current viewport
-reduce the height of the boundary so that buttons and zoom control does not overlap
-reduce the height and width of the viewport (maintaining same aspect ratio)

![image](https://user-images.githubusercontent.com/20153241/27908521-d8d36b56-6269-11e7-9f7d-d04f4d28ea96.png)

demo- http://open-event-frontend-branch6.herokuapp.com/profile
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #424 
