### PR TITLE
Implement a generic error page

### DIFF
--- a/app/components/errors/generic-error.js
+++ b/app/components/errors/generic-error.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/templates/components/errors/generic-error.hbs
+++ b/app/templates/components/errors/generic-error.hbs
@@ -1,0 +1,9 @@
+<br>
+<h1 class="text muted weight-300 less bottom margin">{{t 'An unexpected error has occurred.'}}</h1>
+<h1 class="weight-300 description">{{t 'Oops, the page you were trying'}}<br> {{t 'to access'}}<br> {{t 'has caused an error. '}}.</h1>
+<h3 class="weight-300">
+  {{t 'This, may or may not be a server issue. We are looking into it. You may want to head back to the home page.'}}<br>
+  {{t 'Please try visiting after some time.'}}
+</h3>
+<br>
+<a class="ui secondary basic button" href="{{href-to 'index'}}">{{t 'Go Back Home'}}</a>

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -4,7 +4,9 @@
     {{errors/not-found}}
   {{else if (eq model.errors.0.status 403)}}
     {{errors/forbidden-error}}
-  {{else}}
+  {{else if (eq model.errors.0.status 500)}}
     {{errors/server-error}}
+  {{else}}
+    {{errors/generic-error}}
   {{/if}}
 </div>

--- a/tests/integration/components/errors/generic-error-test.js
+++ b/tests/integration/components/errors/generic-error-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | errors/generic-error', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{errors/generic-error}}`);
+    assert.ok(this.element.innerHTML.trim().includes('error'));
+  });
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently, even for non server related errors, 500 error status is displayed.

#### Changes proposed in this pull request:

- This will enable to show a generic error page, when the type of the error is not identifiable.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1197 
