### PR TITLE
Hide ticket description if it is set to hidden 

### DIFF
--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -16,7 +16,9 @@
             <div class="ui small">
               {{ticket.name}}
             </div>
-            <small class="ui gray-text tiny">{{ticket.description}}</small>
+            {{#if ticket.isDescriptionVisible}}
+              <small class="ui gray-text tiny">{{ticket.description}}</small>
+            {{/if}}
           </td>
           <td>{{moment-format ticket.salesEndsAt 'dddd, DD MMMM'}}</td>
           <td id="{{ticket.id}}_price">$ {{number-format ticket.price}}</td>

--- a/app/templates/components/widgets/forms/ticket-input.hbs
+++ b/app/templates/components/widgets/forms/ticket-input.hbs
@@ -43,7 +43,7 @@
       <h4>Settings</h4>
       <div class="field">
         <label for="ticket_description">{{t 'Ticket Description'}}</label>
-        {{textarea rows=3 name='ticket_description' placeholder=(t 'This description would be available to the attendees when ordering tickets.') maxlength=160}}
+        {{textarea rows=3 name='ticket_description' value=ticket.description placeholder=(t 'This description would be available to the attendees when ordering tickets.') maxlength=160}}
       </div>
       <div class="field">
         <div class="ui checkbox">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently ticket list at public route shows description of tickets irrespective of whether it is set to hidden or visible.
Ticket input widget does not show description hence organizer is unable ti edit the description.

#### Changes proposed in this pull request:
- Hide the description if organizer has set it to hidden at public routes.
- Enables description edits.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1233 
