### PR TITLE
fix: Fix failing Travis by adding global path for yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ addons:
     packages:
       - g++-4.8
 
-before_install: yarn global add greenkeeper-lockfile@1
+before_install:
+  - export PATH="$(yarn global bin):$PATH"
+  - yarn global add greenkeeper-lockfile@1
+
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 install: yarn


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fix failing Travis by following this solution https://github.com/greenkeeperio/greenkeeper-lockfile/issues/185.

#### Changes proposed in this pull request:
- Change `before_install` to this : 
```yml
before_install:
  - export PATH="$(yarn global bin):$PATH"
  - yarn global add greenkeeper-lockfile@1
```

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1426 
