### PR TITLE
Add functionality to view action button in speakers

### DIFF
--- a/app/controllers/events/view/speakers/list.js
+++ b/app/controllers/events/view/speakers/list.js
@@ -42,6 +42,9 @@ export default Controller.extend({
     },
     editSpeaker(id) {
       this.transitionToRoute('events.view.speakers.edit', id);
+    },
+    viewSpeaker(id) {
+      this.transitionToRoute('events.view.speakers.edit', id);
     }
   }
 });

--- a/app/templates/components/ui-table/cell/events/view/speakers/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/speakers/cell-buttons.hbs
@@ -1,5 +1,5 @@
 <div class="ui vertical compact basic buttons">
-  {{#ui-popup content=(t 'View') class='ui icon button' position='left center'}}
+  {{#ui-popup content=(t 'View') class='ui icon button' click=(action viewSpeaker record.id) position='left center'}}
     <i class="unhide icon"></i>
   {{/ui-popup}}
   {{#ui-popup content=(t 'Edit') class='ui icon button' click=(action editSpeaker record.id) position='left center'}}

--- a/app/templates/events/view/speakers/list.hbs
+++ b/app/templates/events/view/speakers/list.hbs
@@ -5,5 +5,6 @@
                         showPageSize=true
                         deleteSpeaker=(action 'deleteSpeaker')
                         editSpeaker=(action 'editSpeaker')
+                        viewSpeaker=(action 'viewSpeaker')
   }}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The view button in speakers ember table currently doesn't work.

#### Changes proposed in this pull request:

- When the view action button is clicked in the speakers table it redirects to the speakers form.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1257 
