### PR TITLE
fix: set record on event in getOrCreate of EventWizard

### DIFF
--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -43,6 +43,7 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
         .catch(() => {
           let record = this.store.createRecord(modelName);
           record.set('event', event);
+          event.set(relationship, record);
           resolve(record);
         });
     });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Call for speakers doesn't load right after we create an event.(Make sure to not reload the web application). It is because we aren't setting the record on the event.

#### Changes proposed in this pull request:
- Setting record on event in getOrCreate method of EventWizard.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1260 
