### PR TITLE
Add delete functionality to button in Event overview for sponsors

### DIFF
--- a/app/components/events/view/overview/event-sponsors.js
+++ b/app/components/events/view/overview/event-sponsors.js
@@ -3,5 +3,20 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  classNames: ['ui', 'fluid', 'card']
+  classNames : ['ui', 'fluid', 'card'],
+  actions    : {
+    deleteSponsor(sponsor) {
+      this.set('isLoading', true);
+      sponsor.destroyRecord()
+        .then(() => {
+          this.notify.success(this.l10n.t('Sponsor has been deleted successfully.'));
+        })
+        .catch(()=> {
+          this.notify.error(this.l10n.t('An unexpected error has occurred.'));
+        })
+        .finally(()=>{
+          this.set('isLoading', false);
+        });
+    }
+  }
 });

--- a/app/templates/components/events/view/overview/event-sponsors.hbs
+++ b/app/templates/components/events/view/overview/event-sponsors.hbs
@@ -12,5 +12,7 @@
     showPageSize=true
     moveToDetails='moveToDetails'
     editEvent='editEvent'
+    deleteSponsor=(action 'deleteSponsor')
+    isLoading=isLoading
   }}
 </div>

--- a/app/templates/components/ui-table/cell/cell-sponsor-options.hbs
+++ b/app/templates/components/ui-table/cell/cell-sponsor-options.hbs
@@ -2,7 +2,7 @@
   {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
     <i class="edit icon"></i>
   {{/ui-popup}}
-  {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
+  {{#ui-popup content=(t 'Delete') click=(action (confirm (t 'Are you sure you would like to delete this Sponsor?') (action deleteSponsor record))) class='ui icon button' position='left center'}}
     <i class="trash outline icon"></i>
   {{/ui-popup}}
 </div>

--- a/tests/integration/components/ui-table/cell/cell-sponsor-options-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sponsor-options-test.js
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 moduleForComponent('ui-table/cell/cell-sponsor-options', 'Integration | Component | ui table/cell/cell sponsor options');
 
 test('it renders', function(assert) {
-  this.render(hbs`{{ui-table/cell/cell-sponsor-options}}`);
+  this.set('deleteSponsor', () => {});
+  this.render(hbs`{{ui-table/cell/cell-sponsor-options deleteSponsor=(action deleteSponsor)}}`);
   assert.ok(this.$().text().trim().includes(''));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It add the functionality to delete button.

#### Changes proposed in this pull request:

- The sponsor added in the event overview section to the table gets deleted on clicking the delete button in the options.



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #972 
