### PR TITLE
feat: Add functionality to mark all as read button

### DIFF
--- a/app/mixins/notifications.js
+++ b/app/mixins/notifications.js
@@ -11,6 +11,23 @@ export default Mixin.create({
         .catch(() => {
           this.get('notify').error(this.get('l10n').t('An unexpected error occurred.'));
         });
+    },
+    markAllAsRead(notifications) {
+      const bulkPromises = [];
+
+      for (const notification of notifications ? notifications.toArray() : []) {
+        notification.set('isRead', true);
+        bulkPromises.push(notification.save());
+      }
+
+      Promise
+        .all(bulkPromises)
+        .then(() => {
+          this.get('notify').success(this.get('l10n').t('Marked all as Read successfully'));
+        })
+        .catch(() => {
+          this.get('notify').error(this.get('l10n').t('An unexpected error occurred.'));
+        });
     }
   }
 });

--- a/app/templates/notifications/all.hbs
+++ b/app/templates/notifications/all.hbs
@@ -8,7 +8,7 @@
     <button class="ui button">{{t 'All'}}</button>
   {{/link-to}}
   {{#if showMarkAllRead}}
-    <button class="ui button right floated" {{action 'markAllRead'}}>{{t 'Mark all as read'}}</button>
+    <button class="ui button right floated" {{action 'markAllAsRead' model.notifications}}>{{t 'Mark all as read'}}</button>
   {{/if}}
 </div>
 {{#each model.notifications as |notification|}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Right now, nothing happens when we click on the "mark all as read" button in the notification panel. It should work

#### Changes proposed in this pull request:
Added action in the notifications mixin to mark all the notifications as read.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1611 
