### PR TITLE
Add functionality to save button in admin/settings/images

### DIFF
--- a/app/controllers/admin/settings/images.js
+++ b/app/controllers/admin/settings/images.js
@@ -4,10 +4,15 @@ export default Controller.extend({
   actions: {
     saveImages() {
       this.set('isLoading', true);
-      let images = this.get('model');
-      images.save()
+      this.get('model.eventImageSize').save()
         .then(() => {
-          this.notify.success(this.get('l10n').t('Image sizes have been saved successfully.'));
+          this.get('model.speakerImageSize').save()
+            .then(() => {
+              this.notify.success(this.get('l10n').t('Image sizes have been saved successfully.'));
+            })
+            .catch(() => {
+              this.notify.error(this.get('l10n').t('An unexpected error has occurred. Image sizes not saved.'));
+            });
         })
         .catch(() => {
           this.notify.error(this.get('l10n').t('An unexpected error has occurred. Image sizes not saved.'));


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds functionality to the the save button in admin/settings/images

#### Changes proposed in this pull request:

- The save button when clicked changes the values of different attributes of the image size model accordingly. 
![image](https://user-images.githubusercontent.com/22127980/42248944-f42180c4-7f45-11e8-99fe-9ff031c4e6b8.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1344 
