### PR TITLE
fix: Update sponsors list upon deletion, Delete role-invites after deletion from server

### DIFF
--- a/app/components/events/view/overview/manage-roles.js
+++ b/app/components/events/view/overview/manage-roles.js
@@ -40,10 +40,10 @@ export default Component.extend({
     },
     deleteUserRole(invite) {
       this.set('isLoading', true);
-      this.get('data.roleInvites').removeObject(invite);
       invite.destroyRecord()
         .then(()=>{
           this.get('notify').success(this.get('l10n').t('Role Invite deleted successfully'));
+          this.get('data.roleInvites').removeObject(invite);
         })
         .catch(()=> {
           this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));

--- a/app/controllers/events/view/index.js
+++ b/app/controllers/events/view/index.js
@@ -33,6 +33,7 @@ export default Controller.extend({
       sponsor.destroyRecord()
         .then(() => {
           this.notify.success(this.get('l10n').t('Sponsor has been deleted successfully.'));
+          this.get('model.sponsors').removeObject(sponsor);
         })
         .catch(()=> {
           this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When we delete a sponsor in the event overview screen, the sponsor deleted successfully message is shown but the list stays the same.
Moreover in the Role Invites section, we delete the record from the data before the api call. It can cause problems when due to any error, the entry is not deleted from the server. In that case the list won't show the role invite but it would appear again on reload.

#### Changes proposed in this pull request:
1.The sponsor's list gets updated automatically upon successful deletion.
2. The role invite object is deleted from the list after the successful deletion from the server.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1209 
