### PR TITLE
Update columns Starts At, Ends At, Submitted At of the route admin/sessions

### DIFF
--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -17,18 +17,21 @@ export default Controller.extend({
       disableSorting : true
     },
     {
-      propertyName : 'submitted-at',
+      propertyName : 'submittedAt',
       template     : 'components/ui-table/cell/cell-simple-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
       title        : 'Submitted At'
     },
     {
-      propertyName : 'starts-at',
-      template     : 'components/ui-table/cell/cell-date',
+      propertyName : 'startsAt',
+      template     : 'components/ui-table/cell/cell-simple-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
       title        : 'Starts At'
     },
     {
-      propertyName : 'ends-at',
-      template     : 'components/ui-table/cell/cell-date',
+      propertyName : 'endsAt',
+      template     : 'components/ui-table/cell/cell-simple-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
       title        : 'Ends At'
     },
     {

--- a/app/templates/components/ui-table/cell/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-date.hbs
@@ -1,5 +1,0 @@
-<span>
-  {{moment-format record.startsAt 'MMMM DD, YYYY - HH:mm A'}}
-  <br>To<br>
-  {{moment-format record.endsAt 'MMMM DD, YYYY - HH:mm A'}}
-</span>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
All the date columns in the admin/sessions route use the same template and the starts at and ends at columns show the starting and ending date of the session.

#### Changes proposed in this pull request:

- Use of same template for the dates in admin/sessions
- Updated columns Starts At and Ends At.

![image](https://user-images.githubusercontent.com/22127980/40582153-0b0c97c6-618a-11e8-8773-cbcb2673e2b7.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1188 
