### PR TITLE
Sort event types and event locations alphabetically on footer of homepage

### DIFF
--- a/app/components/footer-main.js
+++ b/app/components/footer-main.js
@@ -11,5 +11,19 @@ export default Component.extend({
     switchLanguage(locale) {
       this.get('l10n').switchLanguage(locale);
     }
+  },
+
+  didInsertElement() {
+    this.set('eventLocations', this.get('eventLocations').sortBy('name'));
+
+    let eventTypes = this.get('eventTypes').sortBy('name').toArray();
+    eventTypes.forEach(eventType => {
+      if (eventType.name === 'Other') {
+        let other = eventType;
+        eventTypes.splice(eventTypes.indexOf(eventType), 1);
+        eventTypes.push(other);
+      }
+    });
+    this.set('eventTypes', eventTypes);
   }
 });

--- a/tests/integration/components/footer-main-test.js
+++ b/tests/integration/components/footer-main-test.js
@@ -6,8 +6,33 @@ import { render } from '@ember/test-helpers';
 module('Integration | Component | footer main', function(hooks) {
   setupIntegrationTest(hooks);
 
+  const eventLocations = [
+    {
+      name : 'Berlin',
+      slug : 'berlin'
+    },
+    {
+      name : 'New Delhi',
+      slug : 'new-delhi'
+    }
+  ];
+
+  const eventTypes = [
+    {
+      name : 'Conference',
+      slug : 'conference'
+    },
+    {
+      name : 'Meetup',
+      slug : 'meetup'
+    }
+  ];
+
+
   test('it renders', async function(assert) {
-    await render(hbs`{{footer-main l10n=l10n}}`);
+    this.set('eventTypes', eventTypes);
+    this.set('eventLocations', eventLocations);
+    await render(hbs`{{footer-main l10n=l10n eventLocations=eventLocations eventTypes=eventTypes}}`);
     assert.ok(this.element.innerHTML.trim().includes('footer'));
   });
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently event types and event locations on home page are not sorted. This looks weird.

#### Changes proposed in this pull request:
Sort them alphabetically.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1488 
