### PR TITLE
Add option to add event type and event topic to admin panel

### DIFF
--- a/app/components/modals/admin/content/new-event-sub-topic-modal.js
+++ b/app/components/modals/admin/content/new-event-sub-topic-modal.js
@@ -1,0 +1,33 @@
+import FormMixin from 'open-event-frontend/mixins/form';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend(FormMixin, {
+  isSmall            : true,
+  autoScrollToErrors : false,
+
+  actions: {
+    addEventProperty(modelInstance) {
+      this.onValid(() => {
+        this.sendAction('addEventProperty', modelInstance);
+      });
+    }
+  },
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        subTopicName: {
+          identifier : 'sub_topic_name',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter a sub topic name')
+            }
+          ]
+        }
+      }
+    };
+  }
+});

--- a/app/components/modals/admin/content/new-event-topic-modal.js
+++ b/app/components/modals/admin/content/new-event-topic-modal.js
@@ -1,0 +1,33 @@
+import FormMixin from 'open-event-frontend/mixins/form';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend(FormMixin, {
+  isSmall            : true,
+  autoScrollToErrors : false,
+
+  actions: {
+    addEventProperty(modelInstance) {
+      this.onValid(() => {
+        this.sendAction('addEventProperty', modelInstance);
+      });
+    }
+  },
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        topicName: {
+          identifier : 'topic_name',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter a topic name')
+            }
+          ]
+        }
+      }
+    };
+  }
+});

--- a/app/components/modals/admin/content/new-event-type-modal.js
+++ b/app/components/modals/admin/content/new-event-type-modal.js
@@ -1,0 +1,33 @@
+import FormMixin from 'open-event-frontend/mixins/form';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend(FormMixin, {
+  isSmall            : true,
+  autoScrollToErrors : false,
+
+  actions: {
+    addEventProperty(modelInstance) {
+      this.onValid(() => {
+        this.sendAction('addEventProperty', modelInstance);
+      });
+    }
+  },
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        typeName: {
+          identifier : 'type_name',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter a event type')
+            }
+          ]
+        }
+      }
+    };
+  }
+});

--- a/app/controllers/admin/content/events.js
+++ b/app/controllers/admin/content/events.js
@@ -1,0 +1,52 @@
+import Controller from '@ember/controller';
+import { camelCase, startCase } from 'lodash';
+
+export default Controller.extend({
+  actions: {
+    async loadSubTopics(topic) {
+      this.set('isLoading', true);
+      try {
+        this.set('subTopics', await topic.get('subTopics'));
+      } catch (e) {
+        this.notify.error(this.get('l10n').t('An unexpected error has occurred. SubTopics not loaded.'));
+      } finally {
+        this.set('isLoading', false);
+      }
+    },
+    openModalFor(modelInstanceOrName) {
+      const modelName = typeof modelInstanceOrName === 'string' ? modelInstanceOrName : modelInstanceOrName.constructor.modelName;
+      const modelInstance = typeof modelInstanceOrName === 'string' ? this.store.createRecord(modelInstanceOrName) : modelInstanceOrName;
+      const camelCasedValue = camelCase(modelName);
+      this.set(camelCasedValue, modelInstance);
+      modelInstance.openModal = true;
+    },
+    deleteEventProperty(eventProp) {
+      this.set('isLoading', true);
+      eventProp.destroyRecord()
+        .then(() => {
+          this.notify.success(this.get('l10n').t('This Event Property has been deleted successfully.'));
+        })
+        .catch(()=> {
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred. Event Type was not deleted.'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
+    },
+    addEventProperty(modelInstance) {
+      const camelCasedValue = camelCase(modelInstance.constructor.modelName);
+      this.set('isLoading', true);
+      modelInstance.save()
+        .then(() => {
+          this.notify.success(this.get('l10n').t(`${startCase(camelCasedValue)} has been added successfully.`));
+        })
+        .catch(() => {
+          this.notify.error(this.get('l10n').t(`An unexpected error has occurred. ${startCase(camelCasedValue)} not saved.`));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+          this.set(camelCasedValue, null);
+        });
+    }
+  }
+});

--- a/app/models/event-sub-topic.js
+++ b/app/models/event-sub-topic.js
@@ -6,7 +6,7 @@ export default ModelBase.extend({
   name : attr('string'),
   slug : attr('string'),
 
-  topic       : belongsTo('event-topic'),
+  eventTopic  : belongsTo('event-topic'),
   events      : hasMany('event'),
   placeholder : belongsTo('custom-placeholder')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -150,6 +150,7 @@ router.map(function() {
         this.route('list', { path: '/:topic_id' });
       });
       this.route('translations');
+      this.route('events');
     });
   });
   this.route('orders', function() {

--- a/app/routes/admin/content/events.js
+++ b/app/routes/admin/content/events.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  titleToken() {
+    return this.get('l10n').t('Social Links');
+  },
+  async model() {
+    return {
+      'eventTopics': await this.get('store').query('event-topic', {
+        sort    : 'name',
+        include : 'event-sub-topics'
+      }),
+
+      'eventTypes': await this.get('store').query('event-type', {})
+    };
+  }
+});

