### PR TITLE
Render serverside html after sanitizing in ember model tables

### DIFF
--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -26,7 +26,7 @@
       </div>
       <div class="row">
         <div class="column session-description">
-          {{session.shortAbstract}}
+          {{sanitize session.shortAbstract}}
         </div>
       </div>
     </div>

--- a/app/templates/components/ui-table/row.hbs
+++ b/app/templates/components/ui-table/row.hbs
@@ -17,7 +17,7 @@
             {{#if column.component}}
               {{component column.component data=data record=record column=column table=this}}
             {{else}}
-              {{get record column.propertyName}}
+              {{sanitize (get record column.propertyName)}}
             {{/if}}
           {{/if}}
         {{/if}}


### PR DESCRIPTION


#### Short description of what this resolves:
Formats the text according to html tags returned in the server side data, instead of rendering the actual tags.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1795 
