### PR TITLE
Add settings user link to admin/users

### DIFF
--- a/app/controllers/admin/users.js
+++ b/app/controllers/admin/users.js
@@ -5,7 +5,8 @@ import { computed } from '@ember/object';
 export default Controller.extend({
   onSessionRoute: computed('routing.currentRouteName', function() {
     let currentRouteName = this.get('routing.currentRouteName');
-    return (currentRouteName !== 'admin.users.view.index' && currentRouteName !== 'admin.users.view.sessions.list' && currentRouteName !== 'admin.users.view.events.list');
+    const routes = ['admin.users.view.index', 'admin.users.view.sessions.list', 'admin.users.view.events.list', 'admin.users.view.settings.contact-info', 'admin.users.view.settings.email-preferences', 'admin.users.view.settings.applications'];
+    return !routes.includes(currentRouteName);
   })
 });
 

--- a/app/controllers/admin/users/view/settings/contact-info.js
+++ b/app/controllers/admin/users/view/settings/contact-info.js
@@ -1,0 +1,21 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    updateContactInfo() {
+      this.set('isLoading', true);
+      let currentUser = this.get('model.user');
+      currentUser.save()
+        .then(() => {
+          this.get('notify').success(this.get('l10n').t('Your Contact Info has been updated'));
+        })
+        .catch(() => {
+          this.get('notify').error(this.get('l10n').t('An unexpected error occurred'));
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        });
+    }
+  }
+});
+

--- a/app/router.js
+++ b/app/router.js
@@ -141,6 +141,11 @@ router.map(function() {
         this.route('events', function() {
           this.route('list', { path: '/:event_status' });
         });
+        this.route('settings', function() {
+          this.route('applications');
+          this.route('contact-info');
+          this.route('email-preferences');
+        });
       });
       this.route('list', { path: '/:users_status' });
     });

--- a/app/routes/admin/users/view/settings.js
+++ b/app/routes/admin/users/view/settings.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken() {
+    return this.get('l10n').t('Settings');
+  },
+  model() {
+    const currentUser = this.modelFor('admin.users.view');
+    return {
+      user: currentUser
+    };
+  }
+});

--- a/app/routes/admin/users/view/settings/applications.js
+++ b/app/routes/admin/users/view/settings/applications.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken() {
+    return this.get('l10n').t('Applications');
+  }
+});

--- a/app/routes/admin/users/view/settings/contact-info.js
+++ b/app/routes/admin/users/view/settings/contact-info.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model() {
+    const currentUser = this.modelFor('admin.users.view');
+    return {
+      user: currentUser
+    };
+  }
+});

--- a/app/routes/admin/users/view/settings/email-preferences.js
+++ b/app/routes/admin/users/view/settings/email-preferences.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken() {
+    return this.get('l10n').t('Email Preferences');
+  },
+  model() {
+    const currentUser = this.modelFor('admin.users.view');
+    return currentUser.query('emailNotifications', { include: 'event' });
+  }
+});

--- a/app/templates/admin/users/view/settings.hbs
+++ b/app/templates/admin/users/view/settings.hbs
@@ -1,0 +1,21 @@
+<div class="ui container">
+  <h1 class="ui header">{{t 'Settings'}}</h1>
+  <div class="ui grid">
+    <div class="row">
+      <div class="twelve wide column">
+        {{#tabbed-navigation}}
+          {{#link-to 'admin.users.view.settings.contact-info' model.user.id class='item'}}
+            {{t 'Contact Info'}}
+          {{/link-to}}
+          {{#link-to 'admin.users.view.settings.email-preferences' model.user.id class='item'}}
+            {{t 'Email-Preferences'}}
+          {{/link-to}}
+          {{#link-to 'admin.users.view.settings.applications' model.user.id class='item'}}
+            {{t 'Applications'}}
+          {{/link-to}}
+        {{/tabbed-navigation}}
+      </div>
+    </div>
+    {{outlet}}
+  </div>
+</div>

--- a/app/templates/admin/users/view/settings/applications.hbs
+++ b/app/templates/admin/users/view/settings/applications.hbs
@@ -1,0 +1,1 @@
+{{settings/application-section}}

--- a/app/templates/admin/users/view/settings/contact-info.hbs
+++ b/app/templates/admin/users/view/settings/contact-info.hbs
@@ -1,0 +1,1 @@
+{{settings/contact-info-section data=model.user submit='updateContactInfo' isLoading=isLoading}}

--- a/app/templates/admin/users/view/settings/email-preferences.hbs
+++ b/app/templates/admin/users/view/settings/email-preferences.hbs
@@ -1,0 +1,1 @@
+{{settings/email-preferences-section preferences=model}}

--- a/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
@@ -9,6 +9,6 @@
     <a href='#' target='_blank' rel='noopener'>{{t 'Tickets'}}</a>
   </div>
   <div class="item">
-    <a href='#' target='_blank' rel='noopener'>{{t 'Settings'}}</a>
+    {{#link-to 'admin.users.view.settings.contact-info' record.id}} {{t 'Settings'}} {{/link-to}}
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The settings user link in the admin/users was not working

#### Changes proposed in this pull request:

- Make the settings user-link to redirect to the info about the user.
- Add routes for the settings user link displaying contact-info, notifications of the user in the row.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1293 
