### PR TITLE
FIx 1834 Reset email input after link is sent

### DIFF
--- a/app/components/forms/reset-password-form.js
+++ b/app/components/forms/reset-password-form.js
@@ -74,6 +74,7 @@ export default Component.extend(FormMixin, {
             .post('auth/reset-password', payload)
             .then(() => {
               this.set('successMessage', this.get('l10n').t('Please go to the link sent to your email to reset your password'));
+              this.$('input[name=email]').val('')
             })
             .catch(reason => {
               if (reason && reason.hasOwnProperty('errors') && reason.errors[0].status === 404) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Reset email input after link is sent

#### Changes proposed in this pull request:
-Reset email input after link is sent

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1834 
