### PR TITLE
Handle default action of Enter key for Promotional Codes

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -49,6 +49,7 @@ export default Component.extend(FormMixin, {
           this.send('applyPromotionalCode');
         } else {
           this.set('promotionalCodeApplied', false);
+          this.set('code', null);
           let order = this.get('order');
           order.set('accessCode', undefined);
           order.set('discountCode', undefined);
@@ -150,6 +151,13 @@ export default Component.extend(FormMixin, {
         }
       });
       this.sendAction('save');
+    },
+
+    handleKeyPress() {
+      if (event.code === 'Enter') {
+        this.send('applyPromotionalCode');
+        this.set('code', this.get('promotionalCode'));
+      }
     }
   },
   didInsertElement() {

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -1,4 +1,4 @@
-<form class="ui form">
+<form class="ui form" {{action on='submit' preventDefault=true}}>
   <table class="ui very basic compact table" style="margin-bottom: 0">
     <thead class="full-width">
       <tr>
@@ -76,7 +76,12 @@
         <div class="{{if device.isBiggerThanTablet 'right floated eight wide'}} column">
           <div class="field">
             <div class="ui action fluid input">
-              {{input type='text' name='promotional_code' value=promotionalCode placeholder=(t 'Promotional Code') readonly=promotionalCodeApplied}}
+              {{input type='text' name='promotional_code'
+                      value=promotionalCode
+                      placeholder=(t 'Promotional Code')
+                      readonly=promotionalCodeApplied
+                      key-up=(action 'handleKeyPress')
+              }}
               {{#unless promotionalCodeApplied}}
                 <div role="button" class="ui icon button" {{action 'applyPromotionalCode'}}>
                   <i class="checkmark icon"></i>


### PR DESCRIPTION
- Corrects the wrong URL generated while pressing enter
- Removes and sets the query param in the URL when a promotional code is applied.

Fixes #1903 
