### PR TITLE
Adds file-upload widget to edit-session form

### DIFF
--- a/app/components/widgets/forms/file-upload.js
+++ b/app/components/widgets/forms/file-upload.js
@@ -58,7 +58,7 @@ export default Component.extend({
       }
     },
     removeSelection() {
-      if (!this.get('needsConfirmation')) {
+      if (!this.get('needsConfirmation') || this.get('edit') === true) {
         this.set('selectedFile', null);
         this.set('fileUrl', null);
       } else {

--- a/app/templates/components/forms/events/view/edit-session.hbs
+++ b/app/templates/components/forms/events/view/edit-session.hbs
@@ -13,7 +13,13 @@
   </div>
   <div class="field">
     <label>{{t 'Slides'}}</label>
-    {{input type='text' value=data.slidesUrl}}
+    {{widgets/forms/file-upload
+      fileUrl=(mut data.slidesUrl)
+      label=(t 'File')
+      icon='file'
+      hint=(t 'Select a file')
+      maxSizeInKb=10000
+      edit=true}}
   </div>
   <button type="submit" class="ui teal submit button update-changes">
     {{t 'Save Session'}}

--- a/app/templates/components/widgets/forms/file-upload.hbs
+++ b/app/templates/components/widgets/forms/file-upload.hbs
@@ -2,7 +2,7 @@
   {{#if fileUrl}}
     <div class="ui action input">
       {{input type='url' readonly="" value=fileUrl}}
-      <button class="ui icon red button" {{action 'removeSelection'}}>
+      <button class="ui icon red button" {{action (confirm (t 'Are you sure want to remove this slide?') (action 'removeSelection' edit))}}>
         <i class="remove icon"></i>
         {{t 'Remove file'}}
       </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds the file-upload widget to edit-session form.

#### Changes proposed in this pull request:
- Adds the file-upload widget to edit-session form similar to create session-speaker form.

Fixes #1536 