### PR TITLE
Create UI for view route in sessions

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -95,6 +95,7 @@ router.map(function() {
   });
   this.route('my-sessions', function() {
     this.route('list', { path: '/:session_status' });
+    this.route('view', { path: '/s/:session_id' });
   });
   this.route('notifications', function() {
     this.route('all');

--- a/app/routes/my-sessions/view.js
+++ b/app/routes/my-sessions/view.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  titleToken() {
+    return this.l10n.t('Sessions');
+  },
+  model(params) {
+    return this.store.findRecord('session', params.session_id, {
+      include: 'session-type,speakers,track'
+    });
+  }
+});

--- a/app/templates/components/session-card.hbs
+++ b/app/templates/components/session-card.hbs
@@ -1,13 +1,13 @@
 <div class="event wide ui grid row">
   {{#unless device.isMobile}}
     <div class="ui card three wide computer six wide tablet column">
-      <a class="image" href="{{href-to 'public.cfs.new-session' session.event.id}}">
+      <a class="image" href="{{href-to 'my-sessions.view' session.id}}">
         {{widgets/safe-image src='assets/images/landing.jpg'}}
       </a>
     </div>
   {{/unless}}
   <div class="ui card thirteen wide computer ten wide tablet sixteen wide mobile column">
-    <a class="main content" href="{{href-to 'public.cfs.new-session' session.event.id}}">
+    <a class="main content" href="{{href-to 'my-sessions.view' session.id}}">
       <div class="header">
         <span>{{session.title}}</span>
         <div class="right floated author">

--- a/app/templates/my-sessions.hbs
+++ b/app/templates/my-sessions.hbs
@@ -1,16 +1,20 @@
-<h1 class="ui header">{{t 'My Sessions'}}</h1>
-<div class="ui grid">
-  <div class="row">
-    <div class="sixteen wide column">
-      {{#tabbed-navigation}}
-        {{#link-to 'my-sessions.list' 'upcoming' class='item'}}
-          {{t 'Upcomming Sessions'}}
-        {{/link-to}}
-        {{#link-to 'my-sessions.list' 'past' class='item'}}
-          {{t 'Past Sessions'}}
-        {{/link-to}}
-      {{/tabbed-navigation}}
+{{#if (and (not-includes session.currentRouteName 'my-sessions.view'))}}
+  <h1 class="ui header">{{t 'My Sessions'}}</h1>
+  <div class="ui grid">
+    <div class="row">
+      <div class="sixteen wide column">
+        {{#tabbed-navigation}}
+          {{#link-to 'my-sessions.list' 'upcoming' class='item'}}
+            {{t 'Upcomming Sessions'}}
+          {{/link-to}}
+          {{#link-to 'my-sessions.list' 'past' class='item'}}
+            {{t 'Past Sessions'}}
+          {{/link-to}}
+        {{/tabbed-navigation}}
+      </div>
     </div>
+    {{outlet}}
   </div>
+{{else}}
   {{outlet}}
-</div>
+{{/if}}

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,0 +1,57 @@
+<div class="ui container">
+  <div class="ui row">
+    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
+    {{#if device.isMobile}}
+      <div class="ui hidden fitted divider"></div>
+    {{/if}}
+    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker Details'}}</button>
+    {{#if device.isMobile}}
+      <div class="ui hidden fitted divider"></div>
+    {{/if}}
+    <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Withdraw Proposal'}}</button>
+    {{#if device.isMobile}}
+      <div class="ui hidden fitted divider"></div>
+    {{/if}}
+  </div>
+  <div class="ui row">
+    <h2 class="ui header left aligned">
+      {{t 'Session Details'}}
+    </h2>
+    <div class="ui segment">
+      <h3 class="ui header">
+        <div>
+          {{#if (eq model.state 'accepted')}}
+            <div class="ui green large label">{{t 'Accepted'}}</div>
+          {{else if (eq model.state 'pending')}}
+            <div class="ui yellow large label">{{t 'Pending'}}</div>
+          {{else if (eq model.state 'rejected')}}
+            <div class="ui red large label">{{t 'Rejected'}}</div>
+          {{/if}}
+        </div>
+      </h3>
+      <div class="field">
+        <div class="ui divider"></div>
+        <h1 class="ui header"> {{model.title}} </h1>
+        <h2 class="ui header"> {{model.speaker.name}} </h2>
+        <h2 class="ui sub header"> <div class="ui gray-text">{{t 'From '}}{{moment-format model.startAt 'ddd, MMM DD HH:mm A'}}{{t ' to '}}{{moment-format model.endsAt 'ddd, MMM DD HH:mm A'}}</div> </h2>
+      </div>
+      <div class="ui divider"></div>
+      {{#if model.shortAbstract}}
+        <h3 class="ui left aligned header">Short Abstract</h3>
+        <p> <i>{{model.shortAbstract}}</i> </p>
+      {{/if}}
+      {{#if model.sessionType.name}}
+        <h3 class="ui left aligned header">Session Type</h3>
+        <p>{{model.sessionType.name}}</p>
+      {{/if}}
+      {{#if model.track.name}}
+        <h3 class="ui left aligned header">Track</h3>
+        <p>{{model.track.name}}</p>
+      {{/if}}
+      {{#if model.slidesUrl}}
+        <h3 class="ui left aligned header">Slide</h3>
+        <a href="{{model.slidesUrl}}">{{t 'Download'}}</a>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/tests/unit/routes/my-sessions/view-test.js
+++ b/tests/unit/routes/my-sessions/view-test.js
@@ -1,0 +1,9 @@
+import { test } from 'ember-qunit';
+import moduleFor from 'open-event-frontend/tests/helpers/unit-helper';
+
+moduleFor('route:my-sessions/view', 'Unit | Route | my sessions/view', []);
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
There was no route to properly view a session.

#### Changes proposed in this pull request:

- Create a route my-sessions/<session_id> to view the sessions.
![image](https://user-images.githubusercontent.com/22127980/36343357-288075b2-1431-11e8-900d-1e17b4a755f1.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1028 
