### PR TITLE
Make Stripe OAuth functional in event wizard

### DIFF
--- a/app/controllers/create.js
+++ b/app/controllers/create.js
@@ -3,6 +3,7 @@ import RSVP from 'rsvp';
 import EventWizardMixin from 'open-event-frontend/mixins/event-wizard';
 
 export default Controller.extend(EventWizardMixin, {
+
   actions: {
     save() {
       this.set('isLoading', true);
@@ -20,10 +21,18 @@ export default Controller.extend(EventWizardMixin, {
           }
           if (this.get('model.data.event.tax.name')) {
             let tax = this.setRelationship(this.get('model.data.event.tax.content'), data);
-            if (this.get('model.event.isTaxEnabled')) {
+            if (this.get('model.data.event.isTaxEnabled')) {
               promises.push(tax.save());
             } else {
               promises.push(tax.destroyRecord());
+            }
+          }
+          if (this.get('model.data.event.stripeAuthorization.stripeAuthCode')) {
+            let stripeAuthorization = this.setRelationship(this.get('model.data.event.stripeAuthorization.content'), data);
+            if (this.get('model.data.event.canPayByStripe')) {
+              promises.push(stripeAuthorization.save());
+            } else {
+              promises.push(stripeAuthorization.destroyRecord());
             }
           }
           RSVP.Promise.all(promises)
@@ -56,10 +65,18 @@ export default Controller.extend(EventWizardMixin, {
           }
           if (this.get('model.data.event.tax.name')) {
             let tax = this.setRelationship(this.get('model.data.event.tax.content'), data);
-            if (this.get('model.event.isTaxEnabled')) {
+            if (this.get('model.data.event.isTaxEnabled')) {
               promises.push(tax.save());
             } else {
               promises.push(tax.destroyRecord());
+            }
+          }
+          if (this.get('model.data.event.stripeAuthorization.stripeAuthCode')) {
+            let stripeAuthorization = this.setRelationship(this.get('model.data.event.stripeAuthorization.content'), data);
+            if (this.get('model.data.event.canPayByStripe')) {
+              promises.push(stripeAuthorization.save());
+            } else {
+              promises.push(stripeAuthorization.destroyRecord());
             }
           }
           RSVP.Promise.all(promises)

--- a/app/controllers/events/view/edit/basic-details.js
+++ b/app/controllers/events/view/edit/basic-details.js
@@ -20,6 +20,13 @@ export default Controller.extend({
               promises.push(this.get('model.event.tax').then(tax => tax.destroyRecord()));
             }
           }
+          if (this.get('model.event.stripeAuthorization.stripeAuthCode')) {
+            if (this.get('model.event.canPayByStripe')) {
+              promises.push(this.get('model.event.stripeAuthorization.content').save());
+            } else {
+              promises.push(this.get('model.event.stripeAuthorization.content').destroyRecord());
+            }
+          }
           RSVP.Promise.all(promises)
             .then(() => {
               this.set('isLoading', false);
@@ -49,6 +56,13 @@ export default Controller.extend({
               promises.push(this.get('model.event.tax').then(tax => tax.save()));
             } else {
               promises.push(this.get('model.event.tax').then(tax => tax.destroyRecord()));
+            }
+          }
+          if (this.get('model.event.stripeAuthorization.stripeAuthCode')) {
+            if (this.get('model.event.canPayByStripe')) {
+              promises.push(this.get('model.event.stripeAuthorization.content').save());
+            } else {
+              promises.push(this.get('model.event.stripeAuthorization.content').destroyRecord());
             }
           }
           RSVP.Promise.all(promises)

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -100,6 +100,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   speakers               : hasMany('speaker'),
   invoice                : hasMany('event-invoice'),
   speakersCall           : belongsTo('speakers-call'),
+  stripeAuthorization    : belongsTo('stripe-authorization'),
   eventStatisticsGeneral : belongsTo('event-statistics-general'),
   tax                    : belongsTo('tax'),
   copyright              : belongsTo('event-copyright'),

--- a/app/models/stripe-authorization.js
+++ b/app/models/stripe-authorization.js
@@ -3,13 +3,8 @@ import ModelBase from 'open-event-frontend/models/base';
 import { belongsTo } from 'ember-data/relationships';
 
 export default ModelBase.extend({
-  stripeSecretKey      : attr('string'),
-  stripeRefreshToken   : attr('string'),
+  stripeAuthCode       : attr('string'),
   stripePublishableKey : attr('string'),
-  stripeUserId         : attr('string'),
-  stripeEmail          : attr('string'),
 
-  event: belongsTo('event'),
-
-  linked: false
+  event: belongsTo('event')
 });

--- a/app/routes/create.js
+++ b/app/routes/create.js
@@ -10,9 +10,10 @@ export default Route.extend(AuthenticatedRouteMixin, EventWizardMixin, {
     return {
       data: {
         event: this.store.createRecord('event', {
-          socialLinks : [],
-          tax         : this.store.createRecord('tax'),
-          copyright   : this.store.createRecord('event-copyright')
+          socialLinks         : [],
+          tax                 : this.store.createRecord('tax'),
+          copyright           : this.store.createRecord('event-copyright'),
+          stripeAuthorization : this.store.createRecord('stripe-authorization')
         }),
         types: this.store.query('event-type', {
           sort: 'name'

--- a/app/routes/events/view.js
+++ b/app/routes/events/view.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
   model(params) {
     return this.store.findRecord('event', params.event_id, {
-      include: 'event-topic,event-sub-topic,event-type,event-copyright,tax'
+      include: 'event-topic,event-sub-topic,event-type,event-copyright,tax,stripe-authorization'
     });
   }
 });

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -317,8 +317,13 @@
         </div>
         {{#if data.event.canPayByStripe}}
           <div class="field">
-            <label class="required">{{t 'Connect to your Stripe account'}}</label>
-            <a href="#" class="stripe-connect"><span>{{t 'Connect with Stripe'}}</span></a>
+            {{#if (or data.event.stripeAuthorization.stripeAuthCode data.event.stripeAuthorization.stripePublishableKey)}}
+              <label class="required">{{t 'You have linked your Stripe account successfully. Click Here to Disconnect you account.'}}</label>
+              <a class="stripe-connect" role="button" {{action 'disconnectStripe'}}><span>{{t 'Disconnect Stripe Account'}}</span></a>
+            {{else}}
+              <label class="required">{{t 'Connect to your Stripe account'}}</label>
+              <a class="stripe-connect" role="button" {{action 'connectStripe'}}><span>{{t 'Connect with Stripe'}}</span></a>
+            {{/if}}              
           </div>
         {{/if}}
       {{/if}}

--- a/app/torii-providers/stripe.js
+++ b/app/torii-providers/stripe.js
@@ -1,0 +1,14 @@
+import stripeConnect from 'torii/providers/stripe-connect';
+import { alias } from '@ember/object/computed';
+import { inject } from '@ember/service';
+import { configurable } from 'torii/configuration';
+
+export default stripeConnect.extend({
+  settings: inject(),
+
+  clientId: alias('settings.stripeClientId'),
+
+  redirectUri: configurable('redirectUri', function() {
+    return `${window.location.origin}/torii/redirect.html`;
+  })
+});

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "qunit-dom": "^0.6.3",
     "sanitize-html": "^1.14.1",
     "semantic-ui-ember": "^3.0.3",
+    "torii": "^0.10.1",
     "url-parse": "^1.4.1",
     "xgettext-template": "^3.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9080,6 +9080,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+torii@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/torii/-/torii-0.10.1.tgz#caad0a81e82189fc0483b65e68ee28041ad3590f"
+  dependencies:
+    ember-cli-babel "^6.11.0"
+
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently in event creation wizard organizer do not have support to add their stripe account to enable payments. This PR makes connect to stripe button functional.

#### Changes proposed in this pull request:
- Adds a new library torii which makes OAuth implementation simpler.
- Defines new functions and methods to make stripe button functional.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1180 
