### PR TITLE
fix: Hide mark_all_as_read button in Notification panel when there are no unread notifications

### DIFF
--- a/app/controllers/notifications/all.js
+++ b/app/controllers/notifications/all.js
@@ -1,5 +1,9 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import NotificationsMixin from 'open-event-frontend/mixins/notifications';
 
 export default Controller.extend(NotificationsMixin, {
+  showMarkAllRead: computed('model.notifications', 'model.unread', function() {
+    return this.get('model.notifications').length > 0 && this.get('model.unread');
+  })
 });

--- a/app/templates/notifications/all.hbs
+++ b/app/templates/notifications/all.hbs
@@ -7,7 +7,7 @@
   {{#link-to 'notifications.all' 'all'}}
     <button class="ui button">{{t 'All'}}</button>
   {{/link-to}}
-  {{#if model.unread}}
+  {{#if showMarkAllRead}}
     <button class="ui button right floated" {{action 'markAllRead'}}>{{t 'Mark all read'}}</button>
   {{/if}}
 </div>

--- a/app/templates/notifications/all.hbs
+++ b/app/templates/notifications/all.hbs
@@ -8,7 +8,7 @@
     <button class="ui button">{{t 'All'}}</button>
   {{/link-to}}
   {{#if showMarkAllRead}}
-    <button class="ui button right floated" {{action 'markAllRead'}}>{{t 'Mark all read'}}</button>
+    <button class="ui button right floated" {{action 'markAllRead'}}>{{t 'Mark all as read'}}</button>
   {{/if}}
 </div>
 {{#each model.notifications as |notification|}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Mark all as read button appears on unread notifications route having no unread notifications

#### Changes proposed in this pull request:
Add a computed property in the controller and hide the button.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1619 

![resolved](https://user-images.githubusercontent.com/21277837/43996218-9c3e509e-9ddb-11e8-9e6d-a777e80988ff.png)
