### PR TITLE
fix: Show error message for speakers creation

### DIFF
--- a/app/controllers/events/view/sessions/create.js
+++ b/app/controllers/events/view/sessions/create.js
@@ -12,6 +12,9 @@ export default Controller.extend({
             .then(() => {
               this.get('notify').success(this.get('l10n').t('Your session has been saved'));
               this.transitionToRoute('events.view.sessions', this.get('model.event.id'));
+            })
+            .catch(() => {
+              this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));
             });
         })
         .catch(() => {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Right now, when the create session/speaker fails, no error message is shown which leads to confusions.
The error message is shown if there is something wrong with the creation of a session but it isn't shown if something went wrong for the speaker.

#### Changes proposed in this pull request:

- Show error message for speaker creation as well.



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1221 
