### PR TITLE
fix: Upload slides in session create form

### DIFF
--- a/app/components/widgets/forms/file-upload.js
+++ b/app/components/widgets/forms/file-upload.js
@@ -22,7 +22,7 @@ export default Component.extend({
     this.get('loader')
       .uploadFile('/upload/files', this.$(`#${this.get('inputIdGenerated')}`))
       .then(file => {
-        this.set('fileUrl', file.url);
+        this.set('fileUrl', JSON.parse(file).url);
         this.get('notify').success(this.get('l10n').t('File uploaded successfully'));
       })
       .catch(() => {

--- a/app/services/loader.js
+++ b/app/services/loader.js
@@ -148,9 +148,8 @@ export default Service.extend({
         source = files[0];
       }
 
-      const formData = new FormData();
+      let formData = new FormData();
       formData.append(config.fileName, source);
-
       config.skipDataTransform = true;
 
       const { url, fetchOptions } = this.getFetchOptions(urlPath, method, formData, config);
@@ -158,7 +157,8 @@ export default Service.extend({
       xhr.open(fetchOptions.method || 'get', url);
       let headers = fetchOptions.headers || {};
       for (let k in headers) {
-        if (headers.hasOwnProperty(k)) {
+        // https://stackoverflow.com/a/39281156/6870128
+        if (k !== 'Content-Type' && headers.hasOwnProperty(k)) {
           xhr.setRequestHeader(k, fetchOptions.headers[k]);
         }
       }

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -33,7 +33,6 @@
               label=(t 'File')
               id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))
               icon='file'
-              fileUrl=''
               hint=(t 'Select a file')
               maxSizeInKb=10000}}
           {{/if}}

--- a/app/templates/components/widgets/forms/file-upload.hbs
+++ b/app/templates/components/widgets/forms/file-upload.hbs
@@ -1,7 +1,7 @@
 <div class="ui {{if uploadingFile 'loading'}} basic segment less padding">
   {{#if fileUrl}}
     <div class="ui action input">
-      {{input type='url' value=fileUrl}}
+      {{input type='url' readonly="" value=fileUrl}}
       <button class="ui icon red button" {{action 'removeSelection'}}>
         <i class="remove icon"></i>
         {{t 'Remove file'}}
@@ -14,11 +14,11 @@
       </div>
       <span>{{t 'Or'}}</span>
       <div class="column sixteen wide">
-        <label for={{inputIdGenerated}} class="ui icon button">
+        <label for="{{inputIdGenerated}}" class="ui icon button">
           <i class="file icon"></i>
           {{hint}}
         </label>
-        {{input type='file' id=inputIdGenerated class='hidden-item' change=(action 'fileSelected' 'file')}}
+        {{input type='file' name='file' id=inputIdGenerated class='hidden-item' change=(action 'fileSelected' 'file')}}
         <span class="text muted">
           {{#if helpText}}
             {{helpText}}<br>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fix uploading slides field

#### Changes proposed in this pull request:
- Do not add `Content-Type` header while uploading multipart-form as we cannot find the boundary used by the browser.
- The browser automatically generates the required header if it is not added. Refer to this answer https://stackoverflow.com/a/39281156/6870128
- Make the input field for file upload read-only.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1290 
