### PR TITLE
Disable side menu for cfs forms

### DIFF
--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,69 +1,71 @@
-<div class="ui fluid vertical {{unless device.isMobile 'pointing'}} menu">
-  {{#if (eq session.currentRouteName 'public.index')}}
-    {{#scroll-to href='#info' class='item active'}}
-      {{t 'Info'}}
-    {{/scroll-to}}
-    {{#if event.isTicketingEnabled}}
-      {{#scroll-to href='#tickets' class='item'}}
-        {{t 'Tickets'}}
-      {{/scroll-to}}
-    {{/if}}
-    {{#if event.isSessionsSpeakersEnabled}}
-      {{#scroll-to href='#speakers' class='item'}}
-        {{t 'Speakers'}}
-      {{/scroll-to}}
-    {{/if}}
-  {{else}}
-    <a class="item" href="{{href-to 'public.index'}}">
-      {{t 'Info'}}
-    </a>
-    {{#if event.isTicketingEnabled}}
-      <a class="item" href="{{href-to 'public.index'}}#tickets">
-        {{t 'Tickets'}}
-      </a>
-    {{/if}}
-    {{#if event.isSessionsSpeakersEnabled}}
-      <a class="item" href="{{href-to 'public.index'}}#speakers">
-        {{t 'Speakers'}}
-      </a>
-    {{/if}}
-  {{/if}}
-  {{#if event.isSessionsSpeakersEnabled}}
-    {{#link-to 'public.sessions' class='item'}}
-      {{t 'Sessions'}}
-    {{/link-to}}
-  {{/if}}
-  {{#link-to 'public.schedule' class='item'}}
-    {{t 'Schedule'}}
-  {{/link-to}}
-  {{#if shouldShowCallforSpeakers }}
-    {{#link-to 'public.cfs' class='item'}}
-      {{t 'Call for Speakers'}}
-    {{/link-to}}
-  {{/if}}
-  {{#if event.hasOrganizerInfo}}
+{{#if (and (not-eq session.currentRouteName 'public.cfs.new-session') (not-eq session.currentRouteName 'public.cfs.new-speaker'))}}
+  <div class="ui fluid vertical {{unless device.isMobile 'pointing'}} menu">
     {{#if (eq session.currentRouteName 'public.index')}}
-      {{#scroll-to href='#organizer' class='item'}}
-        {{t 'Organizer'}}
+      {{#scroll-to href='#info' class='item active'}}
+        {{t 'Info'}}
+      {{/scroll-to}}
+      {{#if event.isTicketingEnabled}}
+        {{#scroll-to href='#tickets' class='item'}}
+          {{t 'Tickets'}}
+        {{/scroll-to}}
+      {{/if}}
+      {{#if event.isSessionsSpeakersEnabled}}
+        {{#scroll-to href='#speakers' class='item'}}
+          {{t 'Speakers'}}
+        {{/scroll-to}}
+      {{/if}}
+    {{else}}
+      <a class="item" href="{{href-to 'public.index'}}">
+        {{t 'Info'}}
+      </a>
+      {{#if event.isTicketingEnabled}}
+        <a class="item" href="{{href-to 'public.index'}}#tickets">
+          {{t 'Tickets'}}
+        </a>
+      {{/if}}
+      {{#if event.isSessionsSpeakersEnabled}}
+        <a class="item" href="{{href-to 'public.index'}}#speakers">
+          {{t 'Speakers'}}
+        </a>
+      {{/if}}
+    {{/if}}
+    {{#if event.isSessionsSpeakersEnabled}}
+      {{#link-to 'public.sessions' class='item'}}
+        {{t 'Sessions'}}
+      {{/link-to}}
+    {{/if}}
+    {{#link-to 'public.schedule' class='item'}}
+      {{t 'Schedule'}}
+    {{/link-to}}
+    {{#if shouldShowCallforSpeakers }}
+      {{#link-to 'public.cfs' class='item'}}
+        {{t 'Call for Speakers'}}
+      {{/link-to}}
+    {{/if}}
+    {{#if event.hasOrganizerInfo}}
+      {{#if (eq session.currentRouteName 'public.index')}}
+        {{#scroll-to href='#organizer' class='item'}}
+          {{t 'Organizer'}}
+        {{/scroll-to}}
+      {{else}}
+        <a class="item" href="{{href-to 'public.index'}}#organizer">
+          {{t 'Organizer'}}
+        </a>
+      {{/if}}
+    {{/if}}
+    {{#if (eq session.currentRouteName 'public.index')}}
+      {{#scroll-to href='#getting-here' class='item'}}
+        {{t 'Getting here'}}
       {{/scroll-to}}
     {{else}}
-      <a class="item" href="{{href-to 'public.index'}}#organizer">
-        {{t 'Organizer'}}
+      <a class="item" href="{{href-to 'public.index'}}#getting-here">
+        {{t 'Getting here'}}
       </a>
     {{/if}}
-  {{/if}}
-  {{#if (eq session.currentRouteName 'public.index')}}
-    {{#scroll-to href='#getting-here' class='item'}}
-      {{t 'Getting here'}}
-    {{/scroll-to}}
-  {{else}}
-    <a class="item" href="{{href-to 'public.index'}}#getting-here">
-      {{t 'Getting here'}}
-    </a>
-  {{/if}}
-  {{#if event.codeOfConduct}}
-    {{#link-to 'public.coc' class='item'}}
-      {{t 'Code of Conduct'}}
-    {{/link-to}}
-  {{/if}}
-</div>
+    {{#if event.codeOfConduct}}
+      {{#link-to 'public.coc' class='item'}}
+        {{t 'Code of Conduct'}}
+      {{/link-to}}
+    {{/if}}
+  </div>
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Side menu should not be there when the user is on the route to add new session or speaker through cfs modal in the route e/{event_identifier}/cfs/new-session

#### Changes proposed in this pull request:

- Disables the side menu when redirected to session or speaker form.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1367 
