### PR TITLE
Fix the sponsors delete functionality in sponsor step

### DIFF
--- a/app/components/forms/wizard/sponsors-step.js
+++ b/app/components/forms/wizard/sponsors-step.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import FormMixin from 'open-event-frontend/mixins/form';
 
-const { Component } = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(FormMixin, {
 
@@ -23,13 +23,16 @@ export default Component.extend(FormMixin, {
     };
   },
 
+  sponsors: computed('data.event.sponsors.@each.isDeleted', function() {
+    return this.get('data.event.sponsors').filterBy('isDeleted', false);
+  }),
+
   actions: {
     addSponsor() {
       this.get('data.event.sponsors').addObject(this.store.createRecord('sponsor'));
     },
     removeSponsor(sponsor) {
-      this.get('data.event.sponsors').removeObject(sponsor);
-      sponsor.unloadRecord();
+      sponsor.deleteRecord();
     },
     saveDraft() {
       this.onValid(() => {

--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -19,7 +19,7 @@
   </div>
 
   {{#if data.event.isSponsorsEnabled}}
-    {{#each data.event.sponsors as |sponsor index|}}
+    {{#each sponsors as |sponsor index|}}
       <h4>
         {{t 'Sponsor'}} #{{inc index}}
         {{#if data.event.sponsors.length}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixes the sponsors delete functionality in sponsor step, as currently the sponsors don't actually get deleted, they reappear on page refresh.

#### Changes proposed in this pull request:

- To retain the intended functionality i.e. on pressing delete button the sponsor should disappear but the changes should persist only after the user has pressed delete, I have made use of `isDeleted` attribute of sponsor.
- `removeObject` has been removed as that was preventing the model from sending out a **DELETE** request.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #606 
