### PR TITLE
fix: require event location before publishing event

### DIFF
--- a/app/controllers/events/view.js
+++ b/app/controllers/events/view.js
@@ -6,6 +6,10 @@ export default Controller.extend({
       this.set('isEventDeleteModalOpen', true);
     },
     togglePublishState() {
+      if (this.get('model.locationName') === undefined) {
+        this.notify.error(this.get('l10n').t('Your event must have a location before it can be published.'));
+        return;
+      }
       this.set('isLoading', true);
       const state = this.get('model.state');
       this.set('model.state', state === 'draft' ? 'published' : 'draft');

--- a/app/controllers/events/view.js
+++ b/app/controllers/events/view.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { isEmpty } from '@ember/utils';
 
 export default Controller.extend({
   actions: {
@@ -6,7 +7,7 @@ export default Controller.extend({
       this.set('isEventDeleteModalOpen', true);
     },
     togglePublishState() {
-      if (this.get('model.locationName') === undefined) {
+      if (isEmpty(this.get('model.locationName'))) {
         this.notify.error(this.get('l10n').t('Your event must have a location before it can be published.'));
         return;
       }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Now clicking 'Publish' with no event location won't turn the button to 'Unpublish', will show error message: "Your event must have a location before it can be published."

#### Changes proposed in this pull request:

- Adds a check for the location of an event before publishing

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1308 

#### Screenshot

![screenshot from 2018-06-22 15-48-31](https://user-images.githubusercontent.com/35009811/41784668-0878c12c-765e-11e8-9986-25143398cc19.png)
