### PR TITLE
Remove button "Withdraw Session Proposal" for past sessions

### DIFF
--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+
+export default Controller.extend({
+  isUpcoming: computed('model.endsAt', function() {
+    let endAt = this.get('model.endsAt');
+    if (endAt < moment()) {
+      return false;
+    }
+    return true;
+  })
+});

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -8,9 +8,11 @@
     {{#if device.isMobile}}
       <div class="ui hidden fitted divider"></div>
     {{/if}}
-    <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Withdraw Proposal'}}</button>
-    {{#if device.isMobile}}
-      <div class="ui hidden fitted divider"></div>
+    {{#if isUpcoming}}
+      <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Withdraw Proposal'}}</button>
+      {{#if device.isMobile}}
+        <div class="ui hidden fitted divider"></div>
+      {{/if}}
     {{/if}}
   </div>
   <div class="ui row">

--- a/tests/unit/controllers/my-sessions/view-test.js
+++ b/tests/unit/controllers/my-sessions/view-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | my-sessions/view', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:my-sessions/view');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The withdraw session proposal button appears even for past sessions.

#### Changes proposed in this pull request:

- Remove button "Withdraw Session Proposal" for the sessions which are over.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1113 
