### PR TITLE
adds tabbed navigation to /access-code

### DIFF
--- a/app/templates/components/forms/events/view/create-access-code.hbs
+++ b/app/templates/components/forms/events/view/create-access-code.hbs
@@ -78,6 +78,5 @@
     </div>
   </div>
   <div class="ui hidden divider"></div>
-  <button class="ui button">{{t 'Cancel'}}</button>
   <button type="submit" class="ui teal button">{{t 'Save'}}</button>
 </form>

--- a/app/templates/events/view/tickets/access-codes.hbs
+++ b/app/templates/events/view/tickets/access-codes.hbs
@@ -14,12 +14,18 @@
       </div>
     </div>
     <div class="row">
-      <div class="{{if device.isMobile 'eight wide column center' 'left'}} aligned">
-        <div class="ui very basic buttons">
-          <button class="ui button active">{{t 'All'}}</button>
-          <button class="ui button">{{t 'Active'}}</button>
-          <button class="ui button">{{t 'Inactive'}}</button>
-        </div>
+      <div class="sixteen wide column">
+        {{#tabbed-navigation isNonPointing=true}}
+          {{#link-to 'events.view.tickets.access-codes.index' class='item'}}
+            {{t 'All'}}
+          {{/link-to}}
+          {{#link-to 'events.view.tickets.access-codes.list' 'active' class='item'}}
+            {{t 'Active'}}
+          {{/link-to}}
+          {{#link-to 'events.view.tickets.access-codes.list' 'inactive' class='item'}}
+            {{t 'Inactive'}}
+          {{/link-to}}
+        {{/tabbed-navigation}}
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
adds tabbed navigation to `events/<event-id>/tickets/access-codes/`

#### Changes proposed in this pull request:

-adds tabbed navigation with links to dynamic segments 
-removed cancel button on create access-code page as requested [here](https://github.com/fossasia/open-event-frontend/pull/313#discussion_r126005778)

demo- http://open-event-frontend-branch3.herokuapp.com/events/ebaf2dbe/tickets/access-codes

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #455 
