### PR TITLE
fix: Remove validation for empty Call for Speaker Announcement and Mi…

### DIFF
--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -14,15 +14,6 @@ export default Component.extend(EventWizardMixin, FormMixin, {
       delay  : false,
       on     : 'blur',
       fields : {
-        microlocation: {
-          identifier : 'microlocation',
-          rules      : [
-            {
-              type   : 'empty',
-              prompt : this.get('l10n').t('Please enter name for microlocation')
-            }
-          ]
-        },
         sessionType: {
           identifier : 'session',
           rules      : [
@@ -38,15 +29,6 @@ export default Component.extend(EventWizardMixin, FormMixin, {
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter name for track')
-            }
-          ]
-        },
-        announcement: {
-          identifier : 'announcement',
-          rules      : [
-            {
-              type   : 'empty',
-              prompt : this.get('l10n').t('Please enter an Announcement')
             }
           ]
         },


### PR DESCRIPTION
…crolocation.

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Both `Call for Speaker Announcement` and `Microlocation` aren't required fields but had validation for empty values which forced the user to input some value.
This is the desired functionality as per version 1.
![screenshot from 2018-05-25 14-36-49](https://user-images.githubusercontent.com/22395998/40536243-207a0376-6029-11e8-9ef3-98d13c215e6d.png)

#### Changes proposed in this pull request:
- Remove "null-check" validation for not required fields.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1165 
