### PR TITLE
Add functionality to edit button in admin/sessions

### DIFF
--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -55,8 +55,8 @@ export default Controller.extend({
           this.set('isLoading', false);
         });
     },
-    editSession(id) {
-      this.transitionToRoute('public.cfs.new-session', id);
+    editSession(session_id, event_id) {
+      this.transitionToRoute('events.view.sessions.edit', event_id, session_id);
     },
     viewSession(id) {
       this.transitionToRoute('my-sessions.view', id);

--- a/app/templates/components/ui-table/cell/cell-simple-buttons.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-buttons.hbs
@@ -2,7 +2,7 @@
   {{#ui-popup content=(t 'View') class='ui icon button'  click=(action viewSession record.id) position='left center'}}
     <i class="unhide icon"></i>
   {{/ui-popup}}
-  {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action editSession record.id) position='left center'}}
+  {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action editSession record.id record.event.id) position='left center'}}
     <i class="edit icon"></i>
   {{/ui-popup}}
   {{#ui-popup content=(t 'Delete') click=(action (confirm (t 'Are you sure you would like to delete this Session?') (action deleteSession record))) class='ui icon button' position='left center'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When the edit action button is clicked in the route admin/sessions it redirects to the public new-session form.

#### Changes proposed in this pull request:

- The edit button when clicked in the given route now redirects to the edit session form in the route /sessions/edit/<session_id>


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1195 
