### PR TITLE
Implement event-copyright API on public event page

### DIFF
--- a/app/components/public/copyright-item.js
+++ b/app/components/public/copyright-item.js
@@ -1,12 +1,7 @@
 import Ember from 'ember';
-import { licenses } from 'open-event-frontend/utils/dictionary/licenses';
-import { find }  from 'lodash';
 
-const { Component, computed } = Ember;
+const { Component } = Ember;
 
 export default Component.extend({
-  classNames : ['copyright'],
-  license    : computed('licenseName', function() {
-    return find(licenses, license => license.name === this.get('licenseName'));
-  })
+  classNames: ['copyright']
 });

--- a/app/routes/public.js
+++ b/app/routes/public.js
@@ -9,6 +9,6 @@ export default Route.extend({
   },
 
   model(params) {
-    return this.store.findRecord('event', params.event_id, { include: 'social-links' });
+    return this.store.findRecord('event', params.event_id, { include: 'social-links,event-copyright' });
   }
 });

--- a/app/templates/components/public/copyright-item.hbs
+++ b/app/templates/components/public/copyright-item.hbs
@@ -1,7 +1,7 @@
-<img src="{{license.imageSrc}}" class="copyright-image" alt="{{licenses.name}}">
+<img src="{{copyright.logoUrl}}" class="copyright-image" alt="{{copyright.licence}}">
 <br>
 <div class='copyright text'>
   <p>
-    {{t 'This event is licenced under'}} <a href="{{license.link}}"> {{license.name}} </a>.
+    {{t 'This event is licenced under'}} <a href="{{copyright.licenceUrl}}"> {{copyright.licence}} </a>.
   </p>
 </div>

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -55,7 +55,9 @@
     {{public/event-map event=model.event}}
   </div>
   <div class="ui hidden divider"></div>
-  <div class="copyright">
-    {{public/copyright-item licenseName='Attribution'}}
-  </div>
+  {{#if model.event.copyright}}
+    <div class="copyright">
+      {{public/copyright-item copyright=model.event.copyright}}
+    </div>
+  {{/if}}
 </div>

--- a/tests/integration/components/public/copyright-item-test.js
+++ b/tests/integration/components/public/copyright-item-test.js
@@ -1,10 +1,23 @@
 import { test } from 'ember-qunit';
 import moduleForComponent from 'open-event-frontend/tests/helpers/component-helper';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { Object: EmberObject } = Ember;
 
 moduleForComponent('public/copyright-item', 'Integration | Component | public/copyright item');
 
+const copyright = EmberObject.create({
+  holder     : 'Creative Commons',
+  holderUrl  : 'https://creativecommons.org',
+  licence    : 'Public Domain Dedication (CC0)',
+  licenceUrl : 'https://creativecommons.org/publicdomain/zero/1.0/',
+  year       : 2007,
+  logoUrl    : 'http://image.ibb.co/gt7q7v/pdd.png'
+});
+
 test('it renders', function(assert) {
-  this.render(hbs`{{public/copyright-item licenseName='Attribution-NonCommercial-NoDerivs'}}`);
-  assert.ok(this.$().html().trim().includes('https://creativecommons.org/licenses/by-nc-nd/4.0'));
+  this.set('copyright', copyright);
+  this.render(hbs`{{public/copyright-item copyright=copyright}}`);
+  assert.ok(this.$().html().trim().includes('Public Domain Dedication (CC0)'));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Implements event-copyright API on public event page

#### Changes proposed in this pull request:

Use event model to fetch copyright data instead.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #487 
