### PR TITLE
feat: Save custom forms from Order-form tab

### DIFF
--- a/app/controllers/events/view/tickets/order-form.js
+++ b/app/controllers/events/view/tickets/order-form.js
@@ -1,0 +1,30 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  /**
+   * Save the forms.
+   */
+  async saveForms(data) {
+    for (const customForm of data.customForms ? data.customForms.toArray() : []) {
+      await customForm.save();
+    }
+    return data;
+  },
+
+  actions: {
+    save(data) {
+      this.set('isLoading', true);
+      this.saveForms(data)
+        .then(() => {
+          this.get('notify').success(this.get('l10n').t('Your Attendee form has been saved'));
+        })
+        .catch(e => {
+          console.error(e);
+          this.get('notify').error(this.get('l10n').t('Oops something went wrong. Please try again'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
+    }
+  }
+});

--- a/app/helpers/spaces-to-hyphens.js
+++ b/app/helpers/spaces-to-hyphens.js
@@ -1,0 +1,12 @@
+import Helper from '@ember/component/helper';
+
+/**
+ * Helper to make a string lower case and convert spaces into hyphens for URLs
+ * @param params
+ * @returns {*}
+ */
+export function spacesToHyphens(params) {
+  return params[0].toLowerCase().split(' ').join('-');
+}
+
+export default Helper.helper(spacesToHyphens);

--- a/app/mixins/custom-form.js
+++ b/app/mixins/custom-form.js
@@ -268,35 +268,9 @@ export default Mixin.create(MutableArray, {
   getCustomAttendeeForm(parent) {
     return [
       this.store.createRecord('custom-form', {
-        fieldIdentifier : 'firstName',
-        form            : 'attendee',
-        type            : 'text',
-        isRequired      : true,
-        isIncluded      : true,
-        isFixed         : true,
-        event           : parent
-      }),
-      this.store.createRecord('custom-form', {
-        fieldIdentifier : 'lastName',
-        form            : 'attendee',
-        type            : 'text',
-        isRequired      : true,
-        isIncluded      : true,
-        isFixed         : true,
-        event           : parent
-      }),
-      this.store.createRecord('custom-form', {
         fieldIdentifier : 'gender',
         form            : 'attendee',
         type            : 'text',
-        isRequired      : false,
-        isIncluded      : false,
-        event           : parent
-      }),
-      this.store.createRecord('custom-form', {
-        fieldIdentifier : 'email',
-        form            : 'attendee',
-        type            : 'email',
         isRequired      : false,
         isIncluded      : false,
         event           : parent

--- a/app/routes/events/view/tickets/order-form.js
+++ b/app/routes/events/view/tickets/order-form.js
@@ -1,16 +1,14 @@
 import Route from '@ember/routing/route';
 import CustomFormMixin from 'open-event-frontend/mixins/custom-form';
+import { A } from '@ember/array';
 
 export default Route.extend(CustomFormMixin, {
   titleToken() {
     return this.get('l10n').t('Order Form');
   },
   actions: {
-    /**
-     * Save the forms.
-     */
-    save() {
-      // save the forms.
+    async save(data) {
+      this.sendAction('save', data);
     }
   },
   async model() {
@@ -19,20 +17,35 @@ export default Route.extend(CustomFormMixin, {
       op   : 'eq',
       val  : 'attendee'
     }];
-    return {
-      customForms: await this.modelFor('events.view').query('customForms', {
-        filter       : filterOptions,
-        sort         : 'field-identifier',
-        'page[size]' : 50
-      })
+
+    let data = {
+      event: this.modelFor('events.view')
     };
+    data.customForms = await data.event.query('customForms', {
+      filter       : filterOptions,
+      sort         : 'id',
+      'page[size]' : 50
+    });
+
+    return data;
   },
-  afterModel(model) {
+  afterModel(data) {
     /**
-     * Create the custom forms if no form exists.
+     * Create the additional custom forms if only the compulsory forms exist.
      */
-    if (model.customForms.length === 0) {
-      model.customForms = this.getCustomAttendeeForm(this.modelFor('events.view').get('event'));
+    if (data.customForms.length === 3) {
+      let customForms = A();
+      for (const customForm of data.customForms ? data.customForms.toArray() : []) {
+        customForms.pushObject(customForm);
+      }
+
+      const createdCustomForms = this.getCustomAttendeeForm(data.event);
+
+      for (const customForm of createdCustomForms ? createdCustomForms : []) {
+        customForms.pushObject(customForm);
+      }
+
+      data.customForms = customForms;
     }
   }
 });

--- a/app/templates/components/event-info.hbs
+++ b/app/templates/components/event-info.hbs
@@ -1,0 +1,13 @@
+<div class="ui segments">
+  <div class="ui secondary segment">
+    <h3 class="weight-400">{{t 'When & Where'}}</h3>
+  </div>
+  <div class="ui padded segment">
+    {{data.event.locationName}}
+    <br>
+    {{header-date model.event.startsAt}} - {{header-date model.event.endsAt}}
+  </div>
+  <div class="ui padded segment">
+    <a href="{{data.event.url}}">{{t 'Go to event'}}</a>
+  </div>
+</div>

--- a/app/templates/components/order-summary.hbs
+++ b/app/templates/components/order-summary.hbs
@@ -1,0 +1,80 @@
+<div class="ui segments">
+  {{#if (eq session.currentRouteName 'orders.view')}}
+    <div class="ui green inverted segment">
+      <div class="ui inverted mini statistic horizontal">
+        <div class="value">
+          Success
+        </div>
+        <div class="label">
+          {{t 'Your order completed successfully.'}}
+          <br>
+          {{t 'Find all the details related to your order below.'}}
+        </div>
+      </div>
+    </div>
+  {{/if}}
+  <div class="ui secondary segment">
+    <h3 class="weight-400">{{t 'Order Summary'}}</h3>
+  </div>
+  {{#if (or (eq session.currentRouteName 'orders.new') (eq session.currentRouteName 'orders.view'))}}
+    <table class="ui very basic tablet stackable table order-summary">
+      <thead>
+        <tr>
+          <th class="four wide">{{t 'Ticket Type'}}</th>
+          <th class="four wide">{{t 'Price'}}</th>
+          <th class="ui aligned two wide">{{t 'Fee'}}</th>
+          <th class="one wide">{{t 'Quantity'}}</th>
+          <th class="ui aligned two wide">{{t 'Subtotal'}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each data.tickets as |ticket|}}
+          <tr>
+            <td>
+              <div class="ui small">
+                {{ticket.name}}
+              </div>
+            </td>
+            <td>$ {{number-format ticket.price}}</td>
+            <td>$ {{number-format ticket.price}}</td>
+            <td>{{ticket.attendees.length}}</td>
+            <td>
+              $ {{number-format (mult ticket.attendees.length ticket.price)}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+      <tfoot class="full-width">
+        <tr>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th>
+            <div class="ui aligned small primary icon">
+              {{t 'Order Total'}}:
+            </div>
+          </th>
+          <th colspan="4">
+            <div class="ui aligned small primary icon">
+              $ {{number-format total}}
+            </div>
+          </th>
+        </tr>
+      </tfoot>
+    </table>
+  {{/if}}
+</div>
+{{#if (eq session.currentRouteName 'orders.expired')}}
+  <div class="ui orange inverted segment">
+    <div class="ui inverted mini statistic horizontal">
+      <div class="value">
+        Expired
+      </div>
+      <div class="label">
+        {{t 'Your order expired because you did not complete regsitration in time.'}}
+        <br>
+        {{t 'Please click on event link given right to order your tickets again.'}}
+      </div>
+    </div>
+  </div>
+{{/if}}

--- a/app/templates/events/view/tickets/order-form.hbs
+++ b/app/templates/events/view/tickets/order-form.hbs
@@ -1,7 +1,7 @@
 {{#if device.isMobile }}
   <div class="ui hidden divider"></div>
 {{/if}}
-<div class="ui stackable grid">
+<div class="ui stackable grid {{if isLoading 'loading'}}">
   <div class="row">
     <h2 class="ui header {{if device.isTablet 'nine' 'eleven'}} wide column left floated">{{t 'Order Form'}}</h2>
   </div>

--- a/app/templates/events/view/tickets/order-form.hbs
+++ b/app/templates/events/view/tickets/order-form.hbs
@@ -57,7 +57,7 @@
     </table>
 
     <div class="ui buttons {{if device.isMobile 'fluid' 'right floated large'}}">
-      <button class="blue ui right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'save'}}>
+      <button class="blue ui right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'save' model}}>
         {{t 'Save'}}
         <i class="save icon"></i>
       </button>

--- a/app/templates/public/sessions/index.hbs
+++ b/app/templates/public/sessions/index.hbs
@@ -1,0 +1,8 @@
+{{#each model.tracks as |track|}}
+  <h3 class="ui header">{{track.name}}</h3>
+  {{#each track.sessions as |session|}}
+    {{public/session-item session=session}}
+  {{else}}
+    <div class="ui disabled header">{{t 'No sessions exist for this track'}}</div>
+  {{/each}}
+{{/each}}

--- a/tests/integration/components/event-info-test.js
+++ b/tests/integration/components/event-info-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | event info', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{event-info}}`);
+    assert.ok(this.element.textContent.trim(), 'event-info');
+  });
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Right now the forms aren't saved in the order-form section. Add functionality to that.

#### Changes proposed in this pull request:
Added functionality to save the custom forms from the Orderf-form tab.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1466 
