### PR TITLE
Event Public Page: Display event time in it's own timezone

### DIFF
--- a/app/helpers/header-date.js
+++ b/app/helpers/header-date.js
@@ -2,8 +2,8 @@ import Helper from '@ember/component/helper';
 import moment from 'moment';
 
 export function headerDate(params) {
-  let timezone = moment.tz.guess();
-  return `${moment(params[0]).format('dddd, MMMM Do YYYY, h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
+  let timezone = params[1] ? params[1] : moment.tz.guess();
+  return `${moment(params[0]).tz(timezone).format('dddd, MMMM Do YYYY, h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
 }
 
 export default Helper.helper(headerDate);

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -11,7 +11,7 @@
         <div class="ui grid info">
           <div class="one wide column"></div>
           <div class="fifteen wide column">
-            <h4 class="event time">{{header-date model.startsAt}}</h4>
+            <h4 class="event time">{{header-date model.startsAt model.timezone}}</h4>
             <h1 class="event name">{{model.name}}</h1>
             <h4 class="event location"><i class="marker icon"></i>{{model.locationName}}</h4>
           </div>


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Display the time on event public page in it's own timezone.


Fixes #1829 
