### PR TITLE
make event creation wizard time field tablet responsive

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -21,7 +21,7 @@
     {{/widgets/forms/location-input}}
   </div>
   <div class="fields">
-    <div class="five wide field">
+    <div class="{{if device.isTablet 'four' 'five'}} wide field">
       <label class="required" for="start_date">{{t 'Starts'}}</label>
       {{widgets/forms/date-picker type='text'
                                   inputId='start_date'
@@ -29,7 +29,7 @@
                                   rangePosition='start'
                                   value=data.event.startDate}}
     </div>
-    <div class="two wide field">
+    <div class="{{if device.isTablet 'three' 'two'}} wide field">
       <label for="start_time">&nbsp;</label>
       {{widgets/forms/time-picker type='text'
                                   inputId='start_time'
@@ -37,7 +37,7 @@
                                   rangePosition='start'
                                   value=data.event.startTime}}
     </div>
-    <div class="five wide field">
+    <div class="{{if device.isTablet 'four' 'five'}} wide field">
       <label class="required" for="end_date">{{t 'Ends'}}</label>
       {{widgets/forms/date-picker type='text'
                                   inputId='end_date'
@@ -45,7 +45,7 @@
                                   rangePosition='end'
                                   value=data.event.endDate}}
     </div>
-    <div class="two wide field">
+    <div class="{{if device.isTablet 'three' 'two'}} wide field">
       <label for="end_time">&nbsp;</label>
       {{widgets/forms/time-picker type='text'
                                   inputId='end_time'
@@ -55,7 +55,7 @@
     </div>
     <div class="five wide field">
       <label class="required" for="timezone">{{t 'Timezone'}}</label>
-      {{#ui-dropdown class='search selection' selected=data.event.timezone forceSelection=false fullTextSearch=true}}
+      {{#ui-dropdown class='search compact selection' selected=data.event.timezone forceSelection=false fullTextSearch=true}}
         {{input type='hidden' id='timezone' value=data.event.timezone}}
         <i class="dropdown icon"></i>
         <div class="default text">{{t 'Select timezone'}}</div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
make event creation wizard time field tablet responsive
before :
![image](https://user-images.githubusercontent.com/17252805/27923933-c2c6d2ba-629d-11e7-8f1e-2ea9b80548ee.png)



#### Changes proposed in this pull request:
After:

![image](https://user-images.githubusercontent.com/17252805/27923985-dcb12cca-629d-11e7-9916-cdb7a0c2b70d.png)





<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #425

