### PR TITLE
Add filtering to admin/sessions

### DIFF
--- a/app/routes/admin/sessions/list.js
+++ b/app/routes/admin/sessions/list.js
@@ -21,39 +21,131 @@ export default Route.extend({
     if (params.sessions_state === 'pending') {
       filterOptions = [
         {
-          name : 'state',
-          op   : 'eq',
-          val  : 'pending'
+          and:
+            [
+              {
+                name : 'event',
+                op   : 'has',
+                val  : {
+                  name : 'deleted-at',
+                  op   : 'eq',
+                  val  : null
+                }
+              },
+              {
+                name : 'deleted-at',
+                op   : 'eq',
+                val  : null
+              },
+              {
+                name : 'state',
+                op   : 'eq',
+                val  : 'pending'
+              }
+            ]
         }
       ];
     } else if (params.sessions_state === 'accepted') {
       filterOptions = [
         {
-          name : 'state',
-          op   : 'eq',
-          val  : 'accepted'
+          and:
+            [
+              {
+                name : 'event',
+                op   : 'has',
+                val  : {
+                  name : 'deleted-at',
+                  op   : 'eq',
+                  val  : null
+                }
+              },
+              {
+                name : 'deleted-at',
+                op   : 'eq',
+                val  : null
+              },
+              {
+                name : 'state',
+                op   : 'eq',
+                val  : 'accepted'
+              }
+            ]
         }
       ];
     } else if (params.sessions_state === 'rejected') {
       filterOptions = [
         {
-          name : 'state',
-          op   : 'eq',
-          val  : 'rejected'
+          and:
+            [
+              {
+                name : 'event',
+                op   : 'has',
+                val  : {
+                  name : 'deleted-at',
+                  op   : 'eq',
+                  val  : null
+                }
+              },
+              {
+                name : 'deleted-at',
+                op   : 'eq',
+                val  : null
+              },
+              {
+                name : 'state',
+                op   : 'eq',
+                val  : 'rejected'
+              }
+            ]
         }
       ];
     } else if (params.sessions_state === 'deleted') {
       filterOptions = [
         {
-          name : 'state',
-          op   : 'eq',
-          val  : 'deleted'
+          or:
+            [
+              {
+                name : 'event',
+                op   : 'has',
+                val  : {
+                  name : 'deleted-at',
+                  op   : 'ne',
+                  val  : null
+                }
+              },
+              {
+                name : 'deleted-at',
+                op   : 'ne',
+                val  : null
+              }
+            ]
         }
       ];
     } else {
-      filterOptions = [];
+      filterOptions = [
+        {
+          and:
+            [
+              {
+                name : 'event',
+                op   : 'has',
+                val  : {
+                  name : 'deleted-at',
+                  op   : 'eq',
+                  val  : null
+                }
+              },
+              {
+                name : 'deleted-at',
+                op   : 'eq',
+                val  : null
+              }
+            ]
+        }
+      ];
     }
     return this.get('store').query('session', {
+      get_trashed  : true,
       include      : 'event,speakers',
       filter       : filterOptions,
       'page[size]' : 10


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The deleted tab never showed any sessions.

#### Changes proposed in this pull request:

- The all tab shows all the active sessions
- Rejected, accepted, pending tabs show rejected, accepted, pending sessions respectively.
- Deleted tab shows the sessions which were deleted or the sessions of the event which was deleted.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1394 
