### PR TITLE
Make deleteEvent as submit action of event-delete-modal

### DIFF
--- a/app/templates/components/modals/event-delete-modal.hbs
+++ b/app/templates/components/modals/event-delete-modal.hbs
@@ -5,7 +5,7 @@
   </div>
 </div>
 <div class="content">
-  <form class="ui {{if isLoading 'loading'}} form" autocomplete="off" {{action (optional formSubmit) on='submit' preventDefault=true}}>
+  <form class="ui {{if isLoading 'loading'}} form" id="delete-form" autocomplete="off" {{action deleteEvent on='submit' preventDefault=true}}>
     <div class="field">
       <div class="label">
         {{t 'Please enter the full name of the event to continue'}}
@@ -18,7 +18,7 @@
   <button type="button" class="ui black button" {{action 'close'}}>
     {{t 'Cancel'}}
   </button>
-  <button type="submit" class="ui red button" disabled={{isNameDifferent}} {{action deleteEvent}}>
+  <button type="submit" form="delete-form" class="ui red button" disabled={{isNameDifferent}}>
     {{t 'Delete Event'}}
   </button>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Make deleteEvent as the default action so that user can submit the form by pressing the `return` key


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #852
