### PR TITLE
Break loading state of registration form on pressing back button after successful completion

### DIFF
--- a/app/controllers/register.js
+++ b/app/controllers/register.js
@@ -16,6 +16,7 @@ export default Controller.extend({
       user.save()
         .then(() => {
           this.set('session.newUser', user.get('email'));
+          this.set('isLoading', false);
           this.transitionToRoute('login');
         })
         .catch(reason => {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Breaks loading state of registration form on pressing back button after successful completion which was earlier stuck in loading state.
#### Changes proposed in this pull request:
make the loading state false, after successful registration

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #484 
