### PR TITLE
Add promotional code text field on event page

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import FormMixin from 'open-event-frontend/mixins/form';
 import { sumBy } from 'lodash';
 
 const { Component, computed } = Ember;
 
-export default Component.extend({
+export default Component.extend(FormMixin, {
   classNames: ['ui', 'segments', 'ticket-list'],
 
   hasTicketsInOrder: computed('tickets.@each.orderQuantity', function() {
@@ -16,5 +17,32 @@ export default Component.extend({
       sum += (ticket.price * ticket.orderQuantity);
     });
     return sum;
-  })
+  }),
+  actions: {
+    togglePromotionalCode() {
+      this.toggleProperty('enterPromotionalCode');
+    },
+    applyPromotionalCode() {
+      this.onValid(() => {
+      });
+    }
+  },
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        promotionalCode: {
+          identifier : 'promotional_code',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter the promotional Code')
+            }
+          ]
+        }
+      }
+    };
+  }
 });

--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -35,16 +35,21 @@ body.dimmable.undetached.dimmed {
   }
 }
 
-.margin.less {
-  padding: 0 !important;
-}
 
 .less {
   &.padding {
     padding: 0 !important;
   }
-  
+
+  &.margin {
+    margin: 0 !important;
+  }
+
   &.padding-right {
     padding-right: 0 !important;
+  }
+
+  &.margin-right {
+    margin-right: 0 !important;
   }
 }

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -58,10 +58,33 @@
         </tr>
       </tfoot>
     </table>
-    <div class="ui row grid">
-      <div class="column right aligned">
-        <a href="#">{{t 'Enter promotional code'}}</a>
-      </div>
+    <div class="ui grid">
+      {{#if enterPromotionalCode}}
+        <div class="ui row">
+          <div class="{{if device.isBiggerThanTablet 'right floated eight wide'}} column">
+            <div class="field">
+              <div class="ui action fluid input">
+                {{input type='text' name='promotional_code' placeholder=(t 'Promotional Code')}}
+                <div role="button" class="ui icon button" {{action 'applyPromotionalCode'}}>
+                  <i class="checkmark icon"></i>
+                </div>
+                <div role="button" class="ui black icon button" {{action 'togglePromotionalCode'}}>
+                  <i class="remove icon"></i>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {{else}}
+        <div class="ui row">
+          <div class="column right aligned">
+            {{#if device.isMobile}}
+              <div class="ui hidden divider"></div>
+            {{/if}}
+            <a href="#" {{action 'togglePromotionalCode'}}>{{t 'Enter promotional code'}}</a>
+          </div>
+        </div>
+      {{/if}}
     </div>
     <div class="ui row">
       <div class="ui grid">
@@ -76,7 +99,7 @@
             <i class="colored visa link icon"></i>
           </div>
           <div class="ui padding less two wide computer four wide tablet column right aligned floated">
-            <button id="total" class="ui primary button" disabled={{not hasTicketsInOrder}}>
+            <button id="total" class="ui primary button less margin-right" disabled={{not hasTicketsInOrder}}>
               {{t 'Order Now'}}
             </button>
           </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds the missing promotional code text field on event page

#### Changes proposed in this pull request:
![giphy 6](https://user-images.githubusercontent.com/17252805/27999272-f952be82-6538-11e7-94ca-aed34d345553.gif)
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #434 
