### PR TITLE
feat: Add URL and Email validations in speaker-session form

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { groupBy } from 'lodash';
 import FormMixin from 'open-event-frontend/mixins/form';
+import { compulsoryProtocolValidUrlPattern, validEmailPattern } from 'open-event-frontend/utils/validators';
 
 export default Component.extend(FormMixin, {
 
@@ -96,30 +97,78 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        slidesUrl: {
+        slidesUrlRequired: {
           identifier : 'session_slidesUrl_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter a url')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
         },
-        videoUrl: {
+        slidesUrl: {
+          identifier : 'session_slidesUrl',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            }
+          ]
+        },
+        videoUrlRequired: {
           identifier : 'session_videoUrl_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter a url')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
         },
-        audioUrl: {
+        videoUrl: {
+          identifier : 'session_videoUrl',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            }
+          ]
+        },
+        audioUrlRequired: {
           identifier : 'session_audioUrl_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter a url')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            }
+          ]
+        },
+        audioUrl: {
+          identifier : 'session_audioUrl',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
         },
@@ -132,21 +181,57 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        email: {
+        emailRequired: {
           identifier : 'speaker_email_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter an email')
+            },
+            {
+              type   : 'regExp',
+              value  : validEmailPattern,
+              prompt : this.get('l10n').t('Please enter a valid email')
             }
           ]
         },
-        photoUrl: {
+        email: {
+          identifier : 'speaker_email',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter an email')
+            },
+            {
+              type   : 'regExp',
+              value  : validEmailPattern,
+              prompt : this.get('l10n').t('Please enter a valid email')
+            }
+          ]
+        },
+        photoUrlRequired: {
           identifier : 'speaker_photoUrl_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please select an image')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            }
+          ]
+        },
+        photoUrl: {
+          identifier : 'speaker_photoUrl',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
         },
@@ -249,48 +334,160 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        website: {
+        websiteRequired: {
           identifier : 'speaker_website_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter url of website')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
         },
-        facebook: {
+        website: {
+          identifier : 'speaker_website',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            }
+          ]
+        },
+        facebookRequired: {
           identifier : 'speaker_facebook_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter facebook link')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[facebook.com]',
+              prompt : this.get('l10n').t('Please enter a valid facebook url')
             }
           ]
         },
-        twitter: {
+        facebook: {
+          identifier : 'speaker_facebook',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[facebook.com]',
+              prompt : this.get('l10n').t('Please enter a valid facebook url')
+            }
+          ]
+        },
+        twitterRequired: {
           identifier : 'speaker_twitter_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter twitter link')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[twitter.com]',
+              prompt : this.get('l10n').t('Please enter a valid twitter url')
             }
           ]
         },
-        github: {
+        twitter: {
+          identifier : 'speaker_twitter',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[twitter.com]',
+              prompt : this.get('l10n').t('Please enter a valid twitter url')
+            }
+          ]
+        },
+        githubRequired: {
           identifier : 'speaker_github_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter github link')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[github.com]',
+              prompt : this.get('l10n').t('Please enter a valid github url')
             }
           ]
         },
-        linkedin: {
+        github: {
+          identifier : 'speaker_github',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[github.com]',
+              prompt : this.get('l10n').t('Please enter a valid github url')
+            }
+          ]
+        },
+        linkedinRequired: {
           identifier : 'speaker_linkedin_required',
           rules      : [
             {
               type   : 'empty',
               prompt : this.get('l10n').t('Please enter linkedin link')
+            },
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[linkedin.com]',
+              prompt : this.get('l10n').t('Please enter a valid linkedin url')
+            }
+          ]
+        },
+        linkedin: {
+          identifier : 'speaker_linkedin',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : compulsoryProtocolValidUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid url')
+            },
+            {
+              type   : 'containsExactly[linkedin.com]',
+              prompt : this.get('l10n').t('Please enter a valid linkedin url')
             }
           ]
         }

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -12,17 +12,17 @@
           {{#if (is-input-field field.type) }}
             {{#if field.isLongText}}
               {{widgets/forms/rich-text-editor value=(mut (get data.session field.fieldIdentifier))
-                textareaId=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))}}
+                textareaId=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))}}
             {{else}}
               {{input type=field.type value=(mut (get data.session field.fieldIdentifier))
-                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))}}
+                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}
             {{widgets/forms/image-upload
               imageUrl=(mut (get data.session field.fieldIdentifier))
               label=(t 'Logo')
-              id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))
+              id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))
               icon='image'
               hint=(t 'Select an image')
               maxSizeInKb=1000}}
