### PR TITLE
Fix erratic disabling of new order text fields

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -17,6 +17,14 @@ export default Component.extend(FormMixin, {
   buyer: computed('data.user', function() {
     return this.get('data.user');
   }),
+
+  buyerHasFirstName: computed('data.user', function() {
+    return this.get('data.user.firstName') !== null;
+  }),
+
+  buyerHasLastName: computed('data.user', function() {
+    return this.get('data.user.lastName') !== null;
+  }),
   holders: computed('data.attendees', function() {
     this.get('data.attendees').forEach(attendee => {
       attendee.set('firstname', '');

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -20,11 +20,11 @@
         <i class="ticket icon"></i>
         {{t 'Ticket Buyer'}}
       </h4>
-      <div class="field {{if buyer.firstName 'disabled'}}">
+      <div class="field {{if buyerHasFirstName 'disabled'}}">
         <label class="required" for="firstname">{{t 'First Name'}}</label>
         {{input type='text' name='first_name' value=buyer.firstName}}
       </div>
-      <div class="field {{if buyer.lastName 'disabled'}}">
+      <div class="field {{if buyerHasLastName 'disabled'}}">
         <label class="required" for="lastname">{{t 'Last Name'}}</label>
         {{input type='text' name='last_name' value=buyer.lastName}}
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixes erratic disabling of new order text fields by introducing two new computed properties.

Fixes #1755 
