### PR TITLE
fix: Correct spelling mistake in "canPayByPaypal"

### DIFF
--- a/app/controllers/events/view/edit/sponsors.js
+++ b/app/controllers/events/view/edit/sponsors.js
@@ -42,7 +42,7 @@ export default Controller.extend({
               this.set('isLoading', false);
               this.get('notify').success(this.get('l10n').t('Your event has been saved'));
               if (direction === 'forwards')
-                this.transitionToRoute('events.view.edit.sessions-speakers', data.id)
+                this.transitionToRoute('events.view.edit.sessions-speakers', data.id);
               else if (direction === 'backwards')
                 this.transitionToRoute('events.view.edit.basic-details', data.id);
             }, function() {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -280,7 +280,7 @@
         <label>{{t 'Payment by PayPal'}}</label>
         <div class="field payments">
           <div class="ui checkbox">
-            {{input type='checkbox' id='payment_by_paypal' checked=data.event.canPayByPapal}}
+            {{input type='checkbox' id='payment_by_paypal' checked=data.event.canPayByPaypal}}
             <label for="payment_by_paypal">
               <span>{{t 'YES, accept payment through PayPal'}}</span>
               <br>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Corrects the spelling error in `canPayByPaypal`

#### Changes proposed in this pull request:
![screenshot from 2018-06-04 12-00-25](https://user-images.githubusercontent.com/22395998/40901801-60cb55ba-67ef-11e8-9289-f1b4adc86367.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1236 
