### PR TITLE
Fix: User should be allowed to enter name if not there in profile section

### DIFF
--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -20,11 +20,11 @@
         <i class="ticket icon"></i>
         {{t 'Ticket Buyer'}}
       </h4>
-      <div class="field disabled">
+      <div class="field {{if buyer.firstName 'disabled'}}">
         <label class="required" for="firstname">{{t 'First Name'}}</label>
         {{input type='text' name='first_name' value=buyer.firstName}}
       </div>
-      <div class="field disabled">
+      <div class="field {{if buyer.lastName 'disabled'}}">
         <label class="required" for="lastname">{{t 'Last Name'}}</label>
         {{input type='text' name='last_name' value=buyer.lastName}}
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
User is not allowed to modify the first name and last name fields even if there is no name.

#### Changes proposed in this pull request:
Allow entering name if there is no name.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1614 
