### PR TITLE
Avoid pagination of speakers on public pages

### DIFF
--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -42,7 +42,8 @@ export default Route.extend({
               val  : 'accepted'
             }
           }
-        ]
+        ],
+        'page[size]': 0
       }),
 
       sponsors: await eventDetails.get('sponsors'),

--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -16,7 +16,8 @@ export default Route.extend({
               val  : 'accepted'
             }
           }
-        ]
+        ],
+        'page[size]': 0
       })
 
     };


### PR DESCRIPTION
Fixes the issue of all the speakers not showing up on the public event page.
