### PR TITLE
Enforce display of event currency across the app.

### DIFF
--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -49,11 +49,11 @@
                 {{ticket.name}}
               </div>
             </td>
-            <td>$ {{number-format ticket.price}}</td>
-            <td>$ {{number-format ticket.discount}}</td>
+            <td>{{currency-symbol eventCurrency}} {{number-format ticket.price}}</td>
+            <td>{{currency-symbol eventCurrency}} {{number-format ticket.discount}}</td>
             <td>{{ticket-attendees data.attendees ticket.attendees}}</td>
             <td>
-              $ {{number-format (mult (sub ticket.price ticket.discount) (ticket-attendees data.attendees ticket.attendees))}}
+              {{currency-symbol eventCurrency}} {{number-format (mult (sub ticket.price ticket.discount) (ticket-attendees data.attendees ticket.attendees))}}
             </td>
           </tr>
         {{/each}}
@@ -70,7 +70,7 @@
           </th>
           <th colspan="4">
             <div class="ui aligned small primary icon">
-              $ {{number-format data.amount}}
+              {{currency-symbol eventCurrency}} {{number-format data.amount}}
             </div>
           </th>
         </tr>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -25,14 +25,14 @@
             {{#if ticket.discount}}
               <td>
                 <div id="{{ticket.id}}_price" class="strike text">
-                  $ {{number-format ticket.price}}
+                  {{currency-symbol eventCurrency}} {{number-format ticket.price}}
                 </div>
                 <div id="{{ticket.id}}_discount">
-                  $ {{number-format (sub ticket.price ticket.discount)}}
+                  {{currency-symbol eventCurrency}} {{number-format (sub ticket.price ticket.discount)}}
                 </div>
               </td>
             {{else}}
-              <td id="{{ticket.id}}_price">$ {{number-format ticket.price}}</td>
+              <td id="{{ticket.id}}_price">{{currency-symbol eventCurrency}} {{number-format ticket.price}}</td>
             {{/if}}
             <td>
               <div class="field">
@@ -50,7 +50,7 @@
               </div>
             </td>
             <td id='{{ticket.id}}_subtotal' class="ui right aligned">
-              $ {{number-format (mult (sub ticket.price ticket.discount) ticket.orderQuantity)}}
+              {{currency-symbol eventCurrency}} {{number-format (mult (sub ticket.price ticket.discount) ticket.orderQuantity)}}
             </td>
           </tr>
         {{/unless}}
@@ -64,7 +64,7 @@
         <th></th>
         <th colspan="4">
           <div class="ui right aligned small primary icon">
-            {{t 'Total'}}: $ {{number-format total}}
+            {{t 'Total'}}: {{currency-symbol eventCurrency}} {{number-format total}}
           </div>
         </th>
       </tr>

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-price.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-price.hbs
@@ -1,3 +1,3 @@
 <span>
-  US$ {{number-format record.ticket.price}}
+  {{currency-symbol paymentCurrency}} {{number-format record.ticket.price}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
@@ -1,1 +1,1 @@
-US$ {{number-format record.amount}}
+{{currency-symbol paymentCurrency}} {{number-format record.amount}}

--- a/app/templates/events/view/tickets/attendees/list.hbs
+++ b/app/templates/events/view/tickets/attendees/list.hbs
@@ -3,6 +3,7 @@
                         data=model.data
                         store=model.store
                         query=model.query
+                        paymentCurrency=model.store.paymentCurrency
                         isNotStoreQuery = true
                         modelName = model.objectType
                         useNumericPagination=true

--- a/app/templates/events/view/tickets/orders/list.hbs
+++ b/app/templates/events/view/tickets/orders/list.hbs
@@ -3,6 +3,7 @@
                         data=model.data
                         store=model.store
                         query=model.query
+                        paymentCurrency=model.store.paymentCurrency
                         isNotStoreQuery = true
                         modelName = model.objectType
                         useNumericPagination=true

--- a/app/templates/orders/expired.hbs
+++ b/app/templates/orders/expired.hbs
@@ -15,7 +15,8 @@
   </div>
   <div class="row">
     <div class="ten wide column">
-      {{orders/order-summary data=model}}
+      {{orders/order-summary data=model
+                             eventCurrency=model.event.paymentCurrency}}
     </div>
     <div class="mobile hidden six wide column">
       {{orders/event-info data=model}}

--- a/app/templates/orders/new.hbs
+++ b/app/templates/orders/new.hbs
@@ -15,7 +15,10 @@
   </div>
   <div class="row">
     <div class="ten wide column">
-      {{orders/order-summary data=model.order tickets=model.tickets}}
+      {{orders/order-summary
+        data=model.order
+        tickets=model.tickets
+        eventCurrency=model.order.event.paymentCurrency}}
     </div>
     <div class="mobile hidden six wide column">
       {{orders/event-info data=model.order}}

--- a/app/templates/orders/placed.hbs
+++ b/app/templates/orders/placed.hbs
@@ -15,7 +15,8 @@
   </div>
   <div class="row">
     <div class="ten wide column">
-      {{orders/order-summary data=model.order}}
+      {{orders/order-summary data=model.order
+                             eventCurrency=model.order.event.paymentCurrency}}
     </div>
     <div class="mobile hidden six wide column">
       {{orders/event-info data=model.order}}

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -15,7 +15,8 @@
   </div>
   <div class="row">
     <div class="ten wide column">
-      {{orders/order-summary data=model.order}}
+      {{orders/order-summary data=model.order
+                             eventCurrency=model.order.event.paymentCurrency}}
     </div>
     <div class="mobile hidden six wide column">
       {{orders/event-info data=model.order}}

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -13,7 +13,14 @@
         </div>
         <div class="ui segment">
           {{#if model.event.isTicketingEnabled}}
-            {{public/ticket-list ticketUrl=model.event.ticketUrl isTicketingEnabled=model.event.isTicketingEnabled data=model.tickets order=model.order attendees=model.attendees code=code save='save'}}
+            {{public/ticket-list eventCurrency=model.event.paymentCurrency
+                                 ticketUrl=model.event.ticketUrl
+                                 isTicketingEnabled=model.event.isTicketingEnabled
+                                 data=model.tickets
+                                 order=model.order
+                                 attendees=model.attendees
+                                 code=code
+                                 save='save'}}
           {{else}}
             <div class="ui grid">
               <div class="ui row">

--- a/tests/integration/components/public/ticket-list-test.js
+++ b/tests/integration/components/public/ticket-list-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | public/ticket list', function(hooks) {
   );
   test('it renders', async function(assert) {
     this.set('data', tickets);
-    await render(hbs `{{public/ticket-list data=data}}`);
+    await render(hbs `{{public/ticket-list data=data eventCurrency='USD'}}`);
     assert.ok(this.element.innerHTML.trim().includes('Standard Ticket'));
   });
 });

--- a/tests/integration/components/ui-table/cell/events/view/tickets/attendees/cell-price-test.js
+++ b/tests/integration/components/ui-table/cell/events/view/tickets/attendees/cell-price-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | ui table/cell/events/view/tickets/attendees/ce
   setupIntegrationTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`{{ui-table/cell/events/view/tickets/attendees/cell-price}}`);
+    await render(hbs`{{ui-table/cell/events/view/tickets/attendees/cell-price paymentCurrency='USD'}}`);
     assert.ok(this.element.textContent.trim().includes(''));
   });
 });

--- a/tests/integration/components/ui-table/cell/events/view/tickets/orders/cell-amount-test.js
+++ b/tests/integration/components/ui-table/cell/events/view/tickets/orders/cell-amount-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | ui table/cell/events/view/tickets/orders/cell 
 
   test('it renders', async function(assert) {
 
-    await render(hbs`{{ui-table/cell/events/view/tickets/orders/cell-amount}}`);
+    await render(hbs`{{ui-table/cell/events/view/tickets/orders/cell-amount paymentCurrency='USD'}}`);
     assert.ok(this.element.textContent.trim().includes(''));
   });
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Changes proposed in this pull request:

- Show currency corresponding to the event on the public event page
- Show currency corresponding to the event on the order dashboard
- Show currency corresponding to the event for attendees
- Show currency corresponding to the event for orders on event dashboard


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1850 
