### PR TITLE
fix: Set ticket maxOrder to be always less than quantity

### DIFF
--- a/app/controllers/create.js
+++ b/app/controllers/create.js
@@ -9,7 +9,10 @@ export default Controller.extend(EventWizardMixin, {
       this.get('model.data.event').save()
         .then(data => {
           let promises = [];
-          promises.push(this.get('model.data.event.tickets').toArray().map(ticket => ticket.save()));
+          promises.push(this.get('model.data.event.tickets').toArray().map(ticket => {
+            ticket.set('maxOrder', Math.min(ticket.get('maxOrder'), ticket.get('quantity')));
+            ticket.save();
+          }));
           promises.push(this.get('model.data.event.socialLinks').toArray().map(link => link.save()));
           if (this.get('model.data.event.copyright.licence')) {
             let copyright = this.setRelationship(this.get('model.data.event.copyright.content'), data);
@@ -42,7 +45,10 @@ export default Controller.extend(EventWizardMixin, {
       this.get('model.data.event').save()
         .then(data => {
           let promises = [];
-          promises.push(this.get('model.data.event.tickets').toArray().map(ticket => ticket.save()));
+          promises.push(this.get('model.data.event.tickets').toArray().map(ticket => {
+            ticket.set('maxOrder', Math.min(ticket.get('maxOrder'), ticket.get('quantity')));
+            ticket.save();
+          }));
           promises.push(this.get('model.data.event.socialLinks').toArray().map(link => link.save()));
           if (this.get('model.data.event.copyright.licence')) {
             let copyright = this.setRelationship(this.get('model.data.event.copyright.content'), data);


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The tickets weren't created from the wizard. The problem was that we set a default value of 10 for the max order in the model. If the organizer sets the value of quantity to be less than 10, then the server throws HTTP 422. 

#### Changes proposed in this pull request:
Now we set the maxOrder to be the min of itself and the quantity.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1207 
