### PR TITLE
Add view functionality to events/{event_identifier}/sessions

### DIFF
--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -68,6 +68,9 @@ export default Controller.extend({
     },
     editSession(id) {
       this.transitionToRoute('public.cfs.new-session', id);
+    },
+    viewSession(id) {
+      this.transitionToRoute('my-sessions.view', id);
     }
   }
 });

--- a/app/templates/components/ui-table/cell/cell-simple-buttons.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-buttons.hbs
@@ -1,5 +1,5 @@
 <div class="ui vertical compact basic buttons">
-  {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
+  {{#ui-popup content=(t 'View') class='ui icon button'  click=(action viewSession record.id) position='left center'}}
     <i class="unhide icon"></i>
   {{/ui-popup}}
   {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action editSession record.event.id) position='left center'}}

--- a/app/templates/events/view/sessions/list.hbs
+++ b/app/templates/events/view/sessions/list.hbs
@@ -5,5 +5,6 @@
     showPageSize=true
     deleteSession=(action 'deleteSession')
     editSession=(action 'editSession')
+    viewSession=(action 'viewSession')
   }}
 </div>

--- a/tests/integration/components/ui-table/cell/cell-simple-buttons-test.js
+++ b/tests/integration/components/ui-table/cell/cell-simple-buttons-test.js
@@ -7,6 +7,7 @@ moduleForComponent('ui-table/cell/cell-simple-buttons', 'Integration | Component
 test('it renders', function(assert) {
   this.set('deleteSession', () => {});
   this.set('editSession', () => {});
-  this.render(hbs`{{ui-table/cell/cell-simple-buttons deleteSession=(action deleteSession) editSession=(action editSession)}}`);
+  this.set('viewSession', () => {});
+  this.render(hbs`{{ui-table/cell/cell-simple-buttons deleteSession=(action deleteSession) editSession=(action editSession) viewSession=(action viewSession)}}`);
   assert.ok(this.$().html().trim().includes(''));
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When the view button is clicked sessions content is visible.
![image](https://user-images.githubusercontent.com/22127980/35831007-3756d83e-0aee-11e8-8be4-ca4cf1ef4f03.png)


#### Changes proposed in this pull request:

- Functionality added to the view button on this route.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1022 
