### PR TITLE
fix: Speaker-Session not being linked

### DIFF
--- a/app/controllers/events/view/sessions/create.js
+++ b/app/controllers/events/view/sessions/create.js
@@ -1,28 +1,18 @@
 import Controller from '@ember/controller';
 export default Controller.extend({
   actions: {
-    save() {
-      this.set('isLoading', true);
-      this.get('model.speaker.sessions').addObject(this.get('model.session'));
-      this.get('model.session.speakers').addObject(this.get('model.speaker'));
-
-      this.get('model.session').save()
-        .then(() => {
-          this.get('model.speaker').save()
-            .then(() => {
-              this.get('notify').success(this.get('l10n').t('Your session has been saved'));
-              this.transitionToRoute('events.view.sessions', this.get('model.event.id'));
-            })
-            .catch(() => {
-              this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));
-            });
-        })
-        .catch(() => {
-          this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));
-        })
-        .finally(() => {
-          this.set('isLoading', false);
-        });
+    async save() {
+      try {
+        this.set('isLoading', true);
+        await this.get('model.speaker').save();
+        this.get('model.speaker.sessions').pushObject(this.get('model.session'));
+        await this.get('model.session').save();
+        await this.get('model.speaker').save();
+        this.get('notify').success(this.get('l10n').t('Your session has been saved'));
+        this.transitionToRoute('events.view.sessions', this.get('model.event.id'));
+      } catch (e) {
+        this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));
+      }
     }
   }
 });

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -21,7 +21,7 @@ export default JSONAPISerializer.extend(EventRelationMixin, {
   },
 
   serializeHasMany(snapshot, json, relationship) {
-    if (!snapshot.hasMany(relationship.key) || (snapshot.hasMany(relationship.key) && !snapshot.hasMany(relationship.key).id)) {
+    if (!snapshot.hasMany(relationship.key)) {
       return;
     }
     this._super(...arguments);


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Now the speaker and his corresponding session are linked together.

#### Changes proposed in this pull request:
- First save the speaker to the database so that it gets an ID.
- Now add this speaker to the session.speakers relationship
- Save both again


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1277 
