### PR TITLE
Add helper text if session for a track does not exists

### DIFF
--- a/app/templates/public/sessions/index.hbs
+++ b/app/templates/public/sessions/index.hbs
@@ -2,5 +2,7 @@
   <h3 class="ui header">{{track.name}}</h3>
   {{#each track.sessions as |session|}}
     {{public/session-item session=session}}
+  {{else}}
+    <div class="ui disabled header">{{t 'No sessions exist for this track'}}</div>
   {{/each}}
 {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
There was no text stating that a session for some track did not exist.


#### Changes proposed in this pull request:

- Helper text is added.
![image](https://user-images.githubusercontent.com/22127980/36949827-7efacfe4-2013-11e8-8072-ff49a4d368d0.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1051 
