### PR TITLE
Revert "Update ember-data to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-composable-helpers": "^2.0.0",
     "ember-config-service": "^0.2.0",
     "ember-cookies": "^0.3.0",
-    "ember-data": "~3.3.0",
+    "ember-data": "~3.2.0",
     "ember-data-has-many-query": "^0.2.0",
     "ember-exam": "^1.0.0",
     "ember-export-application-global": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,9 +3719,9 @@ ember-data-has-many-query@^0.2.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-ember-data@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.3.0.tgz#138cc248f61164404f5aa6b8207a3dfae8eaea2a"
+ember-data@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.2.0.tgz#f9e30a51cbd05f26e5e0df6b6a13adcd9db99acc"
   dependencies:
     "@ember/ordered-set" "^1.0.0"
     amd-name-resolver "0.0.7"


### PR DESCRIPTION
Reverts fossasia/open-event-frontend#1401

Most of the collaborators working on this project are facing a similar error. Error popping out is given below. Maybe we can revert this PR and then manually update it when it appears to be fixed.

We tried running yarn but it seems updating dependencies but still error pops up.

```
Missing yarn packages: 
Package: ember-data
  * Specified: ~3.3.0
  * Installed: 3.2.0

Run `yarn` to install missing dependencies.



Stack Trace and Error Report: /tmp/error.dump.2c22997b231a0119f3b5c1e762d813f7.log
An error occurred in the constructor for ember-cli-dependency-checker at /home/rs/Pradeep/github/open-event-frontend/node_modules/ember-cli-dependency-checker
```