### PR TITLE
Hide 'Mark all as read' button when no notifications around

### DIFF
--- a/app/routes/notifications.js
+++ b/app/routes/notifications.js
@@ -7,6 +7,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
   titleToken() {
     return this.l10n.t('Notifications');
   },
+  model() {
+    return this.get('authManager.currentUser').get('notifications').filterBy('isRead', false);
+  },
   actions: {
     markAllRead() {
       this.get('authManager.currentUser').get('notifications')

--- a/app/routes/notifications/index.js
+++ b/app/routes/notifications/index.js
@@ -8,6 +8,6 @@ export default Route.extend({
   },
   templateName: 'notifications/all',
   model() {
-    return this.get('authManager.currentUser').get('notifications').filterBy('isRead', false);
+    return this.modelFor('notifications');
   }
 });

--- a/app/templates/notifications.hbs
+++ b/app/templates/notifications.hbs
@@ -8,7 +8,7 @@
   {{#link-to 'notifications.all'}}
     <button class="ui button">{{t 'All'}}</button>
   {{/link-to}}
-  {{#if (not-includes session.currentRouteName 'notifications.all')}}
+  {{#if (and (not-includes session.currentRouteName 'notifications.all') model)}}
     <button class="ui button right floated" {{action 'markAllRead'}}>{{t 'Mark all read'}}</button>
   {{/if}}
 </div>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->

#### Short description of what this resolves:
- Hides "mark all as read" button when there are no notifications."

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #934 

#### Screenshots

![screenshot-2017-11-3 unread notifications open event](https://user-images.githubusercontent.com/21259802/32378880-df184b0a-c0d1-11e7-9a84-d300891612ba.png)

