### PR TITLE
Enhance device service add more breakpoints

### DIFF
--- a/app/services/device.js
+++ b/app/services/device.js
@@ -43,12 +43,13 @@ export default Service.extend({
     });
     return deviceType;
   }),
+  isMobile           : equal('deviceType', 'mobile'),
+  isComputer         : equal('deviceType', 'computer'),
+  isTablet           : equal('deviceType', 'tablet'),
+  isLargeMonitor     : equal('deviceType', 'largeMonitor'),
+  isWideScreen       : equal('deviceType', 'widescreen'),
+  isBiggerThanTablet : computed.or('isComputer', 'isLargeMonitor', 'isWideScreen'),
 
-  isMobile       : equal('deviceType', 'mobile'),
-  isComputer     : equal('deviceType', 'computer'),
-  isTablet       : equal('deviceType', 'tablet'),
-  isLargeMonitor : equal('deviceType', 'largeMonitor'),
-  isWideScreen   : equal('deviceType', 'widescreen'),
 
   isInternetExplorer: computed(function() {
     let rv = -1;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Currently there are more than 3 screen sizes which are bigger than the tablet,Computer, Large Monitor and Wide Screen
In order to specify an element common to all of them multiple boolean conditions have to be used, also the portrait and landscape tablet sizes are differentiated via isTablet and isComputer respectively, however a similar distinction is not possible for portrait and landscape mobile screens.

#### Changes proposed in this pull request:

- Add isGreaterThanTablet breakpoint
- ~Add isPortraitMobile breakpoint~
- ~Add isLandscapeMobile breakpoint~


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #441 
