### PR TITLE
Add missing 'Last Modified At' to sessions model

### DIFF
--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -31,6 +31,7 @@ export default Controller.extend({
     },
     {
       propertyName : 'last-modified',
+      template     : 'components/ui-table/cell/cell-simple-date',
       title        : 'Last Modified'
     },
     {

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -24,16 +24,16 @@ export default ModelBase.extend({
 
   isMailSent: attr('boolean', { defaultValue: false }),
 
-  createdAt   : attr('string'),
-  deletedAt   : attr('string'),
-  submittedAt : attr('string', { defaultValue: () => moment() }),
-
-  sessionType   : belongsTo('session-type'),
-  microlocation : belongsTo('microlocation'),
-  track         : belongsTo('track'),
-  speakers      : hasMany('speaker'),
-  event         : belongsTo('event'), // temporary
-  user          : belongsTo('user'),
+  createdAt      : attr('string'),
+  deletedAt      : attr('string'),
+  submittedAt    : attr('string', { defaultValue: () => moment() }),
+  lastModifiedAt : attr('string'),
+  sessionType    : belongsTo('session-type'),
+  microlocation  : belongsTo('microlocation'),
+  track          : belongsTo('track'),
+  speakers       : hasMany('speaker'),
+  event          : belongsTo('event'), // temporary
+  user           : belongsTo('user'),
 
   startAtDate : computedDateTimeSplit.bind(this)('startsAt', 'date'),
   startAtTime : computedDateTimeSplit.bind(this)('startsAt', 'time'),


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds the value to the Last Modified At field in sessions table.
![image](https://user-images.githubusercontent.com/22127980/34499326-8fdf38a8-f02b-11e7-95f2-1cb22334adf9.png)


#### Changes proposed in this pull request:

-The missing field 'Last Modified At' is added to sessions model


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #985 
