### PR TITLE
fix: Display only if public, call for speakers, on the event website

### DIFF
--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -1,4 +1,8 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
+  shouldShowCallforSpeakers: computed(function() {
+    return this.get('event.isSessionsSpeakersEnabled') && (this.get('event.speakersCall.privacy') === 'public');
+  })
 });

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -36,7 +36,7 @@
   {{#link-to 'public.schedule' class='item'}}
     {{t 'Schedule'}}
   {{/link-to}}
-  {{#if event.isSessionsSpeakersEnabled}}
+  {{#if shouldShowCallforSpeakers }}
     {{#link-to 'public.cfs' class='item'}}
       {{t 'Call for Speakers'}}
     {{/link-to}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Checks if the call for speakers is public or private.
Displays only if it is public.

#### Changes proposed in this pull request:
- Add a variable to hold the result of the above condition check


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1239 
