### PR TITLE
Add UI for the edit button for admin/users

### DIFF
--- a/app/components/modals/edit-user-modal.js
+++ b/app/components/modals/edit-user-modal.js
@@ -1,0 +1,5 @@
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+export default ModalBase.extend({
+});
+

--- a/app/controllers/admin/users/list.js
+++ b/app/controllers/admin/users/list.js
@@ -79,6 +79,9 @@ export default Controller.extend({
         .finally(() => {
           this.set('isLoading', false);
         });
+    },
+    openEditModal() {
+      this.set('isEditUserModalOpen', true);
     }
   }
 });

--- a/app/templates/admin/users/list.hbs
+++ b/app/templates/admin/users/list.hbs
@@ -6,6 +6,8 @@
                         showPageSize=true
                         moveToUserDetails=(action 'moveToUserDetails')
                         deleteUser=(action 'deleteUser')
+                        openEditModal=(action 'openEditModal')
                         isLoading=isLoading
   }}
 </div>
+{{modals/edit-user-modal isOpen=isEditUserModalOpen}}

--- a/app/templates/components/modals/edit-user-modal.hbs
+++ b/app/templates/components/modals/edit-user-modal.hbs
@@ -1,0 +1,23 @@
+<i class="black close icon"></i>
+<div class="header">
+  {{t 'Update System Roles'}}
+</div>
+<div class="content">
+  <div class="ui form">
+    <h4 class="ui header">{{t 'Provide admin access?'}}</h4>
+    <div class="grouped inline fields">
+      <div class="field">
+        {{ui-radio name="isAdmin" label="Yes" value=true onChange=(action (mut isAdmin))}}
+        {{ui-radio name="isAdmin" label="No" value=false onChange=(action (mut isAdmin))}}
+      </div>
+    </div>
+    <h4 class="ui header">{{t 'Custom system roles'}}</h4>
+    <div class="field">
+      {{ui-checkbox label="Sales Admin" onChange=(action (mut checked))}}
+      {{ui-checkbox label="Marketer" onChange=(action (mut checked))}}
+    </div>
+    <button class="ui teal right floated submit button update-changes">
+      {{t 'Save'}}
+    </button>
+  </div>
+</div>

--- a/app/templates/components/ui-table/cell/admin/users/cell-actions.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-actions.hbs
@@ -3,7 +3,7 @@
     <i class="unhide icon"></i>
   {{/ui-popup}}
   {{#unless record.isSuperAdmin}}
-    {{#ui-popup content=(t 'Edit') class='ui icon button'}}
+    {{#ui-popup content=(t 'Edit') click=(action openEditModal) class='ui icon button'}}
       <i class="edit icon"></i>
     {{/ui-popup}}
     {{#ui-popup content=(t 'Delete') click=(action (confirm (t 'Are you sure you would like to delete this user?') (action deleteUser record))) class='ui icon button'}}

--- a/tests/integration/components/modals/edit-user-modal-test.js
+++ b/tests/integration/components/modals/edit-user-modal-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | modals/edit-user-modal', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('isOpen', false);
+    await render(hbs`{{modals/edit-user-modal isOpen=isOpen}}`);
+    assert.ok(this.element.innerHTML.trim().includes('Update System Roles'));
+  });
+});

--- a/tests/integration/components/ui-table/cell/admin/users/cell-actions-test.js
+++ b/tests/integration/components/ui-table/cell/admin/users/cell-actions-test.js
@@ -9,7 +9,8 @@ module('Integration | Component | ui table/cell/admin/users/cell actions', funct
   test('it renders', async function(assert) {
     this.set('deleteUser', () => {});
     this.set('moveToUserDetails', () => {});
-    await render(hbs`{{ui-table/cell/admin/users/cell-actions deleteUser=(action deleteUser) moveToUserDetails=(action moveToUserDetails)}}`);
+    this.set('openEditModal', () => {});
+    await render(hbs`{{ui-table/cell/admin/users/cell-actions deleteUser=(action deleteUser) moveToUserDetails=(action moveToUserDetails) openEditModal=(action openEditModal)}}`);
     assert.ok(this.element.textContent.trim().includes(''));
   });
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds UI for the edit system roles modal.

#### Changes proposed in this pull request:

- When the edit action button in admin/users is clicked a modal appears.
- UI for the modal is added
- Will do the API integration after https://github.com/fossasia/open-event-server/issues/5142 is solved.

![image](https://user-images.githubusercontent.com/22127980/42909073-7b8ea6f2-8b00-11e8-8873-5ffac0b6717c.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1432 
