### PR TITLE
Add timer to orders form to indicate time remaining to complete registration

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -1,10 +1,15 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { run } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import FormMixin from 'open-event-frontend/mixins/form';
+import moment from 'moment';
 import { countries } from 'open-event-frontend/utils/dictionary/demography';
 import { orderBy } from 'lodash';
 
 export default Component.extend(FormMixin, {
+  router: service(),
+
   buyer: computed('data.user', function() {
     return this.get('data.user');
   }),
@@ -24,6 +29,25 @@ export default Component.extend(FormMixin, {
     return true;
   }),
   sameAsBuyer: false,
+
+  getRemainingTime: computed('data', function() {
+    let willExpireAt = this.get('data.createdAt').add(10, 'minutes');
+    this.timer(willExpireAt, this.get('data.identifier'));
+  }),
+
+  timer(willExpireAt, orderIdentifier) {
+    run.later(() => {
+      let currentTime = moment();
+      let diff = moment.duration(willExpireAt.diff(currentTime));
+      this.set('getRemainingTime', moment.utc(diff.asMilliseconds()).format('mm:ss'));
+      if (diff > 0) {
+        this.timer(willExpireAt, orderIdentifier);
+      } else {
+        this.get('data').reload();
+        this.get('router').transitionTo('orders.expired', orderIdentifier);
+      }
+    }, 1000);
+  },
 
   getValidationRules() {
     let firstNameValidation = {

--- a/app/models/order.js
+++ b/app/models/order.js
@@ -22,6 +22,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   brand          : attr('string'),
   last4          : attr('string'),
   paidVia        : attr('string'),
+  createdAt      : attr('moment', { readOnly: true }),
   completedAt    : attr('moment', { readOnly: true }),
   discountCodeId : attr('string'),
   /**

--- a/app/routes/orders/expired.js
+++ b/app/routes/orders/expired.js
@@ -8,7 +8,8 @@ export default Route.extend({
 
   model(params) {
     return this.store.findRecord('order', params.order_id, {
-      include: 'event'
+      include : 'event',
+      reload  : true
     });
   },
 

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -6,7 +6,7 @@
     <div class="ui yellow inverted segment">
       <div class="ui inverted small horizontal statistic">
         <div class="value">
-          8:48
+          {{getRemainingTime}}
         </div>
         <div class="label">
           {{t 'Please complete registration within 10:00 minutes.'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add timer to orders form to indicate time remaining for order to expire.

#### Changes proposed in this pull request:
- Add necessary variables and function to achieve the functionality.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1450 
Part of #750 
