### PR TITLE
Add a route for tickets user link in admin/users

### DIFF
--- a/app/controllers/admin/users.js
+++ b/app/controllers/admin/users.js
@@ -5,7 +5,7 @@ import { computed } from '@ember/object';
 export default Controller.extend({
   onSessionRoute: computed('routing.currentRouteName', function() {
     let currentRouteName = this.get('routing.currentRouteName');
-    const routes = ['admin.users.view.index', 'admin.users.view.sessions.list', 'admin.users.view.events.list', 'admin.users.view.settings.contact-info', 'admin.users.view.settings.email-preferences', 'admin.users.view.settings.applications'];
+    const routes = ['admin.users.view.index', 'admin.users.view.sessions.list', 'admin.users.view.tickets.list', 'admin.users.view.events.list', 'admin.users.view.settings.contact-info', 'admin.users.view.settings.email-preferences', 'admin.users.view.settings.applications'];
     return !routes.includes(currentRouteName);
   })
 });

--- a/app/router.js
+++ b/app/router.js
@@ -147,6 +147,9 @@ router.map(function() {
           this.route('contact-info');
           this.route('email-preferences');
         });
+        this.route('tickets', function() {
+          this.route('list', { path: '/:tickets_status' });
+        });
       });
       this.route('list', { path: '/:users_status' });
     });

--- a/app/routes/admin/users/view/tickets.js
+++ b/app/routes/admin/users/view/tickets.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken() {
+    return this.get('l10n').t('My Tickets');
+  }
+});

--- a/app/routes/admin/users/view/tickets/index.js
+++ b/app/routes/admin/users/view/tickets/index.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  titleToken() {
+    return this.get('l10n').t('Upcoming');
+  },
+  beforeModel() {
+    this._super(...arguments);
+    this.transitionTo('admin.users.view.tickets.list', 'upcoming');
+  }
+});

--- a/app/routes/admin/users/view/tickets/list.js
+++ b/app/routes/admin/users/view/tickets/list.js
@@ -1,0 +1,21 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken() {
+    switch (this.get('params.tickets_status')) {
+      case 'upcoming':
+        return this.get('l10n').t('Upcoming');
+      case 'past':
+        return this.get('l10n').t('Past');
+      case 'saved':
+        return this.get('l10n').t('Saved');
+    }
+  },
+  model() {
+    const userDetails = this.modelFor('admin.users.view');
+    return this.store.findRecord('user', userDetails.id, {
+      include: 'orders,events'
+    });
+  }
+});

--- a/app/templates/admin/users/view/tickets.hbs
+++ b/app/templates/admin/users/view/tickets.hbs
@@ -1,0 +1,21 @@
+<div class="ui grid">
+  <div class="row">
+    <div class="sixteen wide column">
+      <h1>
+        {{t 'My tickets'}}
+      </h1>
+      {{#tabbed-navigation}}
+        {{#link-to 'admin.users.view.tickets.list' 'upcoming' class='item'}}
+          {{t 'Upcoming Events'}}
+        {{/link-to}}
+        {{#link-to 'admin.users.view.tickets.list' 'saved' class='item'}}
+          {{t 'Saved Events'}}
+        {{/link-to}}
+        {{#link-to 'admin.users.view.tickets.list' 'past' class='item'}}
+          {{t 'Past Events'}}
+        {{/link-to}}
+      {{/tabbed-navigation}}
+    </div>
+  </div>
+  {{outlet}}
+</div>

--- a/app/templates/admin/users/view/tickets/list.hbs
+++ b/app/templates/admin/users/view/tickets/list.hbs
@@ -1,0 +1,11 @@
+<div class="row">
+  <div class="sixteen wide column">
+    {{#each model.orders as |order|}}
+      {{#order-card order=order}}
+      {{/order-card}}
+      <div class="ui hidden divider"></div>
+    {{else}}
+      <div class="ui disabled header">{{t 'No tickets found for this user'}}</div>
+    {{/each}}
+  </div>
+</div>

--- a/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
@@ -6,7 +6,7 @@
     {{#link-to 'admin.users.view.events' record.id}} {{t 'Events'}} {{/link-to}}
   </div>
   <div class="item">
-    <a href='#' target='_blank' rel='noopener'>{{t 'Tickets'}}</a>
+    {{#link-to 'admin.users.view.tickets' record.id}} {{t 'Tickets'}} {{/link-to}}
   </div>
   <div class="item">
     {{#link-to 'admin.users.view.settings.contact-info' record.id}} {{t 'Settings'}} {{/link-to}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The tickets user link in admin/users redirected nowhere.


#### Changes proposed in this pull request:

- Adds a route for users/user_id/tickets
- Shows tickets of the user in this route.
- Will add the filtering of the tickets as per the event in a separate PR.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1514 
