### PR TITLE
Use thumbnail images for event cards

### DIFF
--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -3,7 +3,7 @@
     {{#unless device.isMobile}}
       <div class="ui card three wide computer six wide tablet column">
         <a class="image" href="{{href-to 'public' event.identifier}}">
-          {{widgets/safe-image src=(if event.originalImageUrl event.originalImageUrl event.originalImageUrl)}}
+          {{widgets/safe-image src=(if event.thumbnailImageUrl event.thumbnailImageUrl event.originalImageUrl)}}
         </a>
       </div>
     {{/unless}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

Restores the use of thumbnail images for the event card component.

Fixes #1802 
