### PR TITLE
Enable uploading of pdf ppt and mp4 files in sessions

### DIFF
--- a/app/components/widgets/forms/file-upload.js
+++ b/app/components/widgets/forms/file-upload.js
@@ -35,7 +35,7 @@ export default Component.extend({
 
   processFiles(files) {
     if (files && files[0]) {
-      isFileValid(files[0], this.get('maxSizeInKb'), ['application/pdf', 'application/vnd.ms-powerpoint', 'video/mp4']).then(() => {
+      isFileValid(files[0], this.get('maxSizeInKb'), ['application/pdf', 'application/vnd.ms-powerpoint', 'video/mp4', 'application/vnd.oasis.opendocument.presentation']).then(() => {
         const reader = new FileReader();
         reader.onload = () => {
           this.uploadFile();

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -46,6 +46,15 @@ export const isFileValid = (file, maxSizeInMb, fileTypes = []) => {
           case 'ffd8ffe2':
             type = 'image/jpeg';
             break;
+          case '25504446':
+            type = 'application/pdf';
+            break;
+          case 'd0cf11e0':
+            type = 'application/vnd.ms-powerpoint';
+            break;
+          case '66747970':
+            type = 'video/mp4';
+            break;
           default:
             type = 'unknown';
             break;

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -55,6 +55,9 @@ export const isFileValid = (file, maxSizeInMb, fileTypes = []) => {
           case '66747970':
             type = 'video/mp4';
             break;
+          case '504b34':
+            type = 'application/vnd.oasis.opendocument.presentation';
+            break;
           default:
             type = 'unknown';
             break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently in session creation file upload widget does not allow upload of pdf, ppt and mp4 files for slides. It throws file type not supported error.

#### Changes proposed in this pull request:
- Added respective file codes to utils/file.js so that it does not consider such files as unknown.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1223 