### PR TITLE
Make accept/reject proposal button for sessions functional

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -323,7 +323,7 @@ export default Component.extend(FormMixin, {
     } else if (this.get('isCFS')) {
       this.set('data.session', this.get('store').createRecord('session', {
         event   : this.get('data.event'),
-        user    : this.get('authManager.currentUser'),
+        creator : this.get('authManager.currentUser'),
         speaker : this.get('data.speaker')
       }));
     }

--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -71,6 +71,40 @@ export default Controller.extend({
     },
     viewSession(id) {
       this.transitionToRoute('my-sessions.view', id);
+    },
+    acceptProposal(session, sendEmail) {
+      session.set('sendEmail', sendEmail);
+      session.set('state', 'accepted');
+      session.set('isMailSent', sendEmail);
+      this.set('isLoading', true);
+      session.save()
+        .then(() => {
+          sendEmail ? this.notify.success(this.get('l10n').t('Session has been accepted and speaker has been notified via email.'))
+            : this.notify.success(this.get('l10n').t('Session has been accepted'));
+        })
+        .catch(() => {
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
+    },
+    rejectProposal(session, sendEmail) {
+      session.set('sendEmail', sendEmail);
+      session.set('state', 'rejected');
+      session.set('isMailSent', sendEmail);
+      this.set('isLoading', true);
+      session.save()
+        .then(() => {
+          sendEmail ? this.notify.success(this.get('l10n').t('Session has been rejected and speaker has been notified via email.'))
+            : this.notify.success(this.get('l10n').t('Session has been rejected'));
+        })
+        .catch(() => {
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
     }
   }
 });

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -21,6 +21,7 @@ export default ModelBase.extend({
   videoUrl      : attr('string'),
   audioUrl      : attr('string'),
   signupUrl     : attr('string'),
+  sendEmail     : attr('boolean'),
 
   isMailSent: attr('boolean', { defaultValue: false }),
 
@@ -33,7 +34,7 @@ export default ModelBase.extend({
   track          : belongsTo('track'),
   speakers       : hasMany('speaker'),
   event          : belongsTo('event'), // temporary
-  user           : belongsTo('user'),
+  creator        : belongsTo('user'),
 
   startAtDate : computedDateTimeSplit.bind(this)('startsAt', 'date'),
   startAtTime : computedDateTimeSplit.bind(this)('startsAt', 'time'),

--- a/app/routes/events/view/sessions/create.js
+++ b/app/routes/events/view/sessions/create.js
@@ -13,8 +13,8 @@ export default Route.extend({
         sort         : 'id'
       }),
       session: await this.get('store').createRecord('session', {
-        event : eventDetails,
-        user  : this.get('authManager.currentUser')
+        event   : eventDetails,
+        creator : this.get('authManager.currentUser')
       }),
       speaker: await this.get('store').createRecord('speaker', {
         event : eventDetails,

--- a/app/routes/events/view/sessions/list.js
+++ b/app/routes/events/view/sessions/list.js
@@ -54,7 +54,7 @@ export default Route.extend({
       filterOptions = [];
     }
     return this.modelFor('events.view').query('sessions', {
-      include      : 'event,speakers',
+      include      : 'speakers',
       filter       : filterOptions,
       'page[size]' : 10
     });

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -77,6 +77,7 @@
           {{/if}}
           {{#if (eq field.type 'image')}}
             {{widgets/forms/image-upload
+              imageUrl=(mut (get data.speaker field.fieldIdentifier))
               label=(t 'Logo')
               id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))
               icon='image'

--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
@@ -1,16 +1,20 @@
 <div class="ui vertical compact basic buttons">
-  {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
-    <i class="green checkmark icon"></i>
-    <div class="menu">
-      <div class="item">{{t 'With email'}}</div>
-      <div class="item">{{t 'Without email'}}</div>
-    </div>
-  {{/ui-dropdown}}
-  {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
-    <i class="red remove icon"></i>
-    <div class="menu">
-      <div class="item">{{t 'With email'}}</div>
-      <div class="item">{{t 'Without email'}}</div>
-    </div>
-  {{/ui-dropdown}}
+  {{#unless (eq record.state 'accepted')}}
+    {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
+      <i class="green checkmark icon"></i>
+      <div class="menu">
+        <div class="item" {{action acceptProposal record true}}>{{t 'With email'}}</div>
+        <div class="item" {{action acceptProposal record false}}>{{t 'Without email'}}</div>
+      </div>
+    {{/ui-dropdown}}
+  {{/unless}}
+  {{#unless (eq record.state 'rejected')}}
+    {{#ui-dropdown class='ui icon bottom right pointing dropdown button'}}
+      <i class="red remove icon"></i>
+      <div class="menu">
+        <div class="item" {{action rejectProposal record true}}>{{t 'With email'}}</div>
+        <div class="item" {{action rejectProposal record false}}>{{t 'Without email'}}</div>
+      </div>
+    {{/ui-dropdown}}
+  {{/unless}}
 </div>

--- a/app/templates/events/view/sessions/list.hbs
+++ b/app/templates/events/view/sessions/list.hbs
@@ -6,5 +6,7 @@
     deleteSession=(action 'deleteSession')
     editSession=(action 'editSession')
     viewSession=(action 'viewSession')
+    acceptProposal=(action 'acceptProposal')
+    rejectProposal=(action 'rejectProposal')
   }}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently aceept/reject proposal buttons on sessions route do not work. This PR makes necessary additions and deletions to make it functional.

#### Changes proposed in this pull request:
- Defines new actions that allow organizer to accept or reject a proposal with an option to notify user via mail or not.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1094 
