### PR TITLE
fix: Add port to locally generated url for Event

### DIFF
--- a/app/models/event.js
+++ b/app/models/event.js
@@ -153,7 +153,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   }),
 
   url: computed('identifier', function() {
-    return `${location.protocol}//${location.hostname}${this.get('router').urlFor('public', this.get('id'))}`;
+    return location.origin + this.get('router').urlFor('public', this.get('id'));
   }),
 
   sessionsByState: computed('sessions', function() {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds port to locally generated URL for Event.

#### Changes proposed in this pull request:
URL is a computed property of the Event model. For local setup, adds the port number to the url.

Fixes #1162 
