### PR TITLE
Display login signup modal if user is not logged in before ordering tickets

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -42,6 +42,10 @@ export default Component.extend(FormMixin, {
       }
     },
     placeOrder() {
+      if (!this.get('session.isAuthenticated')) {
+        this.set('isLoginModalOpen', true);
+        return;
+      }
       let order = this.get('order');
       let event = order.get('event');
       order.tickets.forEach(ticket => {

--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -49,5 +49,12 @@ export default Route.extend({
 
       attendees: []
     };
+  },
+  resetController(controller) {
+    this._super(...arguments);
+    const model = controller.get('model.order');
+    if (!model.id) {
+      model.unloadRecord();
+    }
   }
 });

--- a/app/templates/components/modals/login-signup-modal.hbs
+++ b/app/templates/components/modals/login-signup-modal.hbs
@@ -3,7 +3,11 @@
   {{t 'Login or Signup'}}
 </div>
 <div class="content">
-  <h4 class="ui header">{{t 'Please Login or Signup before you can submit a proposal.'}}</h4>
+  {{#if (eq session.currentRouteName 'public.cfs.index')}}
+    <h4 class="ui header">{{t 'Please Login or Signup before you can submit a proposal.'}}</h4>
+  {{else if (eq session.currentRouteName 'public.index')}}
+    <h4 class="ui header">{{t 'Please Login or Signup before you can place an order.'}}</h4>
+  {{/if}}
   <div>
     {{#link-to 'login' class='ui teal button' invokeAction=(action 'toggleView')}}
       {{t 'Login'}}

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -104,3 +104,5 @@
     </div>
   </div>
 </form>
+
+{{modals/login-signup-modal isOpen=isLoginModalOpen}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently if user is not logged in before ordering tickets then it throws an error.

#### Changes proposed in this pull request:
- Force user to be logged in before ordering tickets.
- Render login signup modal before if user is not logged in.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1355 
