### PR TITLE
Hide side menu tabs on public routes if no data is present

### DIFF
--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -5,6 +5,6 @@ export default Component.extend({
     this._super(...arguments);
     let speakersCall = await this.get('event.speakersCall');
     this.set('shouldShowCallforSpeakers',
-      this.get('event.isSessionsSpeakersEnabled') && (speakersCall.privacy === 'public'));
+      speakersCall.announcement && (speakersCall.privacy === 'public'));
   }
 });

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -4,12 +4,12 @@
       {{#scroll-to href='#info' class='item active'}}
         {{t 'Info'}}
       {{/scroll-to}}
-      {{#if event.isTicketingEnabled}}
+      {{#if event.tickets.length}}
         {{#scroll-to href='#tickets' class='item'}}
           {{t 'Tickets'}}
         {{/scroll-to}}
       {{/if}}
-      {{#if event.isSessionsSpeakersEnabled}}
+      {{#if event.speakers.length}}
         {{#scroll-to href='#speakers' class='item'}}
           {{t 'Speakers'}}
         {{/scroll-to}}
@@ -18,18 +18,18 @@
       <a class="item" href="{{href-to 'public.index'}}">
         {{t 'Info'}}
       </a>
-      {{#if event.isTicketingEnabled}}
+      {{#if event.tickets.length}}
         <a class="item" href="{{href-to 'public.index'}}#tickets">
           {{t 'Tickets'}}
         </a>
       {{/if}}
-      {{#if event.isSessionsSpeakersEnabled}}
+      {{#if event.speakers.length}}
         <a class="item" href="{{href-to 'public.index'}}#speakers">
           {{t 'Speakers'}}
         </a>
       {{/if}}
     {{/if}}
-    {{#if event.isSessionsSpeakersEnabled}}
+    {{#if event.sessions.length}}
       {{#link-to 'public.sessions' class='item'}}
         {{t 'Sessions'}}
       {{/link-to}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently all the side menu tabs are displayed when they are enabled by organizer even if they do not contain any information. Purpose of this PR is to display tabs only if they contain some data inside them. This was discussed during recent open event wizard meeting. 

#### Changes proposed in this pull request:
- Hides tabs if no data is present.
- CFS is enabled only if it has a announcement with it.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #650 
