### PR TITLE
Add functionality to Edit Session Proposal Button

### DIFF
--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -12,6 +12,9 @@ export default Controller.extend({
   }),
 
   actions: {
+    editSession(event_id, session_id) {
+      this.transitionToRoute('events.view.sessions.edit', event_id, session_id);
+    },
     openProposalDeleteModal() {
       this.set('isProposalDeleteModalOpen', true);
     },

--- a/app/routes/my-sessions/view.js
+++ b/app/routes/my-sessions/view.js
@@ -7,7 +7,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
   model(params) {
     return this.store.findRecord('session', params.session_id, {
-      include: 'session-type,speakers,track'
+      include: 'session-type,speakers,track,event'
     });
   }
 });

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,6 +1,6 @@
 <div class="ui container">
   <div class="ui row">
-    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
+    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}" {{action 'editSession' model.event.id model.id}}>{{t 'Edit Session Proposal'}}</button>
     {{#if device.isMobile}}
       <div class="ui hidden fitted divider"></div>
     {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
![image](https://user-images.githubusercontent.com/22127980/40325972-4c9659b2-5d5b-11e8-905c-670f3472af11.png)
Adds functionality to the Edit Session Proposal in the route to view a session.

#### Changes proposed in this pull request:

- The edit session proposal button when clicked redirects to the edit session route.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1060 
