### PR TITLE
Temporary fix: Adds attendees to orders API POST request manually

### DIFF
--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -22,7 +22,7 @@ export default Controller.extend({
         for (const attendee of attendees ? attendees.toArray() : []) {
           await attendee.save();
         }
-        order.set('attendees', attendees.slice());
+        order.set('attendees', attendees);
         await order.save()
           .then(order => {
             this.get('notify').success(this.get('l10n').t('Order details saved. Please fill further details within 10 minutes.'));
@@ -38,7 +38,7 @@ export default Controller.extend({
             this.set('isLoading', false);
           });
       } catch (e) {
-        this.get('notify').error(this.get('l10n').t(e.errors[0].detail));
+        this.get('notify').error(this.get('l10n').t(e));
       }
     }
   }

--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -43,10 +43,9 @@ export default Route.extend({
       sponsors: await eventDetails.get('sponsors'),
 
       order: this.store.createRecord('order', {
-        event     : eventDetails,
-        user      : this.get('authManager.currentUser'),
-        tickets   : [],
-        attendees : []
+        event   : eventDetails,
+        user    : this.get('authManager.currentUser'),
+        tickets : []
       }),
 
       attendees: []

--- a/app/serializers/order.js
+++ b/app/serializers/order.js
@@ -31,6 +31,19 @@ export default ApplicationSerializer.extend(CustomPrimaryKeyMixin, {
       }
     };
     return order;
-  }
+  },
 
+  serialize(snapshot) {
+    const json = this._super(...arguments);
+    let attendeeSnapshots = snapshot._hasManyRelationships.attendees;
+    let attendees = { data: [] };
+    attendeeSnapshots.forEach(function(snapshot) {
+      attendees.data.push({
+        type : 'attendee',
+        id   : snapshot.id
+      });
+    });
+    json.data.relationships.attendees = attendees;
+    return json;
+  }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->


#### Short description of what this resolves:
Adds attendees to orders API POST request manually to fix the order placement wizard.

#### Changes proposed in this pull request:

- Modify the serializer of orders to manually add missing attendees relationship

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #  1751 
