### PR TITLE
Fixed style of links on hover

### DIFF
--- a/app/styles/partials/form.scss
+++ b/app/styles/partials/form.scss
@@ -17,3 +17,17 @@ label.required {
 input.preview {
   text-overflow: ellipsis !important;
 }
+
+.ui.stackable .ui.segment .text.muted {
+  &:hover {
+    color: #737373 !important;
+  }
+}
+
+.ui.stackable .ui.segments .ui.secondary.segment {
+  color: #aeaeae !important;
+
+  &:hover {
+    color: #737373 !important;
+  }
+}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Earlier, the links on `Login`/`Register`/`Forget Password` doesn't change its style when hovered. 

#### Changes proposed in this pull request:

- I have added relevant css to fix the style change on hover of links
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/25428397/50047658-f8007f80-00df-11e9-9ac8-ffc24930e15c.gif)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1684 
