### PR TITLE
Remove Add/Edit Session Proposal from cfs modal till Speaker Details are added

### DIFF
--- a/app/templates/components/modals/cfs-proposal-modal.hbs
+++ b/app/templates/components/modals/cfs-proposal-modal.hbs
@@ -15,12 +15,14 @@
         {{t 'Edit Speaker Details'}}
       {{/if}}
     {{/link-to}}
-    {{#link-to 'public.cfs.new-session' class='ui blue button' invokeAction=(action 'toggleView')}}
-      {{#if isNewSession}}
-        {{t 'Add Session Proposal'}}
-      {{else}}
-        {{t 'Edit Session Proposal'}}
-      {{/if}}
-    {{/link-to}}
+    {{#unless isNewSpeaker}}
+      {{#link-to 'public.cfs.new-session' class='ui blue button' invokeAction=(action 'toggleView')}}
+        {{#if isNewSession}}
+          {{t 'Add Session Proposal'}}
+        {{else}}
+          {{t 'Edit Session Proposal'}}
+        {{/if}}
+      {{/link-to}}
+    {{/unless}}
   </div>
 </div>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Removes the button to  Add/Edit Session Proposal from 'cfs modal' till Speaker Details are added

#### Changes proposed in this pull request:

- The session proposal can not be added or edited till you add the speaker details in the 'call for speaker modal'
![image](https://user-images.githubusercontent.com/22127980/40089441-6855a3e2-58c9-11e8-83c9-d12092d72f3c.png)
![image](https://user-images.githubusercontent.com/22127980/40089458-7b8393ac-58c9-11e8-93ac-d8fb6c813aaa.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1130 
