### PR TITLE
Allow only paid tickets to be selected for discount code

### DIFF
--- a/app/components/forms/events/view/create-discount-code.js
+++ b/app/components/forms/events/view/create-discount-code.js
@@ -99,9 +99,7 @@ export default Component.extend(FormMixin, {
     this.set('data.discountUrl', link);
     return link;
   }),
-  eventTickets: computed('tickets', function() {
-    return this.get('tickets');
-  }),
+  eventTickets: computed.filterBy('tickets', 'type', 'paid'),
 
   allTicketTypesChecked: computed('tickets', function() {
     if (this.eventTickets.length && this.get('data.tickets').length === this.eventTickets.length) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently we can select free tickets also for discount code which does not makes sense.

#### Changes proposed in this pull request:
- Filter tickets based on its type and select only paid tickets.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1417 
