### PR TITLE
feat: Check for valid social media profiles in session-speaker form

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -47,6 +47,10 @@ export default Component.extend(FormMixin, {
         {
           type   : 'empty',
           prompt : this.get('l10n').t('Please enter your email')
+        },
+        {
+          type   : 'email',
+          prompt : this.get('l10n').t('Please enter a valid email')
         }
       ]
     };

--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -2,7 +2,8 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { groupBy } from 'lodash';
 import FormMixin from 'open-event-frontend/mixins/form';
-import { compulsoryProtocolValidUrlPattern, validEmailPattern } from 'open-event-frontend/utils/validators';
+import { compulsoryProtocolValidUrlPattern, validTwitterProfileUrlPattern, validFacebookProfileUrlPattern,
+  validGithubProfileUrlPattern, validLinkedinProfileUrlPattern } from 'open-event-frontend/utils/validators';
 
 export default Component.extend(FormMixin, {
 
@@ -189,8 +190,7 @@ export default Component.extend(FormMixin, {
               prompt : this.get('l10n').t('Please enter an email')
             },
             {
-              type   : 'regExp',
-              value  : validEmailPattern,
+              type   : 'email',
               prompt : this.get('l10n').t('Please enter a valid email')
             }
           ]
@@ -204,8 +204,7 @@ export default Component.extend(FormMixin, {
               prompt : this.get('l10n').t('Please enter an email')
             },
             {
-              type   : 'regExp',
-              value  : validEmailPattern,
+              type   : 'email',
               prompt : this.get('l10n').t('Please enter a valid email')
             }
           ]
@@ -368,12 +367,8 @@ export default Component.extend(FormMixin, {
             },
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[facebook.com]',
-              prompt : this.get('l10n').t('Please enter a valid facebook url')
+              value  : validFacebookProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid facebook account url')
             }
           ]
         },
@@ -383,12 +378,8 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[facebook.com]',
-              prompt : this.get('l10n').t('Please enter a valid facebook url')
+              value  : validFacebookProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid facebook account url')
             }
           ]
         },
@@ -401,12 +392,8 @@ export default Component.extend(FormMixin, {
             },
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[twitter.com]',
-              prompt : this.get('l10n').t('Please enter a valid twitter url')
+              value  : validTwitterProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid twitter profile url')
             }
           ]
         },
@@ -416,12 +403,8 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[twitter.com]',
-              prompt : this.get('l10n').t('Please enter a valid twitter url')
+              value  : validTwitterProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid twitter profile url')
             }
           ]
         },
@@ -434,12 +417,8 @@ export default Component.extend(FormMixin, {
             },
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[github.com]',
-              prompt : this.get('l10n').t('Please enter a valid github url')
+              value  : validGithubProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid github profile url')
             }
           ]
         },
@@ -449,12 +428,8 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[github.com]',
-              prompt : this.get('l10n').t('Please enter a valid github url')
+              value  : validGithubProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid github profile url')
             }
           ]
         },
@@ -467,12 +442,8 @@ export default Component.extend(FormMixin, {
             },
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[linkedin.com]',
-              prompt : this.get('l10n').t('Please enter a valid linkedin url')
+              value  : validLinkedinProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid linkedin profile url')
             }
           ]
         },
@@ -482,12 +453,8 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
-              prompt : this.get('l10n').t('Please enter a valid url')
-            },
-            {
-              type   : 'containsExactly[linkedin.com]',
-              prompt : this.get('l10n').t('Please enter a valid linkedin url')
+              value  : validLinkedinProfileUrlPattern,
+              prompt : this.get('l10n').t('Please enter a valid linkedin profile url')
             }
           ]
         }

--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -53,13 +53,26 @@ export const protocolLessValidUrlPattern = new RegExp(
   + '$', 'i'
 );
 
-/**
- * Source: https://stackoverflow.com/a/46181/6748052
- * @type {RegExp}
- */
-export const validEmailPattern = new RegExp(
-  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+export const validTwitterProfileUrlPattern = new RegExp(
+  '^(https?:\\/\\/)' // compulsory protocol
+  + 'twitter\\.com\\/([a-zA-Z0-9_]+)$'
 );
+
+export const validFacebookProfileUrlPattern = new RegExp(
+  '^(https?:\\/\\/)' // compulsory protocol
+  + 'facebook\\.com\\/([a-zA-Z0-9_]+)$'
+);
+
+export const validGithubProfileUrlPattern = new RegExp(
+  '^(https?:\\/\\/)' // compulsory protocol
+  + 'github\\.com\\/([a-zA-Z0-9_]+)$'
+);
+
+export const validLinkedinProfileUrlPattern = new RegExp(
+  '^(https?:\\/\\/)' // compulsory protocol
+  + 'linkedin\\.com\\/([a-zA-Z0-9_]+)$'
+);
+
 
 export const isValidUrl = str => {
   return validUrlPattern.test(str);


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Right now the session-speaker form accepts https://twitter.com as a valid twitter account url. Although this is a valid twitter url but it is not an account URL. Similar cases exist for other social media URL fields.

#### Changes proposed in this pull request:
Added checks for them.

![screenshot from 2018-07-20 02-10-50](https://user-images.githubusercontent.com/21277837/42969038-8e33ef66-8bc2-11e8-8c87-f5e7f876571b.png)
![valid](https://user-images.githubusercontent.com/21277837/42969039-9044e724-8bc2-11e8-95cd-67939bcddd8d.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1443 
