### PR TITLE
fix: stripe connect redirect uri works when re-editing an event

### DIFF
--- a/app/torii-providers/stripe.js
+++ b/app/torii-providers/stripe.js
@@ -9,8 +9,6 @@ export default stripeConnect.extend({
   clientId: alias('settings.stripeClientId'),
 
   redirectUri: configurable('redirectUri', function() {
-    let { pathname } = window.location;
-    pathname = pathname.substr(0, pathname.lastIndexOf('/'));
-    return `${window.location.origin}${pathname}/torii/redirect.html`;
+    return `${window.location.origin}/torii/redirect.html`;
   })
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Stripe redirect uri produces error when re-editing an event

#### Changes proposed in this pull request:
Fixes the stripe redirect uri

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1637 
