### PR TITLE
Remove css vertical-class when in desktop mode for tabbed-navigation …

### DIFF
--- a/app/components/tabbed-navigation.js
+++ b/app/components/tabbed-navigation.js
@@ -15,6 +15,8 @@ export default Component.extend({
     var isMobile = this.get('device.isMobile');
     if (isMobile) {
       this.$('a').addClass('vertical-item');
+    } else {
+      this.$('a').removeClass('vertical-item');
     }
     this.set('item', this.$('a.active').text().trim());
   },
@@ -22,6 +24,8 @@ export default Component.extend({
     var isMobile = this.get('device.isMobile');
     if (isMobile) {
       this.$('a').addClass('vertical-item');
+    } else {
+      this.$('a').removeClass('vertical-item');
     }
   },
   actions: {
@@ -29,7 +33,6 @@ export default Component.extend({
       var menu = this.$('div.menu');
       menu.toggleClass('hidden');
       if (mode === 'reset') {
-        this.$('a.item').addClass('vertical-item');
         this.set('item', event.srcElement.text);
       }
     }


### PR DESCRIPTION
…component

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ x] My branch is up-to-date with the Upstream `development` branch.
- [ x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This resolves vertical text alignment when in desktop mode

#### Changes proposed in this pull request:

- Add an else statement to the conditional to remove vertical-alignment class when in desktop mode
-
-

Fixes #919 