--- a/app/templates/admin/content.hbs
+++ b/app/templates/admin/content.hbs
@@ -14,6 +14,9 @@
         {{#link-to 'admin.content.translations' class='item'}}
           {{t 'Translations'}}
         {{/link-to}}
+        {{#link-to 'admin.content.events' class='item'}}
+          {{t 'Events'}}
+        {{/link-to}}
       {{/tabbed-navigation}}
     </div>
   </div>

--- a/app/templates/admin/content/events.hbs
+++ b/app/templates/admin/content/events.hbs
@@ -1,0 +1,157 @@
+<div class="ui stackable grid">
+  <div class="row">
+    <div class="five wide column">
+      <div class="ui center aligned fluid segment">
+        <div class="ui grid container">
+          <div class="middle aligned content eight wide column left aligned">
+            <h4 class="ui header">
+              {{t 'Event Types'}}
+            </h4>
+          </div>
+          <div class="eight wide column right aligned">
+            <button class="ui icon circular blue button {{if device.isMobile 'fluid'}}" {{action 'openModalFor' 'event-type'}}>
+              <i class="icon plus"></i>
+            </button>
+          </div>
+        </div>
+        <div class="ui divider"></div>
+        <table class="ui celled table">
+          <tbody>
+            {{#each model.eventTypes as |eventType|}}
+              <tr>
+                <td>
+                  <div class="ui grid">
+                    <div class="middle aligned content eight wide column left aligned">
+                      {{eventType.name}}
+                    </div>
+                    <div class="eight wide column right aligned">
+                      <div class="ui horizontal compact basic buttons">
+                        {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action 'openModalFor' eventType)}}
+                          <i class="edit icon"></i>
+                        {{/ui-popup}}
+                        {{#ui-popup content=(t 'Delete') class='ui icon button' click=(action (confirm (t 'Are you sure you would like to delete this event type?') (action 'deleteEventProperty' eventType)))}}
+                          <i class="trash outline icon"></i>
+                        {{/ui-popup}}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="six wide column">
+      <div class="ui center aligned fluid segment">
+        <div class="ui grid container">
+          <div class="middle aligned content eight wide column left aligned">
+            <h4 class="ui left aligned header">
+              {{t 'Event Topics'}}
+            </h4>
+          </div>
+          <div class="eight wide column right aligned">
+            <button class="ui icon circular blue button {{if device.isMobile 'fluid'}}" {{action 'openModalFor' 'event-topic'}}>
+              <i class="icon plus"></i>
+            </button>
+          </div>
+        </div>        
+        <div class="ui divider"></div>
+        <table class="ui celled table">
+          <tbody>
+            {{#each model.eventTopics as |eventTopic|}}
+              <tr>
+                <td>
+                  <div class="ui grid">
+                    <div class="middle aligned content eight wide column left aligned">
+                      {{eventTopic.name}}
+                    </div>
+                    <div class="eight wide column right aligned">
+                      <div class="ui horizontal compact basic buttons">
+                        {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action 'openModalFor' eventTopic)}}
+                          <i class="edit icon"></i>
+                        {{/ui-popup}}
+                        {{#ui-popup content=(t 'Delete') class='ui icon button' click=(action (confirm (t 'Are you sure you would like to delete this event topic?') (action 'deleteEventProperty' eventTopic)))}}
+                          <i class="trash outline icon"></i>
+                        {{/ui-popup}}
+                      </div>
+                    </div>
+                  </div>                  
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="five wide column">
+      <div class="ui center aligned fluid segment">
+        <div class="ui grid container">
+          <div class="middle aligned content eight wide column left aligned">
+            <h4 class="ui left aligned header">
+              {{t 'Event Subtopics'}}
+            </h4>
+          </div>
+          <div class="eight wide column right aligned">
+            <button class="ui icon circular blue button {{if device.isMobile 'fluid'}}" {{action 'openModalFor' 'event-sub-topic'}}>
+              <i class="icon plus"></i>
+            </button>
+          </div>
+        </div>   
+        <div class="ui divider"></div>
+        <div class="field">
+          <label>{{t 'Event Topic'}}</label>
+          {{#ui-dropdown class='search selection' onChange=(action 'loadSubTopics') as |execute mapper|}}
+            <i class="dropdown icon"></i>
+            <div class="default text">{{t 'Select Event Topic'}}</div>
+            <div class="menu">
+              {{#each model.eventTopics as |topic|}}
+                <div class="item" data-value="{{map-value mapper topic}}">{{topic.name}}</div>
+              {{/each}}
+            </div>
+          {{/ui-dropdown}}
+        </div>
+        {{#if subTopics}}
+          <table class="ui celled table">
+            <tbody>
+              {{#each subTopics as |subTopic|}}
+                <tr>
+                  <td>
+                    <div class="ui grid">
+                      <div class="middle aligned content eight wide column left aligned">
+                        {{subTopic.name}}
+                      </div>
+                      <div class="eight wide column right aligned">
+                        <div class="ui horizontal compact basic buttons">
+                          {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action 'openModalFor' subTopic)}}
+                            <i class="edit icon"></i>
+                          {{/ui-popup}}
+                          {{#ui-popup content=(t 'Delete') class='ui icon button' click=(action (confirm (t 'Are you sure you would like to delete this event sub topic?') (action 'deleteEventProperty' subTopic)))}}
+                            <i class="trash outline icon"></i>
+                          {{/ui-popup}}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        {{/if}}
+      </div>
+    </div>
+  </div>
+</div>
+
+{{modals/admin/content/new-event-type-modal isOpen=eventType.openModal
+                              name=eventType.name
+                              addEventProperty=(action 'addEventProperty' eventType)}}
+
+{{modals/admin/content/new-event-topic-modal isOpen=eventTopic.openModal
+                              name=eventTopic.name
+                              addEventProperty=(action 'addEventProperty' eventTopic)}}
+
+{{modals/admin/content/new-event-sub-topic-modal isOpen=eventSubTopic.openModal
+                              model=model
+                              eventSubTopic=eventSubTopic
+                              addEventProperty=(action 'addEventProperty' eventSubTopic)}}

--- a/app/templates/components/modals/admin/content/new-event-sub-topic-modal.hbs
+++ b/app/templates/components/modals/admin/content/new-event-sub-topic-modal.hbs
@@ -1,0 +1,34 @@
+<div class="header">
+  {{t 'Add New Event Sub Topic'}}
+</div>
+<div class="content">
+  <div class="field">
+    <label>{{t 'Event Sub-topic'}}</label>
+    {{#ui-dropdown class='search selection' onChange=(action (mut eventSubTopic.eventTopic)) as |execute mapper|}}
+      <i class="dropdown icon"></i>
+      <div class="default text">{{t 'Select Event Sub-Topic'}}</div>
+      <div class="menu">
+        {{#each model.eventTopics as |topic|}}
+          <div class="item" data-value="{{map-value mapper topic}}">{{topic.name}}</div>
+        {{/each}}
+      </div>
+    {{/ui-dropdown}}
+  </div>
+  <form class="ui {{if isLoading 'loading'}} form" id="add-event-sub-topic-form" autocomplete="off" {{action 'addEventProperty' eventSubTopic on='submit' preventDefault=true}}>
+    <div class="field">
+      <label class="required">
+        {{t 'New Event Sub Topic'}}
+      </label>
+      {{input type='text' name='sub_topic_name' value=eventSubTopic.name placeholder=(t 'Enter New Event Sub Topic')}}
+    </div>
+  </form>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="submit" form="add-event-sub-topic-form" class="ui green right labeled icon button">
+    {{t 'Add Event Sub Topic'}}
+    <i class="checkmark icon"></i>
+  </button>
+</div>

--- a/app/templates/components/modals/admin/content/new-event-topic-modal.hbs
+++ b/app/templates/components/modals/admin/content/new-event-topic-modal.hbs
@@ -1,0 +1,22 @@
+<div class="header">
+  {{t 'Add New Event Topic'}}
+</div>
+<div class="content">
+  <form class="ui {{if isLoading 'loading'}} form" id="add-event-topic-form" autocomplete="off" {{action 'addEventProperty' eventTopic on='submit' preventDefault=true}}>
+    <div class="field">
+      <label class="required">
+        {{t 'New Event Topic'}}
+      </label>
+      {{input type='text' name='topic_name' value=name placeholder=(t 'Enter New Event Topic')}}
+    </div>
+  </form>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="submit" form="add-event-topic-form" class="ui green right labeled icon button">
+    {{t 'Add Event Topic'}}
+    <i class="checkmark icon"></i>
+  </button>
+</div>

--- a/app/templates/components/modals/admin/content/new-event-type-modal.hbs
+++ b/app/templates/components/modals/admin/content/new-event-type-modal.hbs
@@ -1,0 +1,22 @@
+<div class="header">
+  {{t 'Add New Event Type'}}
+</div>
+<div class="content">
+  <form class="ui {{if isLoading 'loading'}} form" id="add-event-type-form" autocomplete="off" {{action 'addEventProperty' eventType on='submit' preventDefault=true}}>
+    <div class="field">
+      <label class="required">
+        {{t 'New Event Type'}}
+      </label>
+      {{input type='text' name='type_name' value=name placeholder=(t 'Enter New Event Type')}}
+    </div>
+  </form>
+</div>
+<div class="actions">
+  <button type="button" class="ui black button" {{action 'close'}}>
+    {{t 'Cancel'}}
+  </button>
+  <button type="submit" form="add-event-type-form" class="ui green right labeled icon button">
+    {{t 'Add Event Type'}}
+    <i class="checkmark icon"></i>
+  </button>
+</div>

--- a/tests/integration/components/modals/new-event-sub-topic-modal-test.js
+++ b/tests/integration/components/modals/new-event-sub-topic-modal-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | modals/admin/content/new event sub topic modal', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('isOpen', false);
+    await render(hbs`{{modals/admin/content/new-event-sub-topic-modal isOpen=isOpen}}`);
+    assert.ok(this.element.innerHTML.trim().includes('Add New Event Sub Topic'));
+  });
+});

--- a/tests/integration/components/modals/new-event-topic-modal-test.js
+++ b/tests/integration/components/modals/new-event-topic-modal-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | modals/admin/content/new event topic modal', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('isOpen', false);
+    await render(hbs`{{modals/admin/content/new-event-topic-modal isOpen=isOpen}}`);
+    assert.ok(this.element.innerHTML.trim().includes('Add New Event Topic'));
+  });
+});

--- a/tests/integration/components/modals/new-event-type-modal-test.js
+++ b/tests/integration/components/modals/new-event-type-modal-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | modals/admin/content/new event type modal', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('isOpen', false);
+    await render(hbs`{{modals/admin/content/new-event-type-modal isOpen=isOpen}}`);
+    assert.ok(this.element.innerHTML.trim().includes('Add New Event Type'));
+  });
+});


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently there is not option to add event types and topic for admins. This causes problem while creating events as we are not able to select types and topics of events. This PR fixes this.

Fixes #1153 
