### PR TITLE
Update columns Starts At and Ends At in admin/events

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -7,9 +7,16 @@ export default Controller.extend({
       title        : 'Name'
     },
     {
-      propertyName : 'starts-at',
-      template     : 'components/ui-table/cell/cell-date',
-      title        : 'Date'
+      propertyName : 'startsAt',
+      template     : 'components/ui-table/cell/cell-simple-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      title        : 'Starts At'
+    },
+    {
+      propertyName : 'endsAt',
+      template     : 'components/ui-table/cell/cell-simple-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      title        : 'Ends At'
     },
     {
       propertyName   : 'roles',


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The admin/events route has a common column for the starting and ending date of event further the template being used to display the information is not the common date template.

#### Changes proposed in this pull request:

- The Starts At and Ends At columns created.
- The common template for dates is now used here.
![image](https://user-images.githubusercontent.com/22127980/40592004-976b30ee-6237-11e8-82e8-de614e8bd496.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1193 
