### PR TITLE
Orders: Make flow similar to eventyay Phase - 1

### DIFF
--- a/app/components/modals/login-signup-modal.js
+++ b/app/components/modals/login-signup-modal.js
@@ -1,6 +1,39 @@
 import ModalBase from 'open-event-frontend/components/modals/modal-base';
+import FormMixin from 'open-event-frontend/mixins/form';
 
-export default ModalBase.extend({
+export default ModalBase.extend(FormMixin, {
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        identification: {
+          identifier : 'email',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter your email ID')
+            },
+            {
+              type   : 'email',
+              prompt : this.get('l10n').t('Please enter a valid email ID')
+            }
+          ]
+        },
+        password: {
+          identifier : 'password',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.get('l10n').t('Please enter your password')
+            }
+          ]
+        }
+      }
+    };
+  },
+
   actions: {
     toggleView() {
       this.set('isOpen', false);

--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -16,7 +16,7 @@ export default Component.extend(FormMixin, {
   }),
 
   shouldDisableOrderButton: computed('isUnverified', 'hasTicketsInOrder', function() {
-    return this.get('isUnverified') || !(this.get('hasTicketsInOrder'));
+    return !this.get('hasTicketsInOrder');
   }),
 
   accessCodeTickets : A(),
@@ -133,27 +133,6 @@ export default Component.extend(FormMixin, {
           order.tickets.removeObject(ticket);
         }
       }
-    },
-    placeOrder() {
-      if (!this.get('session.isAuthenticated')) {
-        this.set('isLoginModalOpen', true);
-        return;
-      }
-      let order = this.get('order');
-      let event = order.get('event');
-      order.tickets.forEach(ticket => {
-        let numberOfAttendees = ticket.orderQuantity;
-        while (numberOfAttendees--) {
-          this.get('attendees').addObject(this.store.createRecord('attendee', {
-            firstname : 'John',
-            lastname  : 'Doe',
-            email     : 'johndoe@example.com',
-            event,
-            ticket
-          }));
-        }
-      });
-      this.sendAction('save');
     },
 
     handleKeyPress() {

--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -9,6 +9,8 @@ export default Controller.extend({
 
   code: null,
 
+  isLoginModalOpen: false,
+
   featuredSpeakers: filterBy('model.speakers', 'isFeatured', true),
 
   nonFeaturedSpeakers: filterBy('model.speakers', 'isFeatured', false),
@@ -18,6 +20,72 @@ export default Controller.extend({
   }),
 
   actions: {
+    async createNewUserViaEmail(email) {
+      this.set('isLoading', true);
+      let newUser = this.store.createRecord('user', {
+        email,
+        'password': (Math.random() * 10).toString(16)
+      });
+      newUser.save()
+        .then(() => {
+          let credentials = newUser.getProperties('email', 'password'),
+              authenticator = 'authenticator:jwt';
+          credentials.identification = newUser.email;
+          this.get('session')
+            .authenticate(authenticator, credentials)
+            .then(async() => {
+              const tokenPayload = this.get('authManager').getTokenPayload();
+              if (tokenPayload) {
+                this.set('session.skipRedirectOnInvalidation', true);
+                this.get('authManager').persistCurrentUser(
+                  await this.get('store').findRecord('user', tokenPayload.identity)
+                );
+                this.set('isLoginModalOpen', false);
+                this.send('placeOrder');
+              }
+            })
+            .catch(reason => {
+              if (!(this.get('isDestroyed') || this.get('isDestroying'))) {
+                if (reason && reason.hasOwnProperty('status_code') && reason.status_code === 401) {
+                  this.set('errorMessage', this.get('l10n').t('Your credentials were incorrect.'));
+                } else {
+                  this.set('errorMessage', this.get('l10n').t('An unexpected error occurred.'));
+                }
+                this.set('isLoading', false);
+              } else {
+                console.warn(reason);
+              }
+            })
+            .finally(() => {
+              this.set('session.skipRedirectOnInvalidation', false);
+              this.set('isLoading', false);
+            });
+        });
+
+    },
+
+    async placeOrder() {
+      if (!this.get('session.isAuthenticated')) {
+        this.set('isLoginModalOpen', true);
+        return;
+      }
+      let order = this.get('model.order');
+      let event = order.get('event');
+      order.tickets.forEach(ticket => {
+        let numberOfAttendees = ticket.orderQuantity;
+        while (numberOfAttendees--) {
+          this.get('model.attendees').addObject(this.store.createRecord('attendee', {
+            firstname : 'John',
+            lastname  : 'Doe',
+            email     : 'johndoe@example.com',
+            event,
+            ticket
+          }));
+        }
+      });
+      this.send('save');
+    },
+
     async save() {
       try {
         this.set('isLoading', true);

--- a/app/templates/components/modals/login-signup-modal.hbs
+++ b/app/templates/components/modals/login-signup-modal.hbs
@@ -1,19 +1,37 @@
-<i class="black close icon"></i>
-<div class="header">
-  {{t 'Login or Signup'}}
-</div>
-<div class="content">
-  {{#if (eq session.currentRouteName 'public.cfs.index')}}
-    <h4 class="ui header">{{t 'Please Login or Signup before you can submit a proposal.'}}</h4>
-  {{else if (eq session.currentRouteName 'public.index')}}
-    <h4 class="ui header">{{t 'Please Login or Signup before you can place an order.'}}</h4>
-  {{/if}}
-  <div>
-    {{#link-to 'login' class='ui teal button' invokeAction=(action 'toggleView')}}
-      {{t 'Login'}}
-    {{/link-to}}
-    {{#link-to 'register' class='ui blue button' invokeAction=(action 'toggleView')}}
-      {{t 'Signup'}}
-    {{/link-to}}
+{{#if (eq session.currentRouteName 'public.cfs.index')}}
+  <i class="black close icon"></i>
+  <div class="header">
+    {{t 'Login or Signup'}}
   </div>
-</div>
+  <div class="content">
+    <h4 class="ui header">{{t 'Please Login or Signup before you can submit a proposal.'}}</h4>
+    <div>
+      {{#link-to 'login' class='ui teal button' invokeAction=(action 'toggleView')}}
+        {{t 'Login'}}
+      {{/link-to}}
+      {{#link-to 'register' class='ui blue button' invokeAction=(action 'toggleView')}}
+        {{t 'Signup'}}
+      {{/link-to}}
+    </div>
+  </div>
+{{else if (eq session.currentRouteName 'public.index')}}
+  <i class="black close icon"></i>
+  <h4 class="ui header">{{t 'Please enter your Email address to continue.'}}</h4>
+  <div class="content">
+    {{t 'Have you used Open Event before? Please'}}
+    {{#link-to 'login'  invokeAction=(action 'toggleView')}}
+      {{t 'Login'}}
+    {{/link-to}} {{t 'to continue'}}
+    <form class="ui {{if isLoading 'loading' }} form">
+      <div class="field">
+        <label class="required" for="email">{{t 'E-mail'}}</label>
+        {{input type='text' name="email" value=email  placeholder=(t 'Email Address')}}
+      </div>
+      <button type="submit" class="ui green button" {{action createNewUserViaEmail email}}>
+        {{t 'Continue'}}
+      </button>
+    </form>
+  </div>
+{{/if}}
+
+

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -117,7 +117,7 @@
         <i class="colored visa link icon"></i>
       </div>
       <div class="ui less padding three wide computer four wide tablet column right aligned floated">
-        <button id="total" class="ui primary small button less right margin" disabled={{shouldDisableOrderButton}} {{action 'placeOrder'}}>
+        <button id="total" class="ui primary small button less right margin" disabled={{shouldDisableOrderButton}} {{action placeOrder}}>
           {{t 'Order Now'}}
         </button>
       </div>
@@ -125,4 +125,4 @@
   </div>
 </form>
 
-{{modals/login-signup-modal isOpen=isLoginModalOpen}}
+{{modals/login-signup-modal isOpen=isLoginModalOpen isLoading=isLoading createNewUserViaEmail=createNewUserViaEmail}}

--- a/app/templates/components/unverified-user-message.hbs
+++ b/app/templates/components/unverified-user-message.hbs
@@ -11,8 +11,6 @@
         <div class="header">
           {{#if (eq session.currentRouteName 'events.view.index')}}
             {{t 'To make your event live, please verify your account by clicking on the confirmation link that has been emailed to you.'}}
-          {{else if (eq session.currentRouteName 'public.index')}}
-            {{t 'To place an order, please verify your account by clicking on the confirmation link that has been emailed to you.'}}
           {{else}}
             {{t 'Your account is unverified. Please verify by clicking on the confirmation link that has been emailed to you.'}}
           {{/if}}

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -20,6 +20,10 @@
                                  order=model.order
                                  attendees=model.attendees
                                  code=code
+                                 createNewUserViaEmail=(action 'createNewUserViaEmail')
+                                 isLoginModalOpen=isLoginModalOpen
+                                 placeOrder=(action 'placeOrder')
+                                 isLoading=isLoading
                                  save='save'}}
           {{else}}
             <div class="ui grid">

--- a/tests/integration/components/public/ticket-list-test.js
+++ b/tests/integration/components/public/ticket-list-test.js
@@ -8,6 +8,11 @@ import { render } from '@ember/test-helpers';
 module('Integration | Component | public/ticket list', function(hooks) {
   setupIntegrationTest(hooks);
 
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
+
   const tickets =  A(
     [
       EmberObject.create({
@@ -47,7 +52,8 @@ module('Integration | Component | public/ticket list', function(hooks) {
   );
   test('it renders', async function(assert) {
     this.set('data', tickets);
-    await render(hbs `{{public/ticket-list data=data eventCurrency='USD'}}`);
+    this.actions.placeOrder = function() { };
+    await render(hbs `{{public/ticket-list data=data placeOrder=(action 'placeOrder') eventCurrency='USD'}}`);
     assert.ok(this.element.innerHTML.trim().includes('Standard Ticket'));
   });
 });

--- a/tests/integration/components/unverified-user-message-test.js
+++ b/tests/integration/components/unverified-user-message-test.js
@@ -30,19 +30,6 @@ module('Integration | Component | unverified user message', function(hooks) {
   test('it renders', async function(assert) {
 
     let session = EmberObject.create({
-      currentRouteName: 'public.index'
-    });
-
-    this.set('shouldShowMessage', true);
-    this.set('isMailSent', false);
-    this.set('session', session);
-    await render(hbs`{{unverified-user-message shouldShowMessage=shouldShowMessage session=session isMailSent=isMailSent}}`);
-    assert.ok(this.element.innerHTML.trim().includes('To place an order, please verify your account by clicking on the confirmation link that has been emailed to you.'));
-  });
-
-  test('it renders', async function(assert) {
-
-    let session = EmberObject.create({
       currentRouteName: 'else'
     });
 


### PR DESCRIPTION
1. Modifies the pop up asking non-logged in users to log in or sign up, to instead ask for an email.
2. Functionality to handle pre-registered users who are simply not logged in will be handled in a separate issue.
3. Enables order now button for unverified users.
4. Generates a random password, and along with the entered user create a new user on the server.
5. Fetches user id from the server, and authenticate the session with him.
6. Posts successful authentication, persist the session with the new user itself.
7. Ensures, that after persisting the current user in the session, the initial session which is about to get invalidated does not cause the app to redirect new user to home page. Keep him on the order page itself.
8. Moves the placeOrder action into the controller of the route where all the controlling logic should reside.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2000 
