### PR TITLE
 Add a default value for schedulePublishedOn in event model

### DIFF
--- a/app/models/event.js
+++ b/app/models/event.js
@@ -65,7 +65,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   onsiteDetails   : attr('string'),
   orderExpiryTime : attr('number', { defaultValue: 10 }),
 
-  schedulePublishedOn: attr('moment'),
+  schedulePublishedOn: attr('moment', { defaultValue: () => moment(0) }),
 
   hasOrganizerInfo: attr('boolean',  { defaultValue: false }),
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->

 Adds a default value (`moment(0)`)for schedulePublishedOn in the event model.