### PR TITLE
Corrects the value of input field when no slide is uploaded in sessio…

### DIFF
--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -218,7 +218,6 @@
                 label=(t 'File')
                 id=(if field.isRequired (concat 'session_' field.fieldIdentifier '_required') (concat 'session_' field.fieldIdentifier))
                 icon='file'
-                fileUrl=''
                 hint=(t 'Select a file')
                 maxSizeInKb=10000}}
             {{/if}}


### PR DESCRIPTION
…n speaker form

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Corrects the value of input field when no slide is uploaded in session speaker form.

#### Changes proposed in this pull request:
- Removed `fileUrl=''` parameter.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1534