### PR TITLE
Add functionality to Edit Speaker Details in view sessions

### DIFF
--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -15,6 +15,9 @@ export default Controller.extend({
     editSession(event_id, session_id) {
       this.transitionToRoute('events.view.sessions.edit', event_id, session_id);
     },
+    editSpeaker(event_id, speaker_id) {
+      this.transitionToRoute('events.view.speakers.edit', event_id, speaker_id);
+    },
     openProposalDeleteModal() {
       this.set('isProposalDeleteModalOpen', true);
     },

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -4,7 +4,7 @@
     {{#if device.isMobile}}
       <div class="ui hidden fitted divider"></div>
     {{/if}}
-    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker Details'}}</button>
+    <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}" {{action 'editSpeaker' model.event.id model.speaker.id}}>{{t 'Edit Speaker Details'}}</button>
     {{#if device.isMobile}}
       <div class="ui hidden fitted divider"></div>
     {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
In view sessions the Edit Speaker Details button has no functionality.

#### Changes proposed in this pull request:

- In view sessions the Edit Speaker Details button redirects to edit speakers form.
![image](https://user-images.githubusercontent.com/22127980/41065722-316d54f2-69fd-11e8-98af-8d7f6e6bdd69.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1253 
