### PR TITLE
Corrects the time format in different tabs of admin panel

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -9,13 +9,13 @@ export default Controller.extend({
     {
       propertyName : 'startsAt',
       template     : 'components/ui-table/cell/cell-simple-date',
-      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat   : 'MMMM DD, YYYY - hh:mm A',
       title        : 'Starts At'
     },
     {
       propertyName : 'endsAt',
       template     : 'components/ui-table/cell/cell-simple-date',
-      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat   : 'MMMM DD, YYYY - hh:mm A',
       title        : 'Ends At'
     },
     {

--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -25,19 +25,19 @@ export default Controller.extend({
     {
       propertyName : 'submittedAt',
       template     : 'components/ui-table/cell/cell-simple-date',
-      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat   : 'MMMM DD, YYYY - hh:mm A',
       title        : 'Submitted At'
     },
     {
       propertyName : 'startsAt',
       template     : 'components/ui-table/cell/cell-simple-date',
-      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat   : 'MMMM DD, YYYY - hh:mm A',
       title        : 'Starts At'
     },
     {
       propertyName : 'endsAt',
       template     : 'components/ui-table/cell/cell-simple-date',
-      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat   : 'MMMM DD, YYYY - hh:mm A',
       title        : 'Ends At'
     },
     {

--- a/app/controllers/admin/users/list.js
+++ b/app/controllers/admin/users/list.js
@@ -52,7 +52,7 @@ export default Controller.extend({
       propertyName     : 'lastAccessedAt',
       title            : 'Last Accessed',
       template         : 'components/ui-table/cell/cell-simple-date',
-      dateFormat       : 'MMMM DD, YYYY - HH:mm A',
+      dateFormat       : 'MMMM DD, YYYY - hh:mm A',
       disableSorting   : true,
       disableFiltering : true
     },


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Corrects the time format in sessions, users, and events tabs of the admin panel.

#### Changes proposed in this pull request:

- Changes 24-hour format to 12-hour format.

Screenshot:
![screenshot_2018-07-29 session sessions administration open event 1](https://user-images.githubusercontent.com/21157929/43364816-96b39bee-933f-11e8-8109-f7c9cd6f1859.png)

Fixes #1520 