### PR TITLE
Allow users to download order invoice

### DIFF
--- a/app/controllers/orders/view.js
+++ b/app/controllers/orders/view.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    downloadInvoice() {
+      window.print();
+    }
+  }
+});

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -36,6 +36,12 @@
         <i class="ticket alternate icon"></i>
         Download Tickets
       </a>
+      <br>
+      <br>
+      <a href="#" {{action 'downloadInvoice'}} class="ui labeled icon blue button">
+        <i class="ticket alternate icon"></i>
+        Order Invoice
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add button to confirmed orders page to download invoice for attendees

#### Changes proposed in this pull request:
- Add buttons to confirmed orders page to download invoice and tickets for attendees.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1457 
