### PR TITLE
fix: Hide payment options if disabled(Paypal and Stripe)

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -181,12 +181,12 @@ export default Component.extend(FormMixin, {
     return orderBy(paymentCurrencies, 'name');
   }),
 
-  canAcceptPayPal: computed('data.event.paymentCurrency', function() {
-    return find(paymentCurrencies, ['code', this.get('data.event.paymentCurrency')]).paypal;
+  canAcceptPayPal: computed('data.event.paymentCurrency', 'settings.paypalSandboxUsername', 'settings.paypalLiveUsername', function() {
+    return (this.get('settings.paypalSandboxUsername') || this.get('settings.paypalLiveUsername')) && find(paymentCurrencies, ['code', this.get('data.event.paymentCurrency')]).paypal;
   }),
 
-  canAcceptStripe: computed('data.event.paymentCurrency', function() {
-    return find(paymentCurrencies, ['code', this.get('data.event.paymentCurrency')]).stripe;
+  canAcceptStripe: computed('data.event.paymentCurrency', 'settings.stripeClientId', function() {
+    return this.get('settings.stripeClientId') && find(paymentCurrencies, ['code', this.get('data.event.paymentCurrency')]).stripe;
   }),
 
   tickets: computed('data.event.tickets.@each.isDeleted', 'data.event.tickets.@each.position', function() {
@@ -301,8 +301,8 @@ export default Component.extend(FormMixin, {
     },
     updateDates() {
       const timezone = this.get('data.event.timezone');
-      var startDate = this.get('data.event.startsAt');
-      var endDate = this.get('data.event.endsAt');
+      let startDate = this.get('data.event.startsAt');
+      let endDate = this.get('data.event.endsAt');
       this.set('data.event.startsAt', moment.tz(startDate, timezone));
       this.set('data.event.endsAt', moment.tz(endDate, timezone));
     },

--- a/app/initializers/blanket.js
+++ b/app/initializers/blanket.js
@@ -17,6 +17,7 @@ export function initialize(application) {
   inject('notify', 'service:notify');
   inject('confirm', 'service:confirm');
   inject('sanitizer', 'service:sanitizer');
+  inject('settings', 'service:settings');
 
   application.inject('component', 'router', 'service:router');
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -14,6 +14,7 @@ export default Route.extend(ApplicationRouteMixin, {
   async beforeModel() {
     this._super(...arguments);
     await this.get('authManager').initialize();
+    await this.get('settings').initialize();
   },
 
   async model() {

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -1,0 +1,43 @@
+import Service, { inject as service } from '@ember/service';
+import { observer } from '@ember/object';
+
+export default Service.extend({
+
+  store       : service(),
+  session     : service(),
+  authManager : service(),
+
+  _lastPromise: Promise.resolve(),
+
+  /**
+   * Reload settings when the authentication state changes.
+   */
+  _authenticationObserver: observer('session.isAuthenticated', function() {
+    this.get('_lastPromise')
+      .then(() => this.set('_lastPromise', this._loadSettings()))
+      .catch(() => this.set('_lastPromise', this._loadSettings()));
+  }),
+
+  /**
+   * Load the settings from the API and set the attributes as properties on the service
+   *
+   * @return {Promise<void>}
+   * @private
+   */
+  async _loadSettings() {
+    const settingsModel = await this.get('store').queryRecord('setting', {});
+    this.get('store').modelFor('setting').eachAttribute(attributeName => {
+      this.set(attributeName, settingsModel.get(attributeName));
+    });
+  },
+
+  /**
+   * Initialize the settings service
+   * @return {*|Promise<void>}
+   */
+  initialize() {
+    const promise = this._loadSettings();
+    this.set('_lastPromise', promise);
+    return promise;
+  }
+});

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -293,7 +293,7 @@
             </label>
           </div>
         </div>
-        {{#if data.event.canPayByPapal}}
+        {{#if data.event.canPayByPaypal}}
           <div class="field">
             <label class="required">PayPal Email</label>
             {{input type='email' value=data.event.paypalEmail}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Hide Stripe and Paypal payment options if they are disabled by the admin.

#### Changes proposed in this pull request:
- Check the settings if these payment options are enabled or disabled.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1245 
