### PR TITLE
Modify orders & attendees table to use paidVia instead of paymentMethod

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
@@ -10,9 +10,11 @@
     {{record.order.state}}
   </div>
   <div class="sub header">
-    <span class="weight-800">
-      {{t 'Payment via'}} {{record.order.paymentMode}}
-    </span>
+    {{#if record.order.paidVia}}
+      <span class="weight-800">
+        {{t 'Payment via'}} {{record.order.paidVia}}
+      </span>
+    {{/if}}
     {{moment-from-now record.order.createdAt}}
   </div>
 </div>

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -7,8 +7,10 @@
     {{record.status}}
   </div>
   <div class="sub header">
-    <span class="weight-800">
-      {{t 'Payment via'}} {{record.paymentMode}}
-    </span>
+    {{#if record.paidVia}}
+      <span class="weight-800">
+        {{t 'Payment via'}} {{record.paidVia}}
+      </span>
+    {{/if}}
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
paidVia is null until we actually pay for the order. So we should change paymentMethod to paidVia in orders list and attendees table which will be correct use of what we want to show.

#### Changes proposed in this pull request:
- Modify the attendees and orders table accordingly.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1399
