### PR TITLE
Promotional Codes: Step 1: Allow users to apply access code to orders

### DIFF
--- a/app/models/access-code.js
+++ b/app/models/access-code.js
@@ -18,6 +18,7 @@ export default ModelBase.extend({
   event    : belongsTo('event', {
     inverse: 'accessCodes'
   }), // The event that this access code belongs to
+  orders: hasMany('order'),
 
   /**
    * Computed properties

--- a/app/models/order.js
+++ b/app/models/order.js
@@ -32,6 +32,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   user           : belongsTo('user'),
   event          : belongsTo('event'),
   discountCode   : belongsTo('discount-code'),
+  accessCode     : belongsTo('access-code'),
   tickets        : hasMany('ticket', { readOnly: true }),
   attendees      : hasMany('attendee')
 });

--- a/app/routes/public.js
+++ b/app/routes/public.js
@@ -7,6 +7,8 @@ export default Route.extend({
   },
 
   model(params) {
-    return this.store.findRecord('event', params.event_id, { include: 'social-links,event-copyright' });
+    return this.store.findRecord('event', params.event_id, {
+      include: 'social-links,event-copyright'
+    });
   }
 });

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -65,10 +65,12 @@
         <div class="{{if device.isBiggerThanTablet 'right floated eight wide'}} column">
           <div class="field">
             <div class="ui action fluid input">
-              {{input type='text' name='promotional_code' placeholder=(t 'Promotional Code')}}
-              <div role="button" class="ui icon button" {{action 'applyPromotionalCode'}}>
-                <i class="checkmark icon"></i>
-              </div>
+              {{input type='text' name='promotional_code' value=promotionalCode placeholder=(t 'Promotional Code') readonly=promotionalCodeApplied}}
+              {{#unless promotionalCodeApplied}}
+                <div role="button" class="ui icon button" {{action 'applyPromotionalCode'}}>
+                  <i class="checkmark icon"></i>
+                </div>
+              {{/unless}}
               <div role="button" class="ui black icon button" {{action 'togglePromotionalCode'}}>
                 <i class="remove icon"></i>
               </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently users cannot apply discount codes and access codes to their orders.

#### Changes proposed in this pull request:
- As step 1 of this functionality allow users to apply access codes.

Part of #1558 
