### PR TITLE
Use modelFor instead of a _super call

### DIFF
--- a/app/routes/events/view/edit.js
+++ b/app/routes/events/view/edit.js
@@ -18,7 +18,7 @@ export default Route.extend(AuthenticatedRouteMixin, EventWizardMixin, {
 
   model() {
     return {
-      event : this._super(...arguments),
+      event : this.modelFor('events.view'),
       steps : this.getSteps(),
       types : this.store.query('event-type', {
         sort: 'name'

--- a/app/routes/events/view/edit/basic-details.js
+++ b/app/routes/events/view/edit/basic-details.js
@@ -8,6 +8,6 @@ export default Route.extend(EventWizardMixin, {
     return this.l10n.t('Basic Details');
   },
   model() {
-    return this._super(...arguments);
+    return this.modelFor('events.view.edit');
   }
 });

--- a/app/routes/events/view/edit/sessions-speakers.js
+++ b/app/routes/events/view/edit/sessions-speakers.js
@@ -9,7 +9,7 @@ export default Route.extend(EventWizardMixin, {
   },
   model() {
     return {
-      parentData       : this._super(...arguments),
+      parentData       : this.modelFor('events.view.edit'),
       sessionsSpeakers : this.getSessionSpeakers()
     };
   }

--- a/app/routes/events/view/edit/sponsors.js
+++ b/app/routes/events/view/edit/sponsors.js
@@ -9,7 +9,7 @@ export default Route.extend(EventWizardMixin, {
   },
   model() {
     return {
-      parentData : this._super(...arguments),
+      parentData : this.modelFor('events.view.edit'),
       sponsors   : this.getSponsors()
     };
   }

--- a/app/routes/public/cfs.js
+++ b/app/routes/public/cfs.js
@@ -9,7 +9,7 @@ export default Route.extend({
 
   model() {
     return RSVP.hash({
-      event: this._super(...arguments)
+      event: this.modelFor('public')
     });
   }
 });

--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -5,7 +5,7 @@ const { Route, RSVP } = Ember;
 
 export default Route.extend({
   model() {
-    const eventDetails = this._super(...arguments);
+    const eventDetails = this.modelFor('public');
     return RSVP.hash({
       event   : eventDetails,
       tickets : eventDetails.query('tickets', {

--- a/app/routes/public/schedule.js
+++ b/app/routes/public/schedule.js
@@ -9,7 +9,7 @@ export default Route.extend({
 
   model() {
     return RSVP.hash({
-      event: this._super(...arguments)
+      event: this.modelFor('public')
     });
   }
 });

--- a/app/routes/public/sessions.js
+++ b/app/routes/public/sessions.js
@@ -9,7 +9,7 @@ export default Route.extend({
 
   model() {
     return RSVP.hash({
-      event: this._super(...arguments),
+      event: this.modelFor('public'),
 
       sessions: [{ session_type: { length: '11:00', id: 12, name: 'Talk' }, shortAbstract: 'An introduction to the event', id: '1', title: 'Welcome to FOSSASIA', startAt: new Date(), endAt: new Date(), track: { color: 'green', fontColor: 'green', id: 1, name: 'Track 1' }, microlocation: { id: 2, name: 'Room 1' }, speakers: [{ shortBiography: 'Works for ORG 1', id: 0, city: 'Delhi', name: 'Arnold Singh', speakingExperience: 'GSOC 2015', organisation: 'ORG 1', longBiography: '', photo: { 'iconImageUrl': '' } }] },
         { session_type: { length: '15:00', id: 11, name: 'Talk' }, shortAbstract: 'Welcome to open source', id: '2', title: 'Introduction to Open source', startAt: new Date(), endAt: new Date(), track: { color: 'red', fontColor: 'white', id: 2, name: 'Track 2' }, microlocation: { id: 3, name: 'Room 5' }, speakers: [{ shortBiography: '', id: 0, city: 'Delhi', name: 'Tux', speakingExperience: 'Speaker at the high conference', organisation: 'ORG 2', longBiography: '', photo: { 'iconImageUrl': '' } }] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6355,12 +6355,13 @@
       }
     },
     "ember-math-helpers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-math-helpers/-/ember-math-helpers-2.1.0.tgz",
-      "integrity": "sha1-zDQtb5H93l1FSG7D8nuXhPGbGIQ=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-math-helpers/-/ember-math-helpers-2.1.1.tgz",
+      "integrity": "sha512-JF2CPmebls+aLVre1vFYLtUBZfjwMoGxm62IVibOpM9ObqXNQQNtIGwt4pl1G+z5Q22JUoOdWe2jrueWEfdouA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.6.0"
+        "ember-cli-babel": "6.6.0",
+        "ember-cli-htmlbars": "2.0.2"
       },
       "dependencies": {
         "ember-cli-babel": {
@@ -6592,13 +6593,35 @@
       "dev": true
     },
     "ember-route-action-helper": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.3.tgz",
-      "integrity": "sha1-tfhf65D/mvNlZbsVLFuiWbu19ls=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.5.tgz",
+      "integrity": "sha512-WBN3CLi8Oz2XYPzLCMmaOUEFnsFZcZ2CH0MV+LIhIlR/Yq3wGo7Sqamz88x3X1ea6hZB1kc3p3Yg8FGnGcQtaQ==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.2.4",
+        "ember-cli-babel": "6.6.0",
         "ember-getowner-polyfill": "1.2.2"
+      },
+      "dependencies": {
+        "ember-cli-babel": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.6.0.tgz",
+          "integrity": "sha1-qDYrxEhBv9+Js4nzGX8QTXulJto=",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "0.0.6",
+            "babel-plugin-debug-macros": "0.1.11",
+            "babel-plugin-ember-modules-api-polyfill": "1.4.2",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-polyfill": "6.23.0",
+            "babel-preset-env": "1.6.0",
+            "broccoli-babel-transpiler": "6.1.1",
+            "broccoli-debug": "0.6.2",
+            "broccoli-funnel": "1.2.0",
+            "broccoli-source": "1.1.0",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "2.0.0"
+          }
+        }
       }
     },
     "ember-router-generator": {
@@ -9206,12 +9229,12 @@
       "dev": true
     },
     "gettext-handlebars": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/gettext-handlebars/-/gettext-handlebars-0.6.0.tgz",
-      "integrity": "sha1-J3Pg3Th65d1rCqo/7Nw8i+rqcOQ=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gettext-handlebars/-/gettext-handlebars-0.7.0.tgz",
+      "integrity": "sha1-CQRbLxqqrUz5UID9iGg9IEDBF9A=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.5"
+        "handlebars": "4.0.6"
       },
       "dependencies": {
         "async": {
@@ -9221,9 +9244,9 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+          "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -9244,12 +9267,14 @@
       }
     },
     "gettext-nunjucks": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/gettext-nunjucks/-/gettext-nunjucks-0.0.1.tgz",
-      "integrity": "sha1-S5AKHYEooCg2AhZCBhOSidgW8yk=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gettext-nunjucks/-/gettext-nunjucks-0.0.2.tgz",
+      "integrity": "sha1-+uyvEsKjZ+6jcsxNZBTO5QAwAEI=",
       "dev": true,
       "requires": {
-        "nunjucks": "3.0.1"
+        "marked": "0.3.6",
+        "nunjucks": "3.0.1",
+        "nunjucks-markdown": "2.0.1"
       }
     },
     "gettext-parser": {
@@ -9262,9 +9287,9 @@
       }
     },
     "gettext-swig": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/gettext-swig/-/gettext-swig-0.2.0.tgz",
-      "integrity": "sha1-sD0UCaljYzhGsnnNUpEM2VJ/lTE=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gettext-swig/-/gettext-swig-0.3.0.tgz",
+      "integrity": "sha1-ToeSOiOexbGwrArZg1oDZ5kjV1g=",
       "dev": true
     },
     "gettext-volt": {
@@ -10626,9 +10651,9 @@
       }
     },
     "loader.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.5.1.tgz",
-      "integrity": "sha512-akVWBpSjHOK+t7DmFoD3gDr1fZGQQJyX6O8P87qph2RPJve1Fp3Ttekmu92aYiBrejAf1EeRHW/cfSZ9OFv4xA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.6.0.tgz",
+      "integrity": "sha512-NjAnzMq/BM2VlXA9er0Nx1Runocgi+hEU53ENhCtTx82GX6/l9NXwfIqg81om6QvmhUlv2zH+4R+N+wOoeXytQ==",
       "dev": true
     },
     "locate-path": {
@@ -11016,6 +11041,12 @@
           }
         }
       }
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
     },
     "matcher-collection": {
       "version": "1.0.4",
@@ -11652,6 +11683,12 @@
           }
         }
       }
+    },
+    "nunjucks-markdown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nunjucks-markdown/-/nunjucks-markdown-2.0.1.tgz",
+      "integrity": "sha1-1V51Qzo1hQ4sNFZR/j+THtmxVqI=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -14714,20 +14751,20 @@
       "dev": true
     },
     "xgettext-template": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/xgettext-template/-/xgettext-template-3.3.0.tgz",
-      "integrity": "sha1-KhEZIwEHxSiXLP1hDfFWKv1pvHs=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/xgettext-template/-/xgettext-template-3.4.0.tgz",
+      "integrity": "sha1-tozZJSd0xQ2vm4+6eJsxeiZ9Qiw=",
       "dev": true,
       "requires": {
         "async": "2.1.4",
         "gettext-ejs": "0.1.1",
-        "gettext-handlebars": "0.6.0",
-        "gettext-nunjucks": "0.0.1",
+        "gettext-handlebars": "0.7.0",
+        "gettext-nunjucks": "0.0.2",
         "gettext-parser": "1.2.1",
-        "gettext-swig": "0.2.0",
+        "gettext-swig": "0.3.0",
         "gettext-volt": "0.2.2",
         "object-assign": "4.1.0",
-        "yargs": "6.5.0"
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "async": {
@@ -14753,34 +14790,6 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
           "dev": true
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.5.0.tgz",
-          "integrity": "sha1-qQLiOh8P6RKyoD9hMbftdAyXGP8=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "ember-link-action": "0.0.36",
     "ember-load-initializers": "^1.0.0",
     "ember-lodash": "^4.17.2",
-    "ember-math-helpers": "^2.1.0",
+    "ember-math-helpers": "^2.1.1",
     "ember-metrics": "^0.12.0",
     "ember-models-table": "^1.12.0",
     "ember-moment": "^7.3.0",
     "ember-notify": "^5.2.1",
     "ember-resolver": "^4.1.0",
-    "ember-route-action-helper": "^2.0.2",
+    "ember-route-action-helper": "^2.0.5",
     "ember-router-scroll": "^0.2.0",
     "ember-scroll-to": "^0.6.4",
     "ember-simple-auth": "^1.4.0",
@@ -86,10 +86,10 @@
     "ember-uuid": "^1.0.0",
     "gettext.js": "^0.5.3",
     "google-material-color": "^1.3.1",
-    "loader.js": "^4.5.1",
+    "loader.js": "^4.6.0",
     "sanitize-html": "^1.14.1",
     "semantic-ui-ember": "^2.0.1",
-    "xgettext-template": "^3.3.0"
+    "xgettext-template": "^3.4.0"
   },
   "engines": {
     "node": ">= 4 <8",

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,13 @@
 /* eslint-env node */
+
+let browserArgs = {
+  'Chrome': ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
+};
+
+if (process.env.NO_BROWSER_ARGS && process.env.NO_BROWSER_ARGS === 'true') {
+  browserArgs = {};
+}
+
 module.exports = {
   'test_page'        : 'tests/index.html?hidepassed',
   'disable_watching' : true,
@@ -9,7 +18,5 @@ module.exports = {
     'PhantomJS',
     'Chrome'
   ],
-  browser_args: {
-    'Chrome': ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
-  }
+  browser_args: browserArgs
 };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
We have been using `this._super(...arguments)` call in a lot of routes to get the model of the parent route. The right way of doing it is by using [`modelFor`](https://www.emberjs.com/api/ember/2.14/classes/Ember.Route/methods/modelFor?anchor=modelFor). This PR refactors all `_super` usages to use `modelFor`.

> Also, in this PR. Did some updates of a few packages after local testing.