### PR TITLE
Add functionality to the delete  action button in the route to list speakers

### DIFF
--- a/app/controllers/events/view/speakers/list.js
+++ b/app/controllers/events/view/speakers/list.js
@@ -25,5 +25,20 @@ export default Controller.extend({
       title        : 'Actions',
       template     : 'components/ui-table/cell/events/view/speakers/cell-buttons'
     }
-  ]
+  ],
+  actions: {
+    deleteSpeaker(speaker) {
+      this.set('isLoading', true);
+      speaker.destroyRecord()
+        .then(() => {
+          this.notify.success(this.get('l10n').t('Speaker has been deleted successfully.'));
+        })
+        .catch(() => {
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
+    }
+  }
 });

--- a/app/templates/components/ui-table/cell/events/view/speakers/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/speakers/cell-buttons.hbs
@@ -5,7 +5,7 @@
   {{#ui-popup content=(t 'Edit') class='ui icon button' position='left center'}}
     <i class="edit icon"></i>
   {{/ui-popup}}
-  {{#ui-popup content=(t 'Delete') class='ui icon button' position='left center'}}
+  {{#ui-popup content=(t 'Delete') click=(action (confirm (t 'Are you sure you would like to delete this Speaker?') (action deleteSpeaker record))) class='ui icon button' position='left center'}}
     <i class="trash outline icon"></i>
   {{/ui-popup}}
 </div>

--- a/app/templates/events/view/speakers/list.hbs
+++ b/app/templates/events/view/speakers/list.hbs
@@ -3,5 +3,6 @@
                         useNumericPagination=true
                         showGlobalFilter=true
                         showPageSize=true
+                        deleteSpeaker=(action 'deleteSpeaker')
   }}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The action button in the route events/{event_identifier}/speakers/all to delete the speakers currently doesn't work.

#### Changes proposed in this pull request:

- The delete action button in the route events/{event_identifier}/speakers/all when clicked now deletes that particular speaker.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1146 
