### PR TITLE
fix: Make date filters in explore route as v1

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -1,9 +1,19 @@
 import Component from '@ember/component';
 import moment from 'moment';
+import { computed } from '@ember/object';
+import { getDateRanges } from 'open-event-frontend/utils/dictionary/filters';
 
 export default Component.extend({
 
   classNames: ['ui', 'fluid', 'explore', 'vertical', 'menu'],
+
+  customStartDate: moment().toISOString(),
+
+  customEndDate: null,
+
+  dateRanges: computed(function() {
+    return getDateRanges.bind(this)();
+  }),
 
   actions: {
     selectCategory(category, subCategory) {
@@ -16,9 +26,70 @@ export default Component.extend({
     },
 
     dateValidate(date) {
-      if (moment(date).isAfter(this.get('endDate'))) {
-        this.set('endDate', date);
+      if (moment(date).isAfter(this.get('customEndDate'))) {
+        this.set('customEndDate', date);
       }
+
+      this.send('selectDateFilter', 'custom_dates');
+    },
+
+    selectDateFilter(dateType) {
+      let newStartDate = null;
+      let newEndDate = null;
+
+      if (dateType === this.get('dateType') && dateType !== 'custom_dates') {
+        this.set('dateType', null);
+      } else {
+        this.set('dateType', dateType);
+        switch (dateType) {
+          case 'custom_dates':
+            newStartDate = this.get('customStartDate');
+            newEndDate = this.get('customEndDate');
+            break;
+
+          case 'all_dates':
+            break;
+
+          case 'today':
+            newStartDate = moment().toISOString();
+            newEndDate = moment().toISOString();
+            break;
+
+          case 'tomorrow':
+            newStartDate = moment().add(1, 'day').toISOString();
+            newEndDate = newStartDate;
+            break;
+
+          case 'this_week':
+            newStartDate = moment().startOf('week').toISOString();
+            newEndDate = moment().endOf('week').toISOString();
+            break;
+
+          case 'this_weekend':
+            newStartDate = moment().isoWeekday('Friday').toISOString();
+            newEndDate = moment().isoWeekday('Sunday').toISOString();
+            break;
+
+          case 'next_week':
+            newStartDate = moment().isoWeekday('Monday').add(1, 'week').toISOString();
+            newEndDate = moment().isoWeekday('Sunday').add(1, 'week').toISOString();
+            break;
+
+          case 'this_month':
+            newStartDate = moment().startOf('month').toISOString();
+            newEndDate = moment().endOf('month').toISOString();
+            break;
+
+          default:
+        }
+      }
+
+      this.set('startDate', newStartDate);
+      this.set('endDate', newEndDate);
+    },
+
+    onDateChange() {
+      this.send('selectDateFilter', 'custom_dates');
     }
   }
 });

--- a/app/controllers/explore.js
+++ b/app/controllers/explore.js
@@ -1,12 +1,11 @@
 import Controller from '@ember/controller';
-import moment from 'moment';
 
 export default Controller.extend({
   queryParams  : ['category', 'sub_category', 'event_type', 'start_date', 'end_date'],
   category     : null,
   sub_category : null,
   event_type   : null,
-  start_date   : moment().toISOString(),
+  start_date   : null,
   end_date     : null,
 
   actions: {

--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import moment from 'moment';
 
 export default Route.extend({
   titleToken() {
@@ -58,11 +57,7 @@ export default Route.extend({
       });
     }
 
-    if (!params.start_date) {
-      params.start_date =  moment().toISOString();
-    }
-
-    if (params.end_date) {
+    if (params.start_date && params.end_date) {
       filterOptions.push({
         or:
           [
@@ -110,8 +105,7 @@ export default Route.extend({
             }
           ]
       });
-    } else {
-
+    } else if (params.start_date) {
       filterOptions.push({
         or: [
           {

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -54,30 +54,42 @@
   {{/ui-accordion}}
 </div>
 <div class="item">
-  <span class="title">
-    {{t 'Date'}}
-  </span>
-  <div class="content menu">
-    <div class="explore sub menu">
-      <div class="ui form">
-        <div class="grouped fields">
-          <div class="item field">
-            <label class="required" for="startDate">{{t 'Starts'}}</label>
-            {{widgets/forms/date-picker type='text'
-                                        rangePosition='start'
-                                        value=startDate
-                                        onChange=(action 'dateValidate')
-            }}
-          </div>
-          <div class="item field">
-            <label class="required" for="endDate">{{t 'Ends'}}</label>
-            {{widgets/forms/date-picker type='text'
-                                        rangePosition='end'
-                                        value=endDate
-            }}
-          </div>
-        </div>
-      </div>
+  {{#ui-accordion}}
+    <span class="title">
+      <i class="dropdown icon"></i>
+      {{t 'Date'}}
+    </span>
+    <div class="content menu">
+      {{#each dateRanges as |dateRange|}}
+        <a href="#" class="link item {{if (eq dateType dateRange.key) 'active'}}" {{action 'selectDateFilter'
+                                                                                             dateRange.key}}>
+          {{dateRange.name}}
+          {{#if (and (eq dateRange.key 'custom_dates') (eq dateType 'custom_dates'))}}
+            <div class="explore sub menu">
+              <div class="ui form">
+                <div class="grouped fields">
+                  <div class="item field">
+                    <label class="required" for="start_date">{{t 'Starts'}}</label>
+                    {{widgets/forms/date-picker type='text'
+                                                value=customStartDate
+                                                rangePosition='start'
+                                                onChange=(action 'dateValidate')
+                    }}
+                  </div>
+                  <div class="item field">
+                    <label class="required" for="end_date">{{t 'Ends'}}</label>
+                    {{widgets/forms/date-picker type='text'
+                                                value=customEndDate
+                                                rangePosition='end'
+                                                onChange=(action 'onDateChange')
+                    }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          {{/if}}
+        </a>
+      {{/each}}
     </div>
-  </div>
+  {{/ui-accordion}}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Makes the date filters in explore route just like v1.

#### Changes proposed in this pull request:
- Restore the UI of v1
- Implement all the date range types

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1383 
