### PR TITLE
Filter users into active and deleted in admin/users

### DIFF
--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -16,9 +16,30 @@ export default Route.extend({
       this.replaceWith('admin.users.view', userState);
     }
   },
-  model() {
+  model(params) {
+    this.set('params', params);
+    let filterOptions = [];
+    if (params.users_status === 'active') {
+      filterOptions = [
+        {
+          name : 'deleted-at',
+          op   : 'eq',
+          val  : null
+        }
+      ];
+    } else if (params.users_status === 'deleted') {
+      filterOptions = [
+        {
+          name : 'deleted-at',
+          op   : 'ne',
+          val  : null
+        }
+      ];
+    }
     return this.get('store').query('user', {
-      'page[size]': 10
+      get_trashed  : true,
+      filter       : filterOptions,
+      'page[size]' : 10
     });
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The users presently are not getting filtered in active and deleted routes.

#### Changes proposed in this pull request:

- The all users route now shows all users including the deleted ones.
- The routes /users/active and /users/deleted now filter the users.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1157 
