### PR TITLE
feat: Retrieve redirect URL from the server for facebook login

### DIFF
--- a/app/components/forms/login-form.js
+++ b/app/components/forms/login-form.js
@@ -76,6 +76,19 @@ export default Component.extend(FormMixin, {
             }
           });
       });
+    },
+
+    async auth(provider) {
+      try {
+        let response = await this.get('loader').load(`/auth/oauth/${  provider}`);
+        if (response.url.length > 0) {
+          this.get('notify').success(this.get('l10n').t('URL received'));
+        } else {
+          this.get('notify').error(this.get('l10n').t('URL not received'));
+        }
+      } catch (error) {
+        this.get('notify').error(this.get('l10n').t(error.message));
+      }
     }
   },
 

--- a/app/templates/components/forms/login-form.hbs
+++ b/app/templates/components/forms/login-form.hbs
@@ -46,7 +46,7 @@
       <div class="ui segment basic center aligned">
         <div class="mobile hidden login-with-fb"> </div>
         <div class="ui vertical buttons">
-          <button type="button" class="ui facebook button">
+          <button type="button" class="ui facebook button" {{action 'auth' 'facebook'}}>
             <i class="facebook icon"></i>
             {{t 'Login with Facebook'}}
           </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Retrieve redirect URL from the server for facebook login.

#### Changes proposed in this pull request:
- Make a call to `v1/auth/oauth/facebook` to get the redirect url
- Created a success notifier just for testing purposes and will be removed in the next PR


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1429 
