### PR TITLE
Show proper error message for invalid email while resetting password

### DIFF
--- a/app/components/forms/reset-password-form.js
+++ b/app/components/forms/reset-password-form.js
@@ -76,7 +76,7 @@ export default Component.extend(FormMixin, {
               this.set('successMessage', this.get('l10n').t('Please go to the link sent to your email to reset your password'));
             })
             .catch(reason => {
-              if (reason && reason.hasOwnProperty('errors') && reason.errors[0].status === 422) {
+              if (reason && reason.hasOwnProperty('errors') && reason.errors[0].status === 404) {
                 this.set('errorMessage', this.get('l10n').t('No account is registered with this email address.'));
               } else {
                 this.set('errorMessage', this.get('l10n').t('An unexpected error occurred.'));


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR fixes the error code check which results in displaying a more specific error message when an email is not found in the server while resetting its password:

<img width="390" alt="screen shot 2018-07-29 at 11 18 53 am" src="https://user-images.githubusercontent.com/22810216/43363385-3a03548e-9321-11e8-9e46-c2ce7a2dba75.png">

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1516
