### PR TITLE
fix: Add fb auth to settings and remove non-supported auths

### DIFF
--- a/app/components/settings/application-section.js
+++ b/app/components/settings/application-section.js
@@ -1,4 +1,44 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  torii: service(),
+
+  isLoading: false,
+
+  actions: {
+    auth(provider) {
+      try {
+        if (provider === 'facebook') {
+          this.get('torii').open('facebook').then(authData => {
+            this.set('isLoading', true);
+            this.get('loader').load(`/auth/oauth/login/${  provider  }/${  authData.authorizationCode  }/?redirect_uri=${  authData.redirectUri}`)
+              .then(async response => {
+                let credentials = {
+                  'identification' : response.email,
+                  'password'       : response.facebook_login_hash
+                };
+
+                let authenticator = 'authenticator:jwt';
+                this.get('session')
+                  .authenticate(authenticator, credentials)
+                  .then(async() => {
+                    const tokenPayload = this.get('authManager').getTokenPayload();
+                    if (tokenPayload) {
+                      this.get('authManager').persistCurrentUser(
+                        await this.get('store').findRecord('user', tokenPayload.identity)
+                      );
+                      this.set('data', this.get('authManager.currentUser'));
+                    }
+                    this.set('isLoading', false);
+                  });
+              });
+          });
+        }
+      } catch (error) {
+        this.get('notify').error(this.get('l10n').t(error.message));
+        this.set('isLoading', false);
+      }
+    }
+  }
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -39,6 +39,8 @@ export default ModelBase.extend({
   twitterUrl    : attr('string'),
   googlePlusUrl : attr('string'),
 
+  facebookId: attr('string', { readOnly: true }),
+
   createdAt      : attr('moment', { readOnly: true }),
   deletedAt      : attr('moment', { readOnly: true }),
   lastAccessedAt : attr('moment', { readOnly: true }),

--- a/app/routes/settings/applications.js
+++ b/app/routes/settings/applications.js
@@ -4,5 +4,8 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default Route.extend(AuthenticatedRouteMixin, {
   titleToken() {
     return this.get('l10n').t('Applications');
+  },
+  model() {
+    return this.get('authManager.currentUser');
   }
 });

--- a/app/templates/components/forms/login-form.hbs
+++ b/app/templates/components/forms/login-form.hbs
@@ -29,9 +29,20 @@
             </div>
           </div>
           <div class="ui center aligned segment basic">
-            <button type="submit" class="ui fluid large teal submit button register">
-              {{t 'Login'}}
-            </button>
+            <div class="ui vertical buttons">
+              <button type="submit" class="ui fluid large teal submit button register">
+                {{t 'Login'}}
+              </button>
+              {{#unless noSocial}}
+                <button type="button" class="ui facebook button" {{action 'auth' 'facebook'}}>
+                  <i class="facebook icon"></i>
+                  {{t 'Login with Facebook'}}
+                </button>
+              {{/unless}}
+            </div>
+
+          </div>
+          <div class="ui center aligned segment basic">
             <a href="{{href-to 'reset-password'}}" class="text muted"> {{t 'Forgot your password ?'}}</a>
           </div>
         </div>
@@ -41,25 +52,4 @@
       </div>
     </form>
   </div>
-  {{#unless noSocial}}
-    <div class="column">
-      <div class="ui segment basic center aligned">
-        <div class="mobile hidden login-with-fb"> </div>
-        <div class="ui vertical buttons">
-          <button type="button" class="ui facebook button" {{action 'auth' 'facebook'}}>
-            <i class="facebook icon"></i>
-            {{t 'Login with Facebook'}}
-          </button>
-          <button type="button" class="ui twitter button">
-            <i class="twitter icon"></i>
-            {{t 'Login with Twitter'}}
-          </button>
-          <button type="button" class="ui google plus button">
-            <i class="google plus icon"></i>
-            {{t 'Login with Google Plus'}}
-          </button>
-        </div>
-      </div>
-    </div>
-  {{/unless}}
 </div>

--- a/app/templates/components/settings/application-section.hbs
+++ b/app/templates/components/settings/application-section.hbs
@@ -1,56 +1,11 @@
 <h4>{{t 'Facebook'}}</h4>
 <div class="ui fluid labeled action input">
-  <div class="ui label">
-    {{t 'facebook.com/'}}
-  </div>
-  {{input type='text' name='facebook'}}
-  <button class="ui {{if device.isMobile 'icon'}} blue button">
-    {{#if device.isMobile}}
-      <i class="linkify icon"></i>
-    {{else}}
-      {{t 'Connect'}}
-    {{/if}}
-  </button>
-</div>
-<h4>{{t 'Twitter'}}</h4>
-<div class="ui fluid labeled action input">
-  <div class="ui label">
-    {{t 'twitter.com/'}}
-  </div>
-  {{input type='text' name='twitter'}}
-  <button class="ui {{if device.isMobile 'icon'}} blue button">
-    {{#if device.isMobile}}
-      <i class="linkify icon"></i>
-    {{else}}
-      {{t 'Connect'}}
-    {{/if}}
-  </button>
-</div>
-<h4>{{t 'Instagram'}}</h4>
-<div class="ui fluid labeled action input">
-  <div class="ui label">
-    {{t 'instagram.com/'}}
-  </div>
-  {{input type='text' name='instagram'}}
-  <button class="ui {{if device.isMobile 'icon'}} blue button">
-    {{#if device.isMobile}}
-      <i class="linkify icon"></i>
-    {{else}}
-      {{t 'Connect'}}
-    {{/if}}
-  </button>
-</div>
-<h4>{{t 'Google+'}}</h4>
-<div class="ui fluid labeled action input">
-  <div class="ui label">
-    {{t 'plus.google.com/'}}
-  </div>
-  {{input type='text' name='google'}}
-  <button class="ui {{if device.isMobile 'icon'}} blue button">
-    {{#if device.isMobile}}
-      <i class="linkify icon"></i>
-    {{else}}
-      {{t 'Connect'}}
-    {{/if}}
-  </button>
+  {{#if data.facebookId}}
+    {{t 'Successfully linked with Facebook'}}
+  {{else}}
+    <button type="button" class="ui facebook button {{if isLoading 'loading'}}" {{action 'auth' 'facebook'}}>
+      <i class="facebook icon"></i>
+      {{t 'Connect with Facebook'}}
+    </button>
+  {{/if}}
 </div>

--- a/app/templates/settings/applications.hbs
+++ b/app/templates/settings/applications.hbs
@@ -1,1 +1,1 @@
-{{settings/application-section}}
+{{settings/application-section data=model}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds Facebook connect option to user -> settings. Removes unsupported auths from login and settings page

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1556 
