### PR TITLE
Stop automatic deploy to gcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - bash scripts/pr_deploy.sh
-  - bash kubernetes/travis/deploy.sh
+ # - bash kubernetes/travis/deploy.sh


### PR DESCRIPTION
fixes #995 .
The dev frontend is live on https://open-event-frontend-dev.herokuapp.com/ using https://open-event-api-dev.herokuapp.com/ as its server.

@mariobehling While this PR stops the automatic deploys to gcloud, nextgen.eventyay.com is currently up and it has to be manually shut down by someone with gloud access