### PR TITLE
Add bank,cheque and onsite as payment options in order from

### DIFF
--- a/app/controllers/orders/new.js
+++ b/app/controllers/orders/new.js
@@ -6,11 +6,11 @@ export default Controller.extend({
       try {
         this.set('isLoading', true);
         let order = data;
-        let { attendees } = data;
+        let { attendees, paymentMode } = data;
         for (const attendee of attendees ? attendees.toArray() : []) {
           await attendee.save();
         }
-        if (order.get('paymentMode') === 'free') {
+        if (paymentMode === 'free' || paymentMode === 'bank' || paymentMode === 'cheque' || paymentMode === 'onsite') {
           order.set('status', 'completed');
         } else {
           order.set('status', 'placed');

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -53,6 +53,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   isTaxEnabled    : attr('boolean', { defaultValue: false }),
   canPayByPaypal  : attr('boolean', { defaultValue: false }),
   canPayByStripe  : attr('boolean', { defaultValue: false }),
+  isStripeLinked  : attr('boolean'),
   canPayByCheque  : attr('boolean', { defaultValue: false }),
   canPayByBank    : attr('boolean', { defaultValue: false }),
   canPayOnsite    : attr('boolean', { defaultValue: false }),

--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -72,15 +72,33 @@
         <div class="field disabled">
           <label for="payment_mode">{{t 'Payment Mode'}}</label>
           <div class="grouped inline fields">
-            <div class="field disabled">
+            <div class="field">
               {{ui-radio name='payment_mode' label='stripe' value='stripe' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
               <label for="payment_mode"><img class="ui small image" src="/images/payment-logos/stripe.png" alt="stripe"></label>
             </div>
-            <div class="field disabled">
+            <div class="field">
               {{ui-radio name='payment_mode' label='paypal' value='paypal' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
               <label for="payment_mode"><img src="/images/payment-logos/paypal.png" alt="paypal"></label>
             </div>
+            <div class="field">
+              {{ui-radio name='payment_mode' label=(t 'Cheque') value='cheque' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+            </div>
+            <div class="field">
+              {{ui-radio name='payment_mode' label=(t 'Bank') value='bank' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+            </div>
+            <div class="field">
+              {{ui-radio name='payment_mode' label=(t 'Onsite') value='onsite' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+            </div>
           </div>
+        </div>
+        <div class="field disabled">
+          {{#if (eq data.paymentMode 'bank')}}
+            {{textarea name="payment_details" value=data.event.bankDetails readonly=""}}
+          {{else if (eq data.paymentMode 'cheque')}}
+            {{textarea name="payment_details" value=data.event.chequeDetails readonly=""}}
+          {{else if (eq data.paymentMode 'onsite')}}
+            {{textarea name="payment_details" value=data.event.onsiteDetails readonly=""}}
+          {{/if}}
         </div>
       {{/if}}
     </div>

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -121,15 +121,43 @@
         <div class="field">
           <label class="required" for="payment_mode">{{t 'Payment Mode'}}</label>
           <div class="grouped inline fields">
-            <div class="field">
-              {{ui-radio name='payment_mode' label='stripe' value='stripe' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-              <label for="payment_mode"><img class="ui small image" src="/images/payment-logos/stripe.png" alt="stripe"></label>
-            </div>
-            <div class="field">
-              {{ui-radio name='payment_mode' label='paypal' value='paypal' current=data.paymantMode onChange=(action (mut data.paymentMode))}}
-              <label for="payment_mode"><img src="/images/payment-logos/paypal.png" alt="paypal"></label>
-            </div>
+            {{#if data.event.isStripeLinked}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Stripe') value='stripe' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+                <label for="payment_mode"><img class="ui small image" src="/images/payment-logos/stripe.png" alt="stripe"></label>
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByPaypal}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Paypal') value='paypal' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+                <label for="payment_mode"><img src="/images/payment-logos/paypal.png" alt="paypal"></label>
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByCheque}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Cheque') value='cheque' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByBank}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Bank') value='bank' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
+            {{#if data.event.canPayOnsite}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Onsite') value='onsite' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
           </div>
+        </div>
+        <div class="field">
+          {{#if (eq data.paymentMode 'bank')}}
+            {{textarea name="payment_details" value=data.event.bankDetails readonly=""}}
+          {{else if (eq data.paymentMode 'cheque')}}
+            {{textarea name="payment_details" value=data.event.chequeDetails readonly=""}}
+          {{else if (eq data.paymentMode 'onsite')}}
+            {{textarea name="payment_details" value=data.event.onsiteDetails readonly=""}}
+          {{/if}}
         </div>
       {{/if}}
       <h4 class="ui horizontal divider header">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
 Currently only payment options supported in orders form are paypal and stripe.

#### Changes proposed in this pull request:
- Add bank, cheque and onsite as payment options if organizer has enabled them
- Add if else conditions to check if a payment option is supported.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1524 
