### PR TITLE
Add edit functionality to button in Event overview for sponsors

### DIFF
--- a/app/controllers/events/view/index.js
+++ b/app/controllers/events/view/index.js
@@ -42,6 +42,9 @@ export default Controller.extend({
         .finally(()=>{
           this.set('isLoading', false);
         });
+    },
+    editSponsor() {
+      this.transitionToRoute('events.view.edit.sponsors');
     }
   }
 });

--- a/app/templates/components/events/view/overview/event-sponsors.hbs
+++ b/app/templates/components/events/view/overview/event-sponsors.hbs
@@ -14,5 +14,6 @@
     editEvent='editEvent'
     deleteSponsor=deleteSponsor
     isLoading=isLoading
+    editSponsor=editSponsor
   }}
 </div>

--- a/app/templates/components/ui-table/cell/cell-sponsor-options.hbs
+++ b/app/templates/components/ui-table/cell/cell-sponsor-options.hbs
@@ -1,5 +1,5 @@
 <div class="ui vertical compact basic buttons">
-  {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
+  {{#ui-popup content=(t 'Edit') click=(action editSponsor) class='ui icon button' position='left center'}}
     <i class="edit icon"></i>
   {{/ui-popup}}
   {{#ui-popup content=(t 'Delete') click=(action (confirm (t 'Are you sure you would like to delete this Sponsor?') (action deleteSponsor record))) class='ui icon button' position='left center'}}

--- a/app/templates/events/view/index.hbs
+++ b/app/templates/events/view/index.hbs
@@ -9,7 +9,7 @@
     {{events/view/overview/manage-roles data=model}}
   </div>
   <div class="eight wide column">
-    {{events/view/overview/event-sponsors data=model.sponsors columns=sponsorsColumns deleteSponsor=(action 'deleteSponsor')}}
+    {{events/view/overview/event-sponsors data=model.sponsors columns=sponsorsColumns deleteSponsor=(action 'deleteSponsor') editSponsor=(action 'editSponsor')}}
   </div>
   <div class="eight wide column">
     {{events/view/overview/event-apps}}

--- a/tests/integration/components/ui-table/cell/cell-sponsor-options-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sponsor-options-test.js
@@ -6,6 +6,7 @@ moduleForComponent('ui-table/cell/cell-sponsor-options', 'Integration | Componen
 
 test('it renders', function(assert) {
   this.set('deleteSponsor', () => {});
-  this.render(hbs`{{ui-table/cell/cell-sponsor-options deleteSponsor=(action deleteSponsor)}}`);
+  this.set('editSponsor', () => {});
+  this.render(hbs`{{ui-table/cell/cell-sponsor-options deleteSponsor=(action deleteSponsor) editSponsor=(action editSponsor)}}`);
   assert.ok(this.$().text().trim().includes(''));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When the edit button in the sponsor in the event overview section is clicked it then helps to edit the sponsors.

#### Changes proposed in this pull request:

-It adds functionality to the edit button in the event overview section.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #977 
