### PR TITLE
Add helper text to add session/speaker form

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -302,6 +302,16 @@ export default Component.extend(FormMixin, {
     return groupBy(this.get('fields').toArray(), field => field.get('form'));
   }),
 
+  // Clicking on the add session button creates a blank record which increases the length of the speaker's list by 1.
+  noSpeakerExists: computed('speakers', function() {
+    return (this.get('speakers').length === 1);
+  }),
+
+  // Clicking on the add speaker button creates a blank record which increases the length of the session's list by 1.
+  noSessionExists: computed('sessions', function() {
+    return (this.get('sessions').length === 1);
+  }),
+
   shouldShowNewSpeakerDetails: computed('speakerDetails', 'newSpeakerSelected', function() {
     return this.get('newSpeakerSelected') && !this.get('speakerDetails');
   }),

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -69,6 +69,9 @@
         {{/if}}
       </div>
     {{/each}}
+    {{#if noSpeakerExists}}
+      <div class="ui small disabled header">{{t 'No speaker exists. Add a new speaker.'}}</div>
+    {{/if}}
     <div class="ui horizontal divider">
       Or
     </div>
@@ -177,6 +180,9 @@
         {{/if}}
       </div>
     {{/each}}
+    {{#if noSessionExists}}
+      <div class="ui small disabled header">{{t 'No session exists. Add a new session proposal.'}}</div>
+    {{/if}}
     <div class="ui horizontal divider">
       Or
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


#### Changes proposed in this pull request:

- In the add speaker form if there are no sessions for the event helper text should come.
- In the create session form if there are no speakers for the event helper text should come.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1406 
