### PR TITLE
Use the events order expiry time instead of hardcoded 10 minutes

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -35,7 +35,8 @@ export default Component.extend(FormMixin, {
   sameAsBuyer: false,
 
   getRemainingTime: computed('data', function() {
-    let willExpireAt = this.get('data.createdAt').add(10, 'minutes');
+    let orderExpiryTime = this.get('data.event.orderExpiryTime');
+    let willExpireAt = this.get('data.createdAt').add(orderExpiryTime, 'minutes');
     this.timer(willExpireAt, this.get('data.identifier'));
   }),
 

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -9,9 +9,9 @@
           {{getRemainingTime}}
         </div>
         <div class="label">
-          {{t 'Please complete registration within 10:00 minutes.'}}
+          {{t 'Please complete registration within '}} {{data.event.orderExpiryTime}} {{t 'minutes.'}}
           <br>
-          {{t 'After 10:00 minutes, the reservation we\'re holding will be released to others.'}}
+          {{t 'After '}} {{data.event.orderExpiryTime}} {{t 'minutes, the reservation we\'re holding will be released to others.'}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Right now we use the hardcoded 10 minutes set as the order expiry time. We should now use the order expiry time set by the event organizer.

#### Changes proposed in this pull request:
- Change hardcoded value to orderExpiryTime.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1540 
