### PR TITLE
Hide 'select all' checkbox when no suitable tickets available

### DIFF
--- a/app/components/forms/events/view/create-access-code.js
+++ b/app/components/forms/events/view/create-access-code.js
@@ -109,7 +109,7 @@ export default Component.extend(FormMixin, {
   hiddenTickets: computed.filterBy('tickets', 'isHidden', true),
 
   allTicketTypesChecked: computed('tickets', function() {
-    if (this.get('data.tickets').length === this.hiddenTickets.length) {
+    if (this.hiddenTickets.length && this.get('data.tickets').length === this.hiddenTickets.length) {
       return true;
     }
     return false;

--- a/app/components/forms/events/view/create-discount-code.js
+++ b/app/components/forms/events/view/create-discount-code.js
@@ -99,6 +99,17 @@ export default Component.extend(FormMixin, {
     this.set('data.discountUrl', link);
     return link;
   }),
+  eventTickets: computed('data.event.tickets', function() {
+    return this.get('data.event.tickets');
+  }),
+
+  allTicketTypesChecked: computed('data.event.tickets', function() {
+    if (this.eventTickets.length && this.get('data.tickets').length === this.eventTickets.length) {
+      return true;
+    }
+    return false;
+  }),
+
   actions: {
     toggleAllSelection(allTicketTypesChecked) {
       this.toggleProperty('allTicketTypesChecked');

--- a/app/routes/events/view/tickets/discount-codes/create.js
+++ b/app/routes/events/view/tickets/discount-codes/create.js
@@ -15,5 +15,11 @@ export default Route.extend({
   resetController(controller) {
     this._super(...arguments);
     controller.get('model').unloadRecord();
+  },
+  afterModel(model) {
+    let allTickets = model.event.get('tickets');
+    allTickets.forEach(ticket => {
+      ticket.set('isChecked', false);
+    });
   }
 });

--- a/app/templates/components/forms/events/view/create-access-code.hbs
+++ b/app/templates/components/forms/events/view/create-access-code.hbs
@@ -16,11 +16,17 @@
       {{ui-radio name='status' label='Inactive' value='false' current=data.isActive onChange=(action (mut data.isActive))}}
     </div>
   </div>
-  <div class="inline field">
-    <label class="required">{{t 'Select Tickets applied to the access code'}}</label>
-    <div class="ui hidden divider"></div>
-    {{ui-checkbox label='Select all Ticket types' name='all_ticket_types' value='tickets' checked=allTicketTypesChecked onChange=(action 'toggleAllSelection')}}
-  </div>
+  {{#if hiddenTickets}}
+    <div class="inline field">
+      <label class="required">{{t 'Select Tickets applied to the access code'}}</label>
+      <div class="ui hidden divider"></div>
+      {{ui-checkbox label='Select all Ticket types' name='all_ticket_types' value='tickets' checked=allTicketTypesChecked onChange=(action 'toggleAllSelection')}}
+    </div>
+  {{else}}
+    <div class="inline field">
+      <label>{{t 'No hidden tickets available for this event to select from'}}</label>
+    </div>
+  {{/if}}
   <div class="ui list">
     {{#each hiddenTickets as |ticket|}}
       {{ui-checkbox label=ticket.name checked=ticket.isChecked onChange=(action 'updateTicketsSelection' ticket)}}

--- a/app/templates/components/forms/events/view/create-discount-code.hbs
+++ b/app/templates/components/forms/events/view/create-discount-code.hbs
@@ -33,13 +33,19 @@
       {{ui-radio name='status' label=(t 'Inactive') value='false' current=data.isActive onChange=(action (mut data.isActive))}}
     </div>
   </div>
-  <div class="inline field">
-    <label class="required">{{t 'Select Ticket(s) applied to the discount code'}}</label>
-    <div class="ui hidden divider"></div>
-    {{ui-checkbox label='Select all Ticket types' name='all_ticket_types' value='tickets' checked=allTicketTypesChecked onChange=(action 'toggleAllSelection')}}
-  </div>
+  {{#if eventTickets}}
+    <div class="inline field">
+      <label class="required">{{t 'Select Ticket(s) applied to the discount code'}}</label>
+      <div class="ui hidden divider"></div>
+      {{ui-checkbox label='Select all Ticket types' name='all_ticket_types' value='tickets' checked=allTicketTypesChecked onChange=(action 'toggleAllSelection')}}
+    </div>
+  {{else}}
+    <div class="inline field">
+      <label>{{t 'No event tickets to select from'}}</label>
+    </div>
+  {{/if}}
   <div class="ui list">
-    {{#each data.event.tickets as |ticket|}}
+    {{#each eventTickets as |ticket|}}
       {{ui-checkbox label=ticket.name checked=ticket.isChecked onChange=(action 'updateTicketsSelection' ticket)}}
       <br>
     {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently "select all tickets" checkbox is visible even when no tickets are available to select from.

#### Changes proposed in this pull request:
- Add proper checks to hide the ticket.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1376 
