### PR TITLE
fix: Private CFS not working

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -39,6 +39,10 @@ router.map(function() {
     this.route('sessions', function() {
       this.route('list', { path: '/:track_id' });
     });
+    this.route('cfs', { path: '/cfs/:speaker_call_hash' }, function() {
+      this.route('new-speaker');
+      this.route('new-session');
+    });
     this.route('cfs', function() {
       this.route('new-speaker');
       this.route('new-session');

--- a/app/routes/public/cfs/index.js
+++ b/app/routes/public/cfs/index.js
@@ -5,6 +5,21 @@ export default Route.extend({
     return this.get('l10n').t('Call for Speakers');
   },
 
+  async beforeModel(transition) {
+    let hash = transition.params['public.cfs'].speaker_call_hash;
+    const eventDetails = this.modelFor('public');
+    const speakersCall = await eventDetails.get('speakersCall');
+    /*
+    The following should show the CFS page to the user:
+     - CFS is public and no hash is entered
+     - CFS is public and a valid hash is entered
+     - CFS is private and a valid hash is entered
+    */
+    if (!((speakersCall.privacy === 'public' && (!hash || speakersCall.hash === hash)) || (speakersCall.privacy === 'private' && hash === speakersCall.hash))) {
+      this.transitionTo('not-found');
+    }
+  },
+
   async model() {
     const eventDetails = this.modelFor('public');
     if (this.get('session.isAuthenticated')) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add a route for private CFS link

#### Changes proposed in this pull request:
- Re-direct to the cfs page if the hash in the url is correct.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1244 

@niranjan94 There is one flaw in this which was there from before. The public cfs route doesn't check the privacy. So directly accessing `/cfs` from the address bar works irrespective of the privacy. I don't know how to handle this efficiently. I can add a check in the public route and define the whole private route but that would involve code repetition. Maybe we can pass an additional variable to the public route which would signify if the hash was correct or not in case of a private cfs.
```javascript
if(cfs.privacy === 'public' || (cfs.privacy === 'private' && isVerified === true)) {
// go ahead
}
``` 
But I am not really sure about the second method. How should I approach this?