### PR TITLE
Fix: Inconsistent order summary values

### DIFF
--- a/app/components/orders/order-summary.js
+++ b/app/components/orders/order-summary.js
@@ -4,11 +4,11 @@ import FormMixin from 'open-event-frontend/mixins/form';
 import { sumBy } from 'lodash';
 
 export default Component.extend(FormMixin, {
-  tickets: computed(function() {
+  tickets: computed('data.tickets', function() {
     return this.get('data.tickets').sortBy('position');
   }),
 
-  total: computed('data.tickets.@each.attendees', function() {
+  total: computed('data.tickets', 'data.tickets.@each.attendees', function() {
     return sumBy(this.get('data.tickets').toArray(),
       ticket => (ticket.getWithDefault('price', 0) - ticket.getWithDefault('discount', 0)) * ticket.getWithDefault('attendees.length', 0)
     );

--- a/app/helpers/ticket-attendees.js
+++ b/app/helpers/ticket-attendees.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { intersection } from 'lodash';
+
+export  function ticketAttendees(params/* , hash*/) {
+
+  let allTicketAttendees =  params[1].toArray();
+  let orderAttendees = params[0].toArray();
+  let commonAttendees =  intersection(orderAttendees, allTicketAttendees);
+  return commonAttendees.length;
+
+}
+
+export default helper(ticketAttendees);

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -51,9 +51,9 @@
             </td>
             <td>$ {{number-format ticket.price}}</td>
             <td>$ {{number-format ticket.discount}}</td>
-            <td>{{ticket.attendees.length}}</td>
+            <td>{{ticket-attendees data.attendees ticket.attendees}}</td>
             <td>
-              $ {{number-format (mult (sub ticket.price ticket.discount) ticket.attendees.length)}}
+              $ {{number-format (mult (sub ticket.price ticket.discount) (ticket-attendees data.attendees ticket.attendees))}}
             </td>
           </tr>
         {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


#### Changes proposed in this pull request:

- Move the order summary calculations to a helper to return only the attendees which are related to the order.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1789
