### PR TITLE
Hide Add speaker button till session-speaker part is deactivated

### DIFF
--- a/app/routes/events/view/speakers.js
+++ b/app/routes/events/view/speakers.js
@@ -3,5 +3,8 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   titleToken() {
     return this.get('l10n').t('Speakers');
+  },
+  model() {
+    return this.modelFor('events.view');
   }
 });

--- a/app/templates/events/view/sessions.hbs
+++ b/app/templates/events/view/sessions.hbs
@@ -53,6 +53,6 @@
 {{else}}
   <div class="sixteen wide column">
     <h3 class="centered text">{{t 'In order to use this feature please activate "Sessions and Speakers" for the event.'}}</h3>
-    <h4 class="centered text">{{t 'Please click '}}<a href="{{href-to 'events.view.edit.sessions-speakers'}}">here</a>{{t ' to activate this module.'}}</h4>
+    <h4 class="centered text">{{t 'Please click '}}<a href="{{href-to 'events.view.edit.sessions-speakers'}}">{{t 'here'}}</a>{{t ' to activate this module.'}}</h4>
   </div>
 {{/if}}

--- a/app/templates/events/view/speakers.hbs
+++ b/app/templates/events/view/speakers.hbs
@@ -1,34 +1,41 @@
-<div class="ui grid stackable">
-  {{#if (and (not-eq session.currentRouteName 'events.view.speakers.edit') (not-eq session.currentRouteName 'events.view.speakers.create'))}}
+{{#if model.isSessionsSpeakersEnabled}}
+  <div class="ui grid stackable">
+    {{#if (and (not-eq session.currentRouteName 'events.view.speakers.edit') (not-eq session.currentRouteName 'events.view. speakers.create'))}}
+      <div class="row">
+        <div class="six wide column">
+          {{#tabbed-navigation isNonPointing=true}}
+            {{#link-to 'events.view.speakers.list' 'all' class='item'}}
+              {{t 'All'}}
+            {{/link-to}}
+            {{#link-to 'events.view.speakers.list' 'pending' class='item'}}
+              {{t 'Pending'}}
+            {{/link-to}}
+            {{#link-to 'events.view.speakers.list' 'accepted' class='item'}}
+              {{t 'Accepted'}}
+            {{/link-to}}
+            {{#link-to 'events.view.speakers.list' 'rejected' class='item'}}
+              {{t 'Rejected'}}
+            {{/link-to}}
+          {{/tabbed-navigation}}
+        </div>
+        <div class="ten wide {{if device.isMobile 'center aligned'}} column">
+          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Export as CSV'}}</button>
+          {{#if device.isMobile}}
+            <div class="ui hidden fitted divider"></div>
+          {{/if}}
+          {{#link-to 'events.view.speakers.create' class='ui blue button right floated'}}
+            {{t 'Add Speaker'}}
+          {{/link-to}}
+        </div>
+      </div>
+    {{/if}}
     <div class="row">
-      <div class="six wide column">
-        {{#tabbed-navigation isNonPointing=true}}
-          {{#link-to 'events.view.speakers.list' 'all' class='item'}}
-            {{t 'All'}}
-          {{/link-to}}
-          {{#link-to 'events.view.speakers.list' 'pending' class='item'}}
-            {{t 'Pending'}}
-          {{/link-to}}
-          {{#link-to 'events.view.speakers.list' 'accepted' class='item'}}
-            {{t 'Accepted'}}
-          {{/link-to}}
-          {{#link-to 'events.view.speakers.list' 'rejected' class='item'}}
-            {{t 'Rejected'}}
-          {{/link-to}}
-        {{/tabbed-navigation}}
-      </div>
-      <div class="ten wide {{if device.isMobile 'center aligned'}} column">
-        <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Export as CSV'}}</button>
-        {{#if device.isMobile}}
-          <div class="ui hidden fitted divider"></div>
-        {{/if}}
-        {{#link-to 'events.view.speakers.create' class='ui blue button right floated'}}
-          {{t 'Add Speaker'}}
-        {{/link-to}}
-      </div>
+      {{outlet}}
     </div>
-  {{/if}}
-  <div class="row">
-    {{outlet}}
   </div>
-</div>
+{{else}}
+  <div class="sixteen wide column">
+    <h3 class="centered text">{{t 'In order to use this feature please activate "Sessions and Speakers" for the event.'}}</h3>
+    <h4 class="centered text">{{t 'Please click '}}<a href="{{href-to 'events.view.edit.sessions-speakers'}}">{{t 'here'}}</a>{{t ' to activate this module.'}}</h4>
+  </div>
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
If the session-speaker part is deactivated by the event organizer then the speaker table and the add speaker button should not appear in event/{event_identifier}/speakers route.

#### Changes proposed in this pull request:

- The add speaker button and the speaker table should appear only if the session-speaker is enabled by the event organizer.
Else this should come:
![image](https://user-images.githubusercontent.com/22127980/42296025-2f5c48fe-800e-11e8-8457-0a60f73c6f00.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1349 
