### PR TITLE
Show copyright logo only if `logoUrl` is present

### DIFF
--- a/app/templates/components/public/copyright-item.hbs
+++ b/app/templates/components/public/copyright-item.hbs
@@ -1,5 +1,7 @@
-<img src="{{copyright.logoUrl}}" class="copyright-image" alt="{{copyright.licence}}">
-<br>
+{{#if copyright.logoUrl}}
+  <img src="{{copyright.logoUrl}}" class="copyright-image" alt="{{copyright.licence}}">
+  <br>
+{{/if}}
 <div class='copyright text'>
   <p>
     {{t 'This event is licenced under'}} <a href="{{copyright.licenceUrl}}"> {{copyright.licence}} </a>.


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Shows the copyright badges only when `logoUrl` is present. I adopted this method because i could not find a badge for All Rights Reserved which is free to use

#### Changes proposed in this pull request:

- Using `logoUrl` as a condition for presence of the logo image

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1991 
