### PR TITLE
Integrate API to the edit user modal

### DIFF
--- a/app/components/modals/edit-user-modal.js
+++ b/app/components/modals/edit-user-modal.js
@@ -2,12 +2,20 @@ import ModalBase from 'open-event-frontend/components/modals/modal-base';
 
 export default ModalBase.extend({
   actions: {
-    saveRole(id, isAdmin) {
+    saveRole(id) {
       this.get('store').findRecord('user', id).then(function(user) {
-        user.set('isAdmin', isAdmin);
         user.save();
       });
       this.set('isOpen', false);
+    },
+    toggleSalesAdmin(user) {
+      user.toggleProperty('isSalesAdmin');
+    },
+    toggleMarketer(user) {
+      user.toggleProperty('isMarketer');
+    },
+    createAdmin(user, isAdmin) {
+      user.set('isAdmin', isAdmin);
     }
   }
 });

--- a/app/templates/components/modals/edit-user-modal.hbs
+++ b/app/templates/components/modals/edit-user-modal.hbs
@@ -7,19 +7,16 @@
     <h4 class="ui header">{{t 'Provide admin access?'}}</h4>
     <div class="grouped inline fields">
       <div class="field">
-        {{#if data.isAdmin}}
-          {{ui-radio name="isAdmin" label="No" value=false onChange=(action (mut isAdmin))}}
-        {{else}}
-          {{ui-radio name="isAdmin" label="Yes" value=true onChange=(action (mut isAdmin))}}
-        {{/if}}
+        {{ui-radio name="isAdmin" label="No" value=false onChange=(action 'createAdmin' data false)}}
+        {{ui-radio name="isAdmin" label="Yes" value=true onChange=(action 'createAdmin' data true)}}
       </div>
     </div>
     <h4 class="ui header">{{t 'Custom system roles'}}</h4>
     <div class="field">
-      {{ui-checkbox label="Sales Admin" onChange=(action (mut checked))}}
-      {{ui-checkbox label="Marketer" onChange=(action (mut checked))}}
+      {{ui-checkbox label='Sales Admin' class='toggle' checked=data.isSalesAdmin onChange=(action 'toggleSalesAdmin' data)}}
+      {{ui-checkbox label='Marketer' class='toggle' checked=data.isMarketer onChange=(action 'toggleMarketer' data)}}
     </div>
-    <button class="ui teal right floated submit button update-changes" {{action 'saveRole' data.id isAdmin}}>
+    <button class="ui teal right floated submit button update-changes" {{action 'saveRole' data.id}}>
       {{t 'Save'}}
     </button>
   </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The edit user modal currently does not work.

#### Changes proposed in this pull request:

- Integrates the attributes sales admin, admin, marketer to gthe edit user modal.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1491 
