### PR TITLE
Update end date of event automatically when start date is selected.

### DIFF
--- a/app/utils/computed-helpers.js
+++ b/app/utils/computed-helpers.js
@@ -46,6 +46,9 @@ export const computedSegmentedLink = function(property) {
 export const computedDateTimeSplit = function(property, segmentFormat) {
   return computed(property, {
     get() {
+      if (property === 'endsAt' && segmentFormat === 'date') {
+        return moment(this.get(property)).add(1, 'days').format(getFormat(segmentFormat));
+      }
       return moment(this.get(property)).format(getFormat(segmentFormat));
     },
     set(key, value) {
@@ -62,6 +65,7 @@ export const computedDateTimeSplit = function(property, segmentFormat) {
         oldDate = newDate;
       }
       this.set(property, oldDate);
+      this.set('endsAt', oldDate);
       return value;
     }
   });


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->

#### Short description of what this resolves:
Currently, on the event creation page, the end date is always the today's date.

#### Changes proposed in this pull request:
This PR changes the date of the end date to be the next date of the start date until the start date is set.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1690 
