### PR TITLE
Fixes #1944: Cannot save profile as valid Facebook and Linkedin URLs …

### DIFF
--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -60,7 +60,7 @@ export const validTwitterProfileUrlPattern = new RegExp(
 
 export const validFacebookProfileUrlPattern = new RegExp(
   '^(https?:\\/\\/)' // compulsory protocol
-  + '?(?:www.)?facebook\\.com\\/([a-zA-Z0-9_]+)$'
+  + '?(?:www.)?(facebook|fb)\\.com\\/([a-zA-Z0-9_.]+)$'
 );
 
 export const validGithubProfileUrlPattern = new RegExp(


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:


#### Changes proposed in this pull request:

Regex for `validFacebookProfilePatterns` is changed so as to accept the following URLs for facebook profile.
`https://www.facebook.com/abc.xy.13`
`https://www.fb.com/abc.xy.13`

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1944 
