### PR TITLE
add user detail as default in call for speaker form

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -311,11 +311,11 @@ export default Component.extend(FormMixin, {
       this.set('data.speaker', this.get('data.speaker').toArray()[0]);
     } else if (this.get('isCFS')) {
       this.set('data.speaker', this.get('store').createRecord('speaker', {
-        email : this.get('authManager.currentUser.email'),
-        name : this.get('authManager.currentUser.firstName')+' '+this.get('authManager.currentUser.lastName'),
+        email    : this.get('authManager.currentUser.email'),
+        name     : `${this.get('authManager.currentUser.firstName')} ${this.get('authManager.currentUser.lastName')}`,
         photoUrl : this.get('authManager.currentUser.avatarUrl'),
-        event : this.get('data.event'),
-        user  : this.get('authManager.currentUser')
+        event    : this.get('data.event'),
+        user     : this.get('authManager.currentUser')
       }));
     }
   }

--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -311,7 +311,9 @@ export default Component.extend(FormMixin, {
       this.set('data.speaker', this.get('data.speaker').toArray()[0]);
     } else if (this.get('isCFS')) {
       this.set('data.speaker', this.get('store').createRecord('speaker', {
-        email : this.get('data.currentUser.email'),
+        email : this.get('authManager.currentUser.email'),
+        name : this.get('authManager.currentUser.firstName')+' '+this.get('authManager.currentUser.lastName'),
+        photoUrl : this.get('authManager.currentUser.avatarUrl'),
         event : this.get('data.event'),
         user  : this.get('authManager.currentUser')
       }));

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -72,17 +72,7 @@
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
             {{else}}
-              {{#if (not (mut (get data.speaker field.fieldIdentifier)))}}
-                {{#if (eq field.fieldIdentifier 'email')}}
-                  {{input type=field.type value=data.speaker.user.email id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
-                {{else if (eq field.fieldIdentifier 'name')}}
-                  {{input type=field.type value=(concat data.speaker.user.firstName ' ' data.speaker.user.lastName) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
-                {{else}}
-                  {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
-                {{/if}}
-              {{else}}
-                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
-              {{/if}}
+              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -72,7 +72,17 @@
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
             {{else}}
-              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+              {{#if (not (mut (get data.speaker field.fieldIdentifier)))}}
+                {{#if (eq field.fieldIdentifier 'email')}}
+                  {{input type=field.type value=data.speaker.user.email id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                {{else if (eq field.fieldIdentifier 'name')}}
+                  {{input type=field.type value=(concat data.speaker.user.firstName ' ' data.speaker.user.lastName) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                {{else}}
+                  {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                {{/if}}
+              {{else}}
+                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+              {{/if}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}


### PR DESCRIPTION

session-speaker-form.hbs: add condition and user data
This change add user data as default for the speaker detail
Fixes #773

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)