### PR TITLE
Revert back to original state if event publish/unpublish fails

### DIFF
--- a/app/controllers/events/view.js
+++ b/app/controllers/events/view.js
@@ -23,6 +23,7 @@ export default Controller.extend({
           }
         })
         .catch(() => {
+          this.set('model.state', state);
           this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
         })
         .finally(() => {


### PR DESCRIPTION

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently if we publish or unpublish the event and it fails then also it shows transformed state in UI. 

#### Changes proposed in this pull request:
- If state change is unsuccessful then it should revert back.