### PR TITLE
Integrate order statistics API at tickets route

### DIFF
--- a/app/routes/events/view/tickets/index.js
+++ b/app/routes/events/view/tickets/index.js
@@ -5,5 +5,8 @@ const { Route } = Ember;
 export default Route.extend({
   titleToken() {
     return this.l10n.t('Overview');
+  },
+  model() {
+    return this.modelFor('events.view').query('orderStatistics', {});
   }
 });

--- a/app/templates/events/view/tickets/index.hbs
+++ b/app/templates/events/view/tickets/index.hbs
@@ -1,7 +1,7 @@
 <div class="ui {{if device.isMobile 'horizontal'}} three statistics">
-  <div class="statistic"><div class="value">4343</div><div class="label">{{t 'Orders'}}</div></div>
-  <div class="statistic"><div class="value">0.00</div><div class="label">{{t 'Sales(US $)'}}</div></div>
-  <div class="statistic"><div class="value">1</div><div class="label">{{t 'Tickets sold'}}</div></div>
+  <div class="statistic"><div class="value">{{model.orders.total}}</div><div class="label">{{t 'Orders'}}</div></div>
+  <div class="statistic"><div class="value">{{number-format model.sales.total}}</div><div class="label">{{t 'Sales(US $)'}}</div></div>
+  <div class="statistic"><div class="value">{{model.tickets.total}}</div><div class="label">{{t 'Tickets sold'}}</div></div>
 </div>
 <br>
 <div class="row">
@@ -25,9 +25,9 @@
         class='ui grey inverted segment link'}}
           <span>{{t 'Cancelled'}}</span>
         {{/link-to}}
-        <td class="right aligned">0</td>
-        <td class="right aligned">0</td>
-        <td class="right aligned">{{number-format 0.00}}</td>
+        <td class="right aligned">{{model.tickets.cancelled}}</td>
+        <td class="right aligned">{{model.orders.cancelled}}</td>
+        <td class="right aligned">{{number-format model.sales.cancelled}}</td>
         <td>
           {{#link-to 'events.view.tickets.orders.list' 'cancelled'}}
             {{t 'View orders'}}
@@ -43,9 +43,9 @@
         class='ui yellow inverted segment link'}}
           <span>{{t 'Pending'}}</span>
         {{/link-to}}
-        <td class="right aligned">0</td>
-        <td class="right aligned">0</td>
-        <td class="right aligned">{{number-format 0.00}}</td>
+        <td class="right aligned">{{model.tickets.pending}}</td>
+        <td class="right aligned">{{model.orders.pending}}</td>
+        <td class="right aligned">{{number-format model.sales.pending}}</td>
         <td>
           {{#link-to 'events.view.tickets.orders.list' 'pending'}}
             {{t 'View orders'}}
@@ -61,9 +61,9 @@
         class='ui red inverted segment link'}}
           <span>{{t 'Expired'}}</span>
         {{/link-to}}
-        <td class="right aligned">0</td>
-        <td class="right aligned">0</td>
-        <td class="right aligned">{{number-format 0.00}}</td>
+        <td class="right aligned">{{model.tickets.expired}}</td>
+        <td class="right aligned">{{model.orders.expired}}</td>
+        <td class="right aligned">{{number-format model.sales.expired}}</td>
         <td>
           {{#link-to 'events.view.tickets.orders.list' 'expired'}}
             {{t 'View orders'}}
@@ -79,9 +79,9 @@
         class='ui blue inverted segment link'}}
           <span>{{t 'Placed'}}</span>
         {{/link-to}}
-        <td class="right aligned">0</td>
-        <td class="right aligned">0</td>
-        <td class="right aligned">{{number-format 0.00}}</td>
+        <td class="right aligned">{{model.tickets.placed}}</td>
+        <td class="right aligned">{{model.orders.placed}}</td>
+        <td class="right aligned">{{number-format model.sales.placed}}</td>
         <td>
           {{#link-to 'events.view.tickets.orders.list' 'placed'}}
             {{t 'View orders'}}
@@ -97,9 +97,9 @@
         class='ui green inverted segment link'}}
           <span>{{t 'Completed'}}</span>
         {{/link-to}}
-        <td class="right aligned">0</td>
-        <td class="right aligned">0</td>
-        <td class="right aligned">{{number-format 0.00}}</td>
+        <td class="right aligned">{{model.tickets.completed}}</td>
+        <td class="right aligned">{{model.orders.completed}}</td>
+        <td class="right aligned">{{number-format model.sales.completed}}</td>
         <td>
           {{#link-to 'events.view.tickets.orders.index'}}
             {{t 'View orders'}}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The PR integrated the order statistics API at events/view/tickets route.

Fixes #671 
@fossasia/open-event-frontend Please review!