### PR TITLE
feat: Add a Previous button in Event wizard

### DIFF
--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -95,6 +95,11 @@ export default Component.extend(EventWizardMixin, FormMixin, {
         this.sendAction('save');
       });
     },
+    move(direction) {
+      this.onValid(() => {
+        this.sendAction('move', direction);
+      });
+    },
     publish() {
       this.onValid(() => {
         this.set('data.event.state', 'published');

--- a/app/components/forms/wizard/sponsors-step.js
+++ b/app/components/forms/wizard/sponsors-step.js
@@ -39,9 +39,9 @@ export default Component.extend(FormMixin, {
         this.sendAction('save');
       });
     },
-    moveForward() {
+    move(direction) {
       this.onValid(() => {
-        this.sendAction('move');
+        this.sendAction('move', direction);
       });
     },
     publish() {

--- a/app/controllers/events/view/edit/sessions-speakers.js
+++ b/app/controllers/events/view/edit/sessions-speakers.js
@@ -35,7 +35,7 @@ export default Controller.extend({
           this.get('notify').error(this.get('l10n').t('Event data did not save. Please try again'));
         });
     },
-    move() {
+    move(direction) {
       this.set('isLoading', true);
       this.get('model.event').save()
         .then(data => {
@@ -57,7 +57,10 @@ export default Controller.extend({
             .then(() => {
               this.get('notify').success(this.get('l10n').t('Your event has been saved'));
               this.set('isLoading', false);
-              this.transitionToRoute('events.view.index', data.id);
+              if (direction === 'forwards')
+                this.transitionToRoute('events.view.index', data.id);
+              else if (direction === 'backwards')
+                this.transitionToRoute('events.view.edit.sponsors', data.id);
             }, function() {
               this.get('notify').error(this.get('l10n').t('Event data did not save. Please try again'));
             });

--- a/app/controllers/events/view/edit/sponsors.js
+++ b/app/controllers/events/view/edit/sponsors.js
@@ -27,7 +27,7 @@ export default Controller.extend({
           this.get('notify').error(this.get('l10n').t('Sponsors data did not save. Please try again'));
         });
     },
-    move() {
+    move(direction) {
       this.set('isLoading', true);
       this.get('model.event').save()
         .then(data => {
@@ -41,7 +41,10 @@ export default Controller.extend({
             .then(() => {
               this.set('isLoading', false);
               this.get('notify').success(this.get('l10n').t('Your event has been saved'));
-              this.transitionToRoute('events.view.edit.sessions-speakers', data.id);
+              if (direction === 'forwards')
+                this.transitionToRoute('events.view.edit.sessions-speakers', data.id)
+              else if (direction === 'backwards')
+                this.transitionToRoute('events.view.edit.basic-details', data.id);
             }, function() {
               this.get('notify').error(this.get('l10n').t('Sponsors data did not save. Please try again'));
             });

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -314,6 +314,10 @@
   {{/if}}
 
   <div class="ui buttons {{if device.isMobile 'fluid' 'right floated large'}}">
+    <button class="ui left labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'move' 'backwards'}}>
+      {{t 'Previous'}}
+      <i class="left chevron icon"></i>
+    </button>
     <button class="blue ui right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'saveDraft'}}>
       {{t 'Save draft'}}
       <i class="save icon"></i>

--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -1,4 +1,4 @@
-<form class="ui form {{if isLoading 'loading'}}" autocomplete="off" {{action 'moveForward' on='submit' preventDefault=true}}>
+<form class="ui form {{if isLoading 'loading'}}" autocomplete="off" {{action 'move' 'forwards' on='submit' preventDefault=true}}>
 
   <div class="ui centered grid">
     <div class="column">
@@ -73,7 +73,11 @@
   {{/if}}
 
   <div class="{{if device.isMobile 'mini three' 'right floated large'}} ui buttons">
-    <button class="ui right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'moveForward'}}>
+    <button class="ui left labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'move' 'backwards'}}>
+      {{t 'Previous'}}
+      <i class="left chevron icon"></i>
+    </button>
+    <button class="ui right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'move' 'forwards'}}>
       {{t 'Forward'}}
       <i class="right chevron icon"></i>
     </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Provides a previous button in Event wizard to go to the previous screen.

#### Changes proposed in this pull request:
- Added a previous button in the sponsors and speakers-sessions wizard steps.
- Pass in an argument "forwards" or "backwards" to decide the next route.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1228 
