### PR TITLE
Refractoring if condition in access and discount codes tabs under tickets tabs

### DIFF
--- a/app/templates/events/view/tickets/access-codes.hbs
+++ b/app/templates/events/view/tickets/access-codes.hbs
@@ -4,8 +4,8 @@
   {{/if}}
   <div class="ui stackable grid">
     <div class="row">
-      <h2 class="ui header {{if device.isMobile 'eight' 'thirteen'}} wide column left floated">{{t 'Access Codes'}}</h2>
-      <div class="{{if device.isMobile 'eight' 'three'}} wide column right floated">
+      <h2 class="ui header {{if device.isTablet 'nine' 'eleven'}} wide column left floated">{{t 'Access Codes'}}</h2>
+      <div class="{{if device.isTablet 'seven' 'five'}} wide column right floated">
         {{#link-to 'events.view.tickets.access-codes.create'
         tagName='button' class='ui button blue fluid'}}
           <i class="plus icon"></i>

--- a/app/templates/events/view/tickets/discount-codes.hbs
+++ b/app/templates/events/view/tickets/discount-codes.hbs
@@ -3,8 +3,8 @@
 {{else}}
   <div class="ui grid stackable">
     <div class="row">
-      <h2 class="ui header {{if device.isMobile 'eight' 'thirteen'}} wide column left floated">{{t 'Discount Codes'}}</h2>
-      <div class="{{if device.isMobile 'eight' 'three'}} wide column right floated">
+      <h2 class="ui header {{if device.isTablet 'nine' 'eleven'}} wide column left floated">{{t 'Discount Codes'}}</h2>
+      <div class="{{if device.isTablet 'seven' 'five'}} wide column right floated">
         {{#link-to 'events.view.tickets.discount-codes.create' tagName='button'
         class='ui blue button fluid'}}
           <i class="plus icon"></i>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR resolves the distortion of Create an access code and Create a discount code button in access code and discount code tabs respectively under Tickets tab.
![image](https://user-images.githubusercontent.com/12701036/28494701-d179e91a-6f53-11e7-9615-d93d8df5e080.png)
![image](https://user-images.githubusercontent.com/12701036/28494702-dac1d456-6f53-11e7-9fce-507e15d8fdc0.png)

#### Changes proposed in this pull request:
Changed the if condition from mobile to tablet device because due to fluid it won't help much in mobile so changed it for tablet and other large screens.

Fixes #543 

@fossasia/open-event-frontend Please review.
