### PR TITLE
Add Order Page: Step 1: Fix Add order form and allow proper selection of tickets

### DIFF
--- a/app/components/ui-table/cell/events/view/tickets/cell-add-order-quantity.js
+++ b/app/components/ui-table/cell/events/view/tickets/cell-add-order-quantity.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/ui-table/cell/events/view/tickets/cell-add-order-total.js
+++ b/app/components/ui-table/cell/events/view/tickets/cell-add-order-total.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/routes/events/view/tickets/add-order.js
+++ b/app/routes/events/view/tickets/add-order.js
@@ -4,7 +4,32 @@ export default Route.extend({
   titleToken() {
     return this.get('l10n').t('Add Order');
   },
-  model() {
-    return this.modelFor('events.view').query('tickets', {});
+  async model() {
+    const eventDetails = this.modelFor('events.view');
+    return {
+      tickets: await eventDetails.query('tickets', {}),
+
+      order: await this.store.createRecord('order', {
+        event     : eventDetails,
+        user      : this.get('authManager.currentUser'),
+        tickets   : [],
+        attendees : []
+      }),
+
+      attendees: []
+    };
+  },
+  afterModel(model) {
+    let { tickets } = model;
+    tickets.forEach(ticket => {
+      ticket.set('orderQuantity', 0);
+    });
+  },
+  resetController(controller) {
+    this._super(...arguments);
+    const model = controller.get('model.order');
+    if (!model.id) {
+      model.unloadRecord();
+    }
   }
 });

--- a/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-quantity.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-quantity.hbs
@@ -1,0 +1,13 @@
+<div class="inline field">
+  {{#ui-dropdown class='compact selection' forceSelection=false onChange=(action updateOrder record) as |execute mapper|}}
+    {{input type='hidden' id=(concat record.id '_quantity') value=record.orderQuantity}}
+    <i class="dropdown icon"></i>
+    <div class="default text">0</div>
+    <div class="menu">
+      <div class="item" data-value="{{map-value mapper 0}}">0</div>
+      {{#each (range record.minOrder record.maxOrder) as |count|}}
+        <div class="item" data-value="{{map-value mapper count}}">{{count}}</div>
+      {{/each}}
+    </div>
+  {{/ui-dropdown}}
+</div>

--- a/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
@@ -1,0 +1,1 @@
+{{number-format (mult record.orderQuantity record.price)}}

--- a/app/templates/events/view/tickets/add-order.hbs
+++ b/app/templates/events/view/tickets/add-order.hbs
@@ -1,9 +1,10 @@
 <h2 class="ui header">{{t 'Add Order'}}</h2>
 <form class="ui form">
-  {{events/events-table columns=columns data=model
+  {{events/events-table columns=columns data=model.tickets
     useNumericPagination=true
     showGlobalFilter=true
     showPageSize=true
+    updateOrder=(action 'updateOrder')
   }}
   <div class="ui grid stackable">
     <div class="row">
@@ -25,7 +26,7 @@
         {{/ui-dropdown}}
       </div>
       <div class="eight wide column right aligned">
-        <button class="ui blue button" disabled= {{not hasTicketsInOrder}}>
+        <button class="ui blue button" disabled={{not hasTicketsInOrder}}>
           {{t 'Continue'}}
         </button>
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
 Currently organizer is unable to add an order from add order section of tickets tab.

#### Changes proposed in this pull request:
- Fix tickets selection table.

Part of #1292
