### PR TITLE
Make Withdraw proposal button functional

### DIFF
--- a/app/components/modals/proposal-delete-modal.js
+++ b/app/components/modals/proposal-delete-modal.js
@@ -1,0 +1,5 @@
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend({
+  isSmall: true
+});

--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -9,5 +9,26 @@ export default Controller.extend({
       return false;
     }
     return true;
-  })
+  }),
+
+  actions: {
+    openProposalDeleteModal() {
+      this.set('isProposalDeleteModalOpen', true);
+    },
+    deleteProposal() {
+      this.set('isLoading', true);
+      this.get('model').destroyRecord()
+        .then(() => {
+          this.transitionToRoute('my-sessions.index');
+          this.notify.success(this.get('l10n').t('Proposal has been deleted successfully.'));
+        })
+        .catch(() => {
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+          this.set('isProposalDeleteModalOpen', false);
+        });
+    }
+  }
 });

--- a/app/templates/components/modals/proposal-delete-modal.hbs
+++ b/app/templates/components/modals/proposal-delete-modal.hbs
@@ -1,0 +1,21 @@
+<div class="header">
+  {{t 'Are you sure you would like to delete this proposal?'}}
+  <div class="muted small text">
+    {{t 'Deleting the proposal will delete all the data associated with it.'}}
+  </div>
+</div>
+<div class="content">
+  <div class="field">
+    <div class="label">
+      {{t 'Proceeding forward will delete the proposal titled:'}} {{proposalName}}
+    </div>
+  </div>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="button" class="ui red button" {{action deleteProposal}}>
+    {{t 'Delete Proposal'}}
+  </button>
+</div>

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -9,7 +9,7 @@
       <div class="ui hidden fitted divider"></div>
     {{/if}}
     {{#if isUpcoming}}
-      <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Withdraw Proposal'}}</button>
+      <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}" {{action 'openProposalDeleteModal'}}>{{t 'Withdraw Proposal'}}</button>
       {{#if device.isMobile}}
         <div class="ui hidden fitted divider"></div>
       {{/if}}
@@ -57,3 +57,7 @@
     </div>
   </div>
 </div>
+
+{{modals/proposal-delete-modal isOpen=isProposalDeleteModalOpen
+                              proposalName=model.title
+                              deleteProposal=(action 'deleteProposal')}}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently Withdraw proposal button in /my-sessions is not functional.

#### Changes proposed in this pull request:
- Adds a confirmation modal for confirming proposal withdraw before actually deleting it.
- Makes withdraw proposal button functional.

Fixes #1143 