@@ -31,7 +31,7 @@
             {{widgets/forms/file-upload
               fileUrl=(mut (get data.session field.fieldIdentifier))
               label=(t 'File')
-              id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))
+              id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))
               icon='file'
               hint=(t 'Select a file')
               maxSizeInKb=10000}}
@@ -86,16 +86,16 @@
             {{#if (is-input-field field.type) }}
               {{#if field.isLongText}}
                 {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
-                                                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                                                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
               {{else}}
-                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
               {{/if}}
             {{/if}}
             {{#if (eq field.type 'image')}}
               {{widgets/forms/image-upload
                 imageUrl=(mut (get data.speaker field.fieldIdentifier))
                 label=(t 'Logo')
-                id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))
+                id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))
                 icon='image'
                 hint=(t 'Select an image')
                 maxSizeInKb=1000}}
@@ -133,16 +133,16 @@
           {{#if (is-input-field field.type) }}
             {{#if field.isLongText}}
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
-                textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+                textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
             {{else}}
-              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))}}
+              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}
             {{widgets/forms/image-upload
               imageUrl=(mut (get data.speaker field.fieldIdentifier))
               label=(t 'Logo')
-              id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required'))
+              id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))
               icon='image'
               hint=(t 'Select an image')
               maxSizeInKb=1000}}
@@ -197,17 +197,17 @@
             {{#if (is-input-field field.type) }}
               {{#if field.isLongText}}
                 {{widgets/forms/rich-text-editor value=(mut (get data.session field.fieldIdentifier))
-                                               textareaId=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))}}
+                                               textareaId=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))}}
               {{else}}
                 {{input type=field.type value=(mut (get data.session field.fieldIdentifier))
-                      id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))}}
+                      id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))}}
               {{/if}}
             {{/if}}
             {{#if (eq field.type 'image')}}
               {{widgets/forms/image-upload
                 imageUrl=(mut (get data.session field.fieldIdentifier))
                 label=(t 'Logo')
-                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))
+                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))
                 icon='image'
                 hint=(t 'Select an image')
                 maxSizeInKb=1000}}
@@ -216,7 +216,7 @@
               {{widgets/forms/file-upload
                 fileUrl=(mut (get data.session field.fieldIdentifier))
                 label=(t 'File')
-                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required'))
+                id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))
                 icon='file'
                 fileUrl=''
                 hint=(t 'Select a file')

--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -11,6 +11,13 @@ const validUrlPattern = new RegExp('^(https?:\\/\\/)?' // protocol
   + '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
   + '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locator
 
+export const compulsoryProtocolValidUrlPattern = new RegExp('^(https?:\\/\\/)' // compulsory protocol
+  + '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' // domain name
+  + '((\\d{1,3}\.){3}\\d{1,3}))' // OR ip (v4) address
+  + '(\\:\\d+)?(\/[-a-z\\d%_.~+]*)*' // port and path
+  + '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
+  + '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locator
+
 export const protocolLessValidUrlPattern = new RegExp(
   '^'
   // user:pass authentication
@@ -44,6 +51,14 @@ export const protocolLessValidUrlPattern = new RegExp(
   // resource path
   + '(?:[/?#]\\S*)?'
   + '$', 'i'
+);
+
+/**
+ * Source: https://stackoverflow.com/a/46181/6748052
+ * @type {RegExp}
+ */
+export const validEmailPattern = new RegExp(
+  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 );
 
 export const isValidUrl = str => {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
URL and Email fields aren't validated in the session/speaker form.

#### Changes proposed in this pull request:
Add validation to those fields.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1430 
Fixes #1326 