### PR TITLE
Enable user to enter values in explore route custom date filter

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -38,7 +38,11 @@ export default Component.extend({
       this.set('filters.eventType', eventType === this.get('filters.eventType') ? null : eventType);
     },
     selectDateRange(dateRange) {
-      this.set('filters.dateRange', dateRange === this.get('filters.dateRange') ? null : dateRange);
+      let isCustomDate = null;
+      if (dateRange === 'custom_dates') {
+        isCustomDate = dateRange;
+      }
+      this.set('filters.dateRange', dateRange === this.get('filters.dateRange') ?  isCustomDate : dateRange);
     }
   }
 });

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -66,13 +66,19 @@
           {{#if (and (eq dateRange.key 'custom_dates') (eq filters.dateRange 'custom_dates'))}}
             <div class="explore sub menu">
               <div class="ui form">
-                <div class="item field">
-                  <label class="required" for="start_date">{{t 'Starts'}}</label>
-                  {{widgets/forms/date-picker type='text'inputId='start_date'}}
-                </div>
-                <div class="item field">
-                  <label class="required" for="end_date">{{t 'Ends'}}</label>
-                  {{widgets/forms/date-picker type='text'inputId='end_date'}}
+                <div class="grouped fields">
+                  <div class="item field">
+                    <label class="required" for="start_date">{{t 'Starts'}}</label>
+                    {{widgets/forms/date-picker type='text'
+                                                rangePosition='start'
+                                                inputId='start_date'}}
+                  </div>
+                  <div class="item field">
+                    <label class="required" for="end_date">{{t 'Ends'}}</label>
+                    {{widgets/forms/date-picker type='text'
+                                                rangePosition='end'
+                                                inputId='end_date'}}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It was not possible for the user to enter the dates in the custom date filter, as the menu closed the field on clicking it.

#### Changes proposed in this pull request:
![giphy 5](https://user-images.githubusercontent.com/17252805/27974880-86259a36-637d-11e7-8ec0-cd9e6034b055.gif)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #438 
