### PR TITLE
Shows payment modes in attendee list only when enabled

### DIFF
--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -72,23 +72,33 @@
         <div class="field disabled">
           <label for="payment_mode">{{t 'Payment Mode'}}</label>
           <div class="grouped inline fields">
-            <div class="field">
-              {{ui-radio name='payment_mode' label='stripe' value='stripe' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-              <label for="payment_mode"><img class="ui small image" src="/images/payment-logos/stripe.png" alt="stripe"></label>
-            </div>
-            <div class="field">
-              {{ui-radio name='payment_mode' label='paypal' value='paypal' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-              <label for="payment_mode"><img src="/images/payment-logos/paypal.png" alt="paypal"></label>
-            </div>
-            <div class="field">
-              {{ui-radio name='payment_mode' label=(t 'Cheque') value='cheque' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-            </div>
-            <div class="field">
-              {{ui-radio name='payment_mode' label=(t 'Bank') value='bank' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-            </div>
-            <div class="field">
-              {{ui-radio name='payment_mode' label=(t 'Onsite') value='onsite' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
-            </div>
+            {{#if data.event.isStripeLinked}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Stripe') value='stripe' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+                <label for="payment_mode"><img class="ui small image" src="/images/payment-logos/stripe.png" alt="stripe"></label>
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByPaypal}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Paypal') value='paypal' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+                <label for="payment_mode"><img src="/images/payment-logos/paypal.png" alt="paypal"></label>
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByCheque}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Cheque') value='cheque' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
+            {{#if data.event.canPayByBank}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Bank') value='bank' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
+            {{#if data.event.canPayOnsite}}
+              <div class="field">
+                {{ui-radio name='payment_mode' label=(t 'Onsite') value='onsite' current=data.paymentMode onChange=(action (mut data.paymentMode))}}
+              </div>
+            {{/if}}
           </div>
         </div>
         <div class="field disabled">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Shows payment modes in attendee list only when enabled.

#### Changes proposed in this pull request:

- Adds if condition to check if payment mode is enabled.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1547 
