### PR TITLE
Make count label not appear when there are no new notifications

### DIFF
--- a/app/templates/components/notification-dropdown.hbs
+++ b/app/templates/components/notification-dropdown.hbs
@@ -1,5 +1,7 @@
-<i class="mail outline icon"></i>
-<div class="floating ui teal circular mini label {{if device.isMobile 'tiny text'}}">{{notifications.length}}</div>
+<i class="mail outline icon {{unless notifications.length 'ui less right margin'}}"></i>
+{{#if notifications.length}}
+  <div class="floating ui teal circular mini label {{if device.isMobile 'tiny text'}}">{{notifications.length}}</div>
+{{/if}}
 <div class="ui wide notification popup bottom left transition">
   <div class="ui basic inverted horizontal segments">
     <div class="ui basic left aligned segment weight-800">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Make count label not appear when 0 new notifications

#### Changes proposed in this pull request:

![image](https://user-images.githubusercontent.com/17252805/28744370-0e62bbee-747d-11e7-8059-aec8db04fdbc.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #563 
