### PR TITLE
Show accepted and confirmed sessions in event scheduler

### DIFF
--- a/app/templates/events/view/scheduler.hbs
+++ b/app/templates/events/view/scheduler.hbs
@@ -9,7 +9,9 @@
       <h3 class="ui header">{{t 'Unscheduled Sessions'}}</h3>
       <div class="ui raised segments">
         {{#each model.unscheduled as |session|}}
-          {{scheduler/unscheduled-session session=session}}
+          {{#if (or (eq session.state 'accepted') (eq session.state 'confirmed'))}}
+            {{scheduler/unscheduled-session session=session}}
+          {{/if}}
         {{/each}}
       </div>
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
All sessions shown in scheduler changed to only accepted and confirmed sessions

#### Changes proposed in this pull request:

-Only accepted and confirmed sessions will be shown in scheduler



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1985 
