### PR TITLE
Fix date formats and add end time to tickets sales end date/time column

### DIFF
--- a/app/helpers/header-date.js
+++ b/app/helpers/header-date.js
@@ -1,0 +1,9 @@
+import Helper from '@ember/component/helper';
+import moment from 'moment';
+
+export function headerDate(params) {
+  let timezone = moment.tz.guess();
+  return `${moment(params[0]).format('dddd, MMMM Do YYYY, h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
+}
+
+export default Helper.helper(headerDate);

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -20,7 +20,7 @@
               <small class="ui gray-text tiny">{{ticket.description}}</small>
             {{/if}}
           </td>
-          <td>{{moment-format ticket.salesEndsAt 'dddd, DD MMMM'}}</td>
+          <td>{{moment-format ticket.salesEndsAt 'ddd, DD MMMM YY, h:mm A'}}</td>
           <td id="{{ticket.id}}_price">$ {{number-format ticket.price}}</td>
           <td>
             <div class="field">

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -6,7 +6,7 @@
         <div class="ui grid info">
           <div class="one wide column"></div>
           <div class="fifteen wide column">
-            <h4 class="event time">{{moment-format model.startsAt 'ddd, MMM DD \at h:mm A'}}</h4>
+            <h4 class="event time">{{header-date model.startsAt 'dddd, MMMM DD \at h:mm A z'}}</h4>
             <h1 class="event name">{{model.name}}</h1>
             <h4 class="event location"><i class="marker icon"></i>{{model.locationName}}</h4>
           </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
- Currently event header shows short forms of month and days. As discussed in meeting we should change it to what other platforms like eventbrite use. Since they use full forms with time zone mentioned, so we are modifying it.
- Ticket sales end date/time column does not include sales end time currently. This PR adds sales end time to that column.

#### Changes proposed in this pull request:
- change date formats.
- add sales end time to tickets list.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1341 
