### PR TITLE
Make ticket buyer and holder same by default

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -12,24 +12,22 @@ export default Component.extend(FormMixin, {
   },
   holders: [
     {
-      firstName   : '',
-      lastName    : '',
-      email       : '',
-      sameAsBuyer : ''
+      firstName : '',
+      lastName  : '',
+      email     : ''
     },
     {
-      firstName   : '',
-      lastName    : '',
-      email       : '',
-      sameAsBuyer : ''
+      firstName : '',
+      lastName  : '',
+      email     : ''
     },
     {
-      firstName   : '',
-      lastName    : '',
-      email       : '',
-      sameAsBuyer : ''
+      firstName : '',
+      lastName  : '',
+      email     : ''
     }
   ],
+  sameAsBuyer: true,
   getValidationRules() {
     let firstNameValidation = {
       rules: [
@@ -158,12 +156,11 @@ export default Component.extend(FormMixin, {
       this.onValid(() => {
       });
     },
-    fillHolderData(holder, isCheckboxChecked) {
-      if (isCheckboxChecked) {
-        set(holder, 'firstName', this.get('buyer.firstName'));
-        set(holder, 'lastName', this.get('buyer.lastName'));
-        set(holder, 'email', this.get('buyer.email'));
-        set(holder, 'sameAsBuyer', true);
+    removeHolderData(holder) {
+      if (this.get('sameAsBuyer')) {
+        set(holder, 'firstName', null);
+        set(holder, 'lastName', null);
+        set(holder, 'email', null);
       }
     }
   }

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -37,25 +37,51 @@
         {{t 'Ticket Holder\'s Information'}}
       </h4>
       {{#each holders as |holder index|}}
-        <div class="inline field">
-          <i class="user icon"></i>
-          <label>{{t 'Ticket Holder '}}{{inc index}}</label>
-        </div>
-        <div class="field">
-          <label class="required" for="firstname">{{t 'First Name'}}</label>
-          {{input type='text' name=(concat 'first_name_' index) value=holder.firstName}}
-        </div>
-        <div class="field">
-          <label class="required" for="lastname">{{t 'Last Name'}}</label>
-          {{input type='text' name=(concat 'last_name_' index) value=holder.lastName}}
-        </div>
-        <div class="field">
-          <label class="required" for="email">{{t 'Email'}}</label>
-          {{input type='text' name=(concat 'email_' index) value=holder.email}}
-        </div>
-        <div class="field">
-          {{ui-checkbox label=(t 'Same as Ticket Buyer') checked=holder.sameAsBuyer onChange=(action 'fillHolderData' holder)}}
-        </div>
+        {{#if (eq holders.length 1)}}
+          <div class="field">
+            {{#unless sameAsBuyer}}
+              <div class="inline field">
+                <i class="user icon"></i>
+                <label>{{t 'Ticket Holder '}}</label>
+              </div>
+              <div class="field">
+                <label class="required" for="firstname">{{t 'First Name'}}</label>
+                {{input type='text' name=(concat 'first_name_' index) value=holder.firstName}}
+              </div>
+              <div class="field">
+                <label class="required" for="lastname">{{t 'Last Name'}}</label>
+                {{input type='text' name=(concat 'last_name_' index) value=holder.lastName}}
+              </div>
+              <div class="field">
+                <label class="required" for="email">{{t 'Email'}}</label>
+                {{input type='text' name=(concat 'email_' index) value=holder.email}}
+              </div>
+            {{/unless}}
+            {{ui-checkbox label=(t 'Ticket holder is the same person as ticket buyer') checked=sameAsBuyer onChange=(action (mut sameAsBuyer))}}
+          </div>
+        {{else}}
+          <div class="inline field">
+            <i class="user icon"></i>
+            <label>{{t 'Ticket Holder '}}{{inc index}}</label>
+          </div>
+          <div class="field">
+            <label class="required" for="firstname">{{t 'First Name'}}</label>
+            {{input type='text' name=(concat 'first_name_' index) value=(if (and sameAsBuyer (eq index 0)) buyer.firstName holder.firstName)}}
+          </div>
+          <div class="field">
+            <label class="required" for="lastname">{{t 'Last Name'}}</label>
+            {{input type='text' name=(concat 'last_name_' index) value=(if (and sameAsBuyer (eq index 0)) buyer.lastName holder.lastName)}}
+          </div>
+          <div class="field">
+            <label class="required" for="email">{{t 'Email'}}</label>
+            {{input type='text' name=(concat 'email_' index) value=(if (and sameAsBuyer (eq index 0)) buyer.email holder.email)}}
+          </div>
+          {{#if (eq index 0)}}
+            <div class="field">
+              {{ui-checkbox label=(t 'Ticket holder is the same person as ticket buyer') checked=sameAsBuyer onChange=(pipe-action (action (mut sameAsBuyer)) (action 'removeHolderData' holder))}}
+            </div>
+          {{/if}}
+        {{/if}}
       {{/each}}
       <h4 class="ui horizontal divider header">
         <i class="ticket icon"></i>


### PR DESCRIPTION
Makes ticket buyer and holder same by default and also, when there is a single ticket holder, it considers it as a special case and makes the fields not appear unless the user specifically selects that the holder is not the same as the buyer.

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Makes ticket buyer holder same by default for single tickets

#### Changes proposed in this pull request:
- separate case for a single buyer.
- checkbox is there only for the first ticket holder of a given ticket
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #562 
