### PR TITLE
Add a label in front of Sessions in the Speaker table

### DIFF
--- a/app/helpers/session-color.js
+++ b/app/helpers/session-color.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+
+export function sessionColor(params) {
+  switch (params[0]) {
+    case 'accepted':
+      return 'green';
+    case 'pending':
+      return 'yellow';
+    case 'confirmed':
+      return 'yellow';
+    default:
+      return 'red';
+  }
+}
+
+export default Helper.helper(sessionColor);

--- a/app/templates/components/ui-table/cell/events/view/speakers/cell-simple-sessions.hbs
+++ b/app/templates/components/ui-table/cell/events/view/speakers/cell-simple-sessions.hbs
@@ -1,8 +1,12 @@
-<div class="ui unordered list">
+<div class="ui list">
   {{#each record.sessions as |session|}}
     {{#if (not eq session.deletedAt)}}
       <div class="item">
-        {{session.title}}
+        <div class="item">
+          {{Colour}}
+          <div class="ui {{session-color session.state}} horizontal label">{{session.state}}</div>
+          {{session.title}}
+        </div>
       </div>
     {{/if}}
   {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds a label with the session name in the speakers table.

#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/22127980/51662042-9386e900-1fd8-11e9-86b3-d6a962e6f3bc.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1942 
