### PR TITLE
Add !important to nav bar search box css class

### DIFF
--- a/app/styles/partials/nav-bar.scss
+++ b/app/styles/partials/nav-bar.scss
@@ -12,5 +12,5 @@
 }
 
 .nav-bar-prompt {
-  border-radius: 0;
+  border-radius: 0 !important;
 }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It resolves the css styling specified in `.nav-bar-prompt` class being overridden, due to missing `!important`

#### Changes proposed in this pull request:

Add !important to nav bar search box css class


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #499 
