### PR TITLE
Fix minor bugs with cfs speaker and session creation

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -340,24 +340,10 @@ export default Component.extend(FormMixin, {
   didInsertElement() {
     if (this.get('isSpeaker') && this.get('data.speaker') && this.get('data.speaker').length) {
       this.set('data.speaker', this.get('data.speaker').toArray()[0]);
-    } else if (this.get('isCFS')) {
-      this.set('data.speaker', this.get('store').createRecord('speaker', {
-        email    : this.get('authManager.currentUser.email'),
-        name     : `${this.get('authManager.currentUser.firstName')} ${this.get('authManager.currentUser.lastName')}`,
-        photoUrl : this.get('authManager.currentUser.avatarUrl'),
-        event    : this.get('data.event'),
-        user     : this.get('authManager.currentUser')
-      }));
     }
 
     if (this.get('isSession') && this.get('data.session') && this.get('data.session').length) {
       this.set('data.session', this.get('data.session').toArray()[0]);
-    } else if (this.get('isCFS')) {
-      this.set('data.session', this.get('store').createRecord('session', {
-        event   : this.get('data.event'),
-        creator : this.get('authManager.currentUser'),
-        speaker : this.get('data.speaker')
-      }));
     }
   }
 });

--- a/app/controllers/events/view/speakers/list.js
+++ b/app/controllers/events/view/speakers/list.js
@@ -31,6 +31,7 @@ export default Controller.extend({
       this.set('isLoading', true);
       speaker.destroyRecord()
         .then(() => {
+          this.get('model').reload();
           this.notify.success(this.get('l10n').t('Speaker has been deleted successfully.'));
         })
         .catch(() => {

--- a/app/routes/events/view/sessions/create.js
+++ b/app/routes/events/view/sessions/create.js
@@ -29,7 +29,11 @@ export default Route.extend({
   resetController(controller) {
     this._super(...arguments);
     const model = controller.get('model');
-    model.speaker.unloadRecord();
-    model.session.unloadRecord();
+    if (!model.speaker.id) {
+      model.speaker.unloadRecord();
+    }
+    if (!model.session.id) {
+      model.session.unloadRecord();
+    }
   }
 });

--- a/app/routes/public/cfs/new-session.js
+++ b/app/routes/public/cfs/new-session.js
@@ -29,5 +29,12 @@ export default Route.extend({
       tracks       : await eventDetails.query('tracks', {}),
       sessionTypes : await eventDetails.query('sessionTypes', {})
     };
+  },
+  resetController(controller) {
+    this._super(...arguments);
+    const model = controller.get('model.session');
+    if (!model.id) {
+      controller.get('model.session').unloadRecord();
+    }
   }
 });

--- a/app/routes/public/cfs/new-speaker.js
+++ b/app/routes/public/cfs/new-speaker.js
@@ -7,6 +7,11 @@ export default Route.extend({
 
   async model() {
     const eventDetails = this.modelFor('public');
+    const currentUser = this.get('authManager.currentUser');
+    let userName;
+    if (currentUser.firstName || currentUser.lastName) {
+      userName = `${currentUser.firstName} ${currentUser.lastName}`;
+    }
     return {
       event : eventDetails,
       forms : await eventDetails.query('customForms', {
@@ -14,9 +19,19 @@ export default Route.extend({
         'page[size]' : 50
       }),
       speaker: await this.get('store').createRecord('speaker', {
-        event : eventDetails,
-        user  : this.get('authManager.currentUser')
+        email    : currentUser.email,
+        name     : userName,
+        photoUrl : currentUser.avatarUrl,
+        event    : eventDetails,
+        user     : currentUser
       })
     };
+  },
+  resetController(controller) {
+    this._super(...arguments);
+    const model = controller.get('model.speaker');
+    if (!model.id) {
+      controller.get('model.speaker').unloadRecord();
+    }
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
- Most of the time if we create a from speaker and then go to /events/view/session or speaker without saving the cfs speaker it shows a blank entry.
- If user has not filled his first name and last name it comes as `null null` in text field.
- For the same route we have two `createRecord` instances the second on present in session-speaker-form component is not required.

#### Changes proposed in this pull request:
- Add necessary code to fix above issues.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1410

