### PR TITLE
Add system roles column to admin/users

### DIFF
--- a/app/templates/components/ui-table/cell/admin/users/cell-system-roles.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-system-roles.hbs
@@ -1,5 +1,19 @@
-<div class="ui ordered list">
-  {{#each record.systemRoles as |systemRole|}}
-    <div class="item">{{systemRole}}</div>
-  {{/each}}
+<div class="ui unordered list">
+  {{#if record.isSuperAdmin}}
+    <div class="item">
+      {{t 'Super Admin'}}
+    </div>
+  {{/if}}
+  {{#if record.isAdmin}}
+    <div class="item">
+      {{t 'Admin'}}
+    </div>
+  {{/if}}
+  <div class="item">
+    {{#if record.isVerified}}
+      {{t 'Verified User'}}
+    {{else}}
+      {{t 'Unverified User'}}
+    {{/if}}
+  </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The column for system roles was missing in admin/users

#### Changes proposed in this pull request:

- Shows info of the system role of the user, i.e. if the user is admin, super admin or a verified user.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1413 
