### PR TITLE
fix: Button title not showing for Sessions

### DIFF
--- a/app/models/notification-action.js
+++ b/app/models/notification-action.js
@@ -99,6 +99,10 @@ export default ModelBase.extend({
         routeName = 'orders.view';
         break;
 
+      case 'session':
+        routeName = 'my-sessions.view';
+        break;
+
       default:
       // Nothing here.
     }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Notification action button doesn't appear for view sessions.

#### Changes proposed in this pull request:
It's visible and working now.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1602 

![sessions_notif_bug](https://user-images.githubusercontent.com/21277837/43916853-5d97a3d2-9c2c-11e8-866c-55c5938ef272.png)
