### PR TITLE
Update the fields 'Validity' and 'Discount Per Ticket' of Discount Code Table

### DIFF
--- a/app/models/discount-code.js
+++ b/app/models/discount-code.js
@@ -1,6 +1,7 @@
 import attr from 'ember-data/attr';
 import ModelBase from 'open-event-frontend/models/base';
 import { hasMany, belongsTo } from 'ember-data/relationships';
+import { computedDateTimeSplit } from 'open-event-frontend/utils/computed-helpers';
 
 /**
  * Two different forms of discount code can exist. (Both use the same model)
@@ -31,5 +32,10 @@ export default ModelBase.extend({
   }), // The event that this discount code belongs to [Form (2)]
   events: hasMany('event', {
     inverse: 'discountCode'
-  })    // The events that this discount code has been applied to [Form (1)]
+  }), // The events that this discount code has been applied to [Form (1)]
+
+  validFromDate : computedDateTimeSplit.bind(this)('validFrom', 'date'),
+  validFromTime : computedDateTimeSplit.bind(this)('validFrom', 'time'),
+  validTillDate : computedDateTimeSplit.bind(this)('validTill', 'date'),
+  validTillTime : computedDateTimeSplit.bind(this)('validTill', 'time')
 });

--- a/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-value.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-value.hbs
@@ -1,3 +1,7 @@
 <span>
-  {{number-format record.value}}
+  {{#if (eq record.type 'percent')}}
+    {{number-format record.value}}{{t '%'}}
+  {{else if (eq record.type 'amount')}}
+    {{t 'US$ '}}{{number-format record.value}}
+  {{/if}}
 </span>


### PR DESCRIPTION


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
1. The field discount per ticket in table now tells if the discount is in percentage or US$.
2. The field validity tells till when is the discount code valid.

#### Changes proposed in this pull request:

- Field 'Discount Per Ticket' shows if the discount is in percentage or in US$.
- Field 'Validity' shows when the discount code is expired.
![image](https://user-images.githubusercontent.com/22127980/36614120-aaea1ace-1901-11e8-9cd6-e11dd3626154.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1044 
