### PR TITLE
Add state column to admin/events

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -19,6 +19,11 @@ export default Controller.extend({
       title        : 'Ends At'
     },
     {
+      propertyName : 'state',
+      template     : 'components/ui-table/cell/cell-event-state',
+      title        : 'State'
+    },
+    {
       propertyName   : 'roles',
       template       : 'components/ui-table/cell/cell-roles',
       title          : 'Roles',

--- a/app/templates/components/ui-table/cell/cell-event-state.hbs
+++ b/app/templates/components/ui-table/cell/cell-event-state.hbs
@@ -1,0 +1,1 @@
+{{get record column.propertyName}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The state column is missing in admin/events

#### Changes proposed in this pull request:

- Adds the state column to admin/events
![image](https://user-images.githubusercontent.com/22127980/42642638-eb676f2c-8614-11e8-87a5-4cca67573ac0.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1358 
