### PR TITLE
Order summary: Add discount to discounted tickets only

### DIFF
--- a/app/components/orders/order-summary.js
+++ b/app/components/orders/order-summary.js
@@ -21,14 +21,17 @@ export default Component.extend(FormMixin, {
       ticket.set('discount', 0);
     });
     if (discountCode) {
+      let discountCodeTickets = await discountCode.get('tickets');
       let discountType = discountCode.get('type');
       let discountValue = discountCode.get('value');
       tickets.forEach(ticket => {
-        let ticketPrice = ticket.get('price');
-        if (discountType === 'amount') {
-          ticket.set('discount', Math.min(ticketPrice, discountValue));
-        } else {
-          ticket.set('discount', ticketPrice * (discountValue / 100));
+        if (discountCodeTickets.includes(ticket)) {
+          let ticketPrice = ticket.get('price');
+          if (discountType === 'amount') {
+            ticket.set('discount', Math.min(ticketPrice, discountValue));
+          } else {
+            ticket.set('discount', ticketPrice * (discountValue / 100));
+          }
         }
       });
     }


### PR DESCRIPTION
Currently, on the orders summary page, all the tickets amount is reduced even if the discount was applied to only a few of them. Although the final order of the amount is determined correctly, the break up does not add up due to incorrectly applied discounts.
