### PR TITLE
Improving filter for my-tickets

### DIFF
--- a/app/routes/my-tickets/list.js
+++ b/app/routes/my-tickets/list.js
@@ -16,28 +16,64 @@ export default Route.extend({
     if (params.ticket_status === 'upcoming') {
       filterOptions.push(
         {
-          name : 'event',
-          op   : 'has',
-          val  : {
-            name : 'starts-at',
-            op   : 'ge',
-            val  : moment().toISOString()
-          }
-        });
+          and: [
+            {
+              name : 'event',
+              op   : 'has',
+              val  : {
+                name : 'starts-at',
+                op   : 'ge',
+                val  : moment().toISOString()
+              }
+            },
+            {
+              or: [
+                {
+                  name : 'status',
+                  op   : 'eq',
+                  val  : 'completed'
+                },
+                {
+                  name : 'status',
+                  op   : 'eq',
+                  val  : 'placed'
+                }
+              ]
+            }
+          ]
+        }
+      );
     } else if (params.ticket_status === 'past') {
       filterOptions.push(
         {
-          name : 'event',
-          op   : 'has',
-          val  : {
-            name : 'ends-at',
-            op   : 'lt',
-            val  : moment().toISOString()
-          }
+          and: [
+            {
+              name : 'event',
+              op   : 'has',
+              val  : {
+                name : 'starts-at',
+                op   : 'lt',
+                val  : moment().toISOString()
+              }
+            },
+            {
+              or: [
+                {
+                  name : 'status',
+                  op   : 'eq',
+                  val  : 'completed'
+                },
+                {
+                  name : 'status',
+                  op   : 'eq',
+                  val  : 'placed'
+                }
+              ]
+            }
+          ]
         }
       );
     }
-
     return this.get('authManager.currentUser').query('orders', {
       include : 'event',
       filter  : filterOptions


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure that only tickets with statuses of ``completed`` and ``placed`` are show in the my-tickets section

#### Changes proposed in this pull request:

- Using ``or`` condition to show only completed and placed orders
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1979 
