### PR TITLE
use 127.0.0.1 as API_HOST in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 GOOGLE_API_KEY="Sample Key"
-API_HOST=http://localhost:5000
+API_HOST=http://127.0.0.1:5000


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

use 127.0.0.1 in example file, instead of localhost to match the CSP.
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1178 
