### PR TITLE
adds empty rule to repeat password field

### DIFF
--- a/app/components/settings/password-section.js
+++ b/app/components/settings/password-section.js
@@ -36,6 +36,10 @@ export default Component.extend(FormMixin, {
           identifier : 'password_repeat',
           rules      : [
             {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter your new password again')
+            },
+            {
               type   : 'match[password_new]',
               prompt : this.l10n.t('Passwords do not match')
             }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
adds empty rule to repeat password field

#### Changes proposed in this pull request:

-added empty rule

demo- https://open-event-frontend-branch5.herokuapp.com/settings/password
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #513 
