### PR TITLE
Remove the check-mark icon from unread notification

### DIFF
--- a/app/templates/notifications/all.hbs
+++ b/app/templates/notifications/all.hbs
@@ -7,7 +7,9 @@
           <p>{{sanitize notification.message}}</p>
         </div>
         <div class="eight wide column right aligned">
-          <i class="checkmark box icon"></i>
+          {{#if notification.isRead}}
+            <i class="checkmark box icon"></i>
+          {{/if}}
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The tick appears only on the read notifications 
![image](https://user-images.githubusercontent.com/22127980/30488092-e8d6ac32-9a24-11e7-9535-020bd40ab2cf.png)


Fixes #876 
