### PR TITLE
feat: Complete the integration of Facebook login

### DIFF
--- a/app/components/forms/login-form.js
+++ b/app/components/forms/login-form.js
@@ -1,11 +1,14 @@
 import Component from '@ember/component';
 import FormMixin from 'open-event-frontend/mixins/form';
+import { inject as service } from '@ember/service';
 
 export default Component.extend(FormMixin, {
 
   identification : '',
   password       : '',
   isLoading      : false,
+  torii          : service(),
+
 
   getValidationRules() {
     return {
@@ -80,11 +83,28 @@ export default Component.extend(FormMixin, {
 
     async auth(provider) {
       try {
-        let response = await this.get('loader').load(`/auth/oauth/${  provider}`);
-        if (response.url.length > 0) {
-          this.get('notify').success(this.get('l10n').t('URL received'));
-        } else {
-          this.get('notify').error(this.get('l10n').t('URL not received'));
+        if (provider === 'facebook') {
+          this.get('torii').open('facebook').then(authData => {
+            this.get('loader').load(`/auth/oauth/login/${  provider  }/${  authData.authorizationCode  }/?redirect_uri=${  authData.redirectUri}`)
+              .then(async response => {
+                let credentials = {
+                  'identification' : response.email,
+                  'password'       : response.facebook_login_hash
+                };
+
+                let authenticator = 'authenticator:jwt';
+                this.get('session')
+                  .authenticate(authenticator, credentials)
+                  .then(async() => {
+                    const tokenPayload = this.get('authManager').getTokenPayload();
+                    if (tokenPayload) {
+                      this.get('authManager').persistCurrentUser(
+                        await this.get('store').findRecord('user', tokenPayload.identity)
+                      );
+                    }
+                  });
+              });
+          });
         }
       } catch (error) {
         this.get('notify').error(this.get('l10n').t(error.message));

--- a/app/torii-providers/facebook.js
+++ b/app/torii-providers/facebook.js
@@ -1,0 +1,14 @@
+import facebookConnect from 'torii/providers/facebook-oauth2';
+import { inject } from '@ember/service';
+import { configurable } from 'torii/configuration';
+import { alias } from '@ember/object/computed';
+
+export default facebookConnect.extend({
+  settings: inject(),
+
+  clientId: alias('settings.fbClientId'),
+
+  redirectUri: configurable('redirectUri', function() {
+    return `${window.location.origin}/torii/redirect.html`;
+  })
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Integrates the facebook login feature with the FE.

#### Changes proposed in this pull request:

- Use torii and the endpoint `/oauth/login/<provider>/<auth_code>/` to login a user via facebook


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1449 
