### PR TITLE
fix: Disable add event sub-topic button until a topic is selected

### DIFF
--- a/app/components/modals/admin/content/new-event-sub-topic-modal.js
+++ b/app/components/modals/admin/content/new-event-sub-topic-modal.js
@@ -6,8 +6,9 @@ export default ModalBase.extend(FormMixin, {
   autoScrollToErrors : false,
 
   actions: {
-    addEventProperty(modelInstance) {
+    addEventProperty(modelInstance, eventTopic) {
       this.onValid(() => {
+        modelInstance.set('eventTopic', eventTopic);
         this.sendAction('addEventProperty', modelInstance);
       });
     }

--- a/app/controllers/admin/content/events.js
+++ b/app/controllers/admin/content/events.js
@@ -2,11 +2,17 @@ import Controller from '@ember/controller';
 import { camelCase, startCase } from 'lodash';
 
 export default Controller.extend({
+
+  disableEventSubtopic : true,
+  currentTopicSelected : null,
+
   actions: {
     async loadSubTopics(topic) {
       this.set('isLoading', true);
       try {
         this.set('subTopics', await topic.get('subTopics'));
+        this.set('disableEventSubtopic', false);
+        this.set('currentTopicSelected', topic);
       } catch (e) {
         this.notify.error(this.get('l10n').t('An unexpected error has occurred. SubTopics not loaded.'));
       } finally {

--- a/app/templates/admin/content/events.hbs
+++ b/app/templates/admin/content/events.hbs
@@ -55,7 +55,7 @@
               <i class="icon plus"></i>
             </button>
           </div>
-        </div>        
+        </div>
         <div class="ui divider"></div>
         <table class="ui celled table">
           <tbody>
@@ -76,7 +76,7 @@
                         {{/ui-popup}}
                       </div>
                     </div>
-                  </div>                  
+                  </div>
                 </td>
               </tr>
             {{/each}}
@@ -93,11 +93,11 @@
             </h4>
           </div>
           <div class="eight wide column right aligned">
-            <button class="ui icon circular blue button {{if device.isMobile 'fluid'}}" {{action 'openModalFor' 'event-sub-topic'}}>
+            <button class="ui icon circular blue {{if disableEventSubtopic 'disabled'}} button {{if device.isMobile 'fluid'}}" {{action 'openModalFor' 'event-sub-topic'}}>
               <i class="icon plus"></i>
             </button>
           </div>
-        </div>   
+        </div>
         <div class="ui divider"></div>
         <div class="field">
           <label>{{t 'Event Topic'}}</label>
@@ -154,4 +154,5 @@
 {{modals/admin/content/new-event-sub-topic-modal isOpen=eventSubTopic.openModal
                               model=model
                               eventSubTopic=eventSubTopic
+                              eventTopic=currentTopicSelected
                               addEventProperty=(action 'addEventProperty' eventSubTopic)}}

--- a/app/templates/components/modals/admin/content/new-event-sub-topic-modal.hbs
+++ b/app/templates/components/modals/admin/content/new-event-sub-topic-modal.hbs
@@ -2,19 +2,12 @@
   {{t 'Add New Event Sub Topic'}}
 </div>
 <div class="content">
-  <div class="field">
-    <label>{{t 'Event Sub-topic'}}</label>
-    {{#ui-dropdown class='search selection' onChange=(action (mut eventSubTopic.eventTopic)) as |execute mapper|}}
-      <i class="dropdown icon"></i>
-      <div class="default text">{{t 'Select Event Sub-Topic'}}</div>
-      <div class="menu">
-        {{#each model.eventTopics as |topic|}}
-          <div class="item" data-value="{{map-value mapper topic}}">{{topic.name}}</div>
-        {{/each}}
-      </div>
-    {{/ui-dropdown}}
-  </div>
-  <form class="ui {{if isLoading 'loading'}} form" id="add-event-sub-topic-form" autocomplete="off" {{action 'addEventProperty' eventSubTopic on='submit' preventDefault=true}}>
+  <form class="ui {{if isLoading 'loading'}} form" id="add-event-sub-topic-form" autocomplete="off" {{action
+    'addEventProperty' eventSubTopic eventTopic on='submit' preventDefault=true}}>
+    <div class="field">
+      <label>{{t 'Event Topic'}}</label>
+      <div class="text">{{eventTopic.name}}</div>
+    </div>
     <div class="field">
       <label class="required">
         {{t 'New Event Sub Topic'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Disable add event sub-topic button until a topic is selected

#### Changes proposed in this pull request:
- Disable add event sub-topic button until a topic is selected
- Lock the selected topic when adding the sub-topic in the modal


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1325 
