### PR TITLE
Show custom dates accordion

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -24,7 +24,7 @@ export default Component.extend({
       if (dateRange === 'custom_dates') {
         isCustomDate = dateRange;
       }
-      this.set('dateRange', dateRange === this.get('dateRange') ?  isCustomDate : dateRange);
+      this.set('date_range', dateRange === this.get('date_range') ?  isCustomDate : dateRange);
     }
   }
 });

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -63,7 +63,7 @@
       {{#each dateRanges as |dateRange|}}
         <a href="#" class="link item {{if (eq date_range dateRange.key) 'active'}}" {{action 'selectDateRange' dateRange.key}}>
           {{dateRange.name}}
-          {{#if (and (eq dateRange.key 'custom_dates') (eq dateRange 'custom_dates'))}}
+          {{#if (and (eq dateRange.key 'custom_dates') (eq date_range 'custom_dates'))}}
             <div class="explore sub menu">
               <div class="ui form">
                 <div class="grouped fields">

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -1,6 +1,6 @@
 <div class="ui stackable grid">
   <div class="four wide column">
-    {{explore/side-bar model=model category=category sub_category=sub_category event_type=event_type date_range=dateRange}}
+    {{explore/side-bar model=model category=category sub_category=sub_category event_type=event_type date_range=date_range}}
   </div>
   <div class="twelve wide column">
     <h1 class="ui header">{{t 'Events'}}</h1>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The field to add the start and the end date in custom dates in the explore routes is missing.

#### Changes proposed in this pull request:

- Adds the field to add the start and the end date in custom dates.
![image](https://user-images.githubusercontent.com/22127980/36724975-d2e8663a-1bda-11e8-83dc-699c4ab0a2d9.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1046 
