### PR TITLE
Making "Speaking Experience" into Paragraph and "Gender" as dropdown

### DIFF
--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -129,12 +129,26 @@
       {{#if field.isIncluded}}
         <div class="field">
           <label class="{{if field.isRequired 'required'}}" for="name">{{field.name}}</label>
-          {{#if (is-input-field field.type) }}
-            {{#if field.isLongText}}
-              {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
+          {{#if (eq field.name "Speaking Experience") }}
+            {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+          {{else}}
+            {{#if (eq field.name "Gender") }}
+              <select  id="gender">
+                <option value="Male" >Male</option>
+                <option value="Female" >Female</option>
+                <option value="Others">Others</option>
+              </select>
+
             {{else}}
-              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{#if (is-input-field field.type) }}
+                {{#if field.isLongText}}
+                  {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
+                    textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+                {{else}}
+                  {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+                {{/if}}
+              {{/if}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
- Making "Speaking Experience" into Paragraph and "Gender" as dropdown


#### Changes proposed in this pull request:

- Making "Speaking Experience" into Paragraph and "Gender" as dropdown
-
-


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1860 
![screenshot from 2019-01-18 18-56-32](https://user-images.githubusercontent.com/17084322/51389659-087a9e80-1b53-11e9-922e-68046b495920.png)
