### PR TITLE
fix: Tabs in admin->settings part is not correctly highlighted

### DIFF
--- a/app/routes/admin/settings/images.js
+++ b/app/routes/admin/settings/images.js
@@ -13,9 +13,8 @@ export default Route.extend({
   },
   actions: {
     willTransition() {
-      this.get('controller.model').forEach(image => {
-        image.rollbackAttributes();
-      });
+      this.get('controller.model.speakerImageSize').rollbackAttributes();
+      this.get('controller.model.eventImageSize').rollbackAttributes();
     }
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Properly highlight tabs in admin -> settings.

#### Changes proposed in this pull request:

- Fix the improper method used to rollback attributes in `willTransition()` method of admin->settings->images route.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1589 
