### PR TITLE
Add authentication security to /settings route

### DIFF
--- a/app/routes/settings/contact-info.js
+++ b/app/routes/settings/contact-info.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
   titleToken() {
     return this.get('l10n').t('Contact Info');
   },

--- a/app/routes/settings/email-preferences.js
+++ b/app/routes/settings/email-preferences.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
   titleToken() {
     return this.get('l10n').t('Email Preferences');
   },

--- a/app/routes/settings/password.js
+++ b/app/routes/settings/password.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
   titleToken() {
     return this.get('l10n').t('Password');
   }


### PR DESCRIPTION
#### Short description of what this resolves:
/settings route was accessible without login.

#### Changes proposed in this pull request:

- Users are redirected to login if they are not logged in before accessing /settings route.

Fixes #1096 
