### PR TITLE
add route to accept role invites

### DIFF
--- a/app/controllers/events/role-invite.js
+++ b/app/controllers/events/role-invite.js
@@ -1,0 +1,27 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  success : false,
+  error   : null,
+
+  accept(id) {
+    let payload = {
+      data: {
+        type       : 'role-invite',
+        attributes : {
+          status: 'accepted'
+        },
+        id
+      }
+    };
+    return this.get('loader')
+      .patch(`/role-invites/${id}`, JSON.stringify(payload), { skipDataTransform: true })
+      .then(() => {
+        this.set('success', true);
+      })
+      .catch(reason => {
+        this.set('error', reason);
+        this.set('success', false);
+      });
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -98,6 +98,7 @@ router.map(function() {
     });
     this.route('list', { path: '/:event_state' });
     this.route('import');
+    this.route('role-invite');
   });
   this.route('profile');
 

--- a/app/routes/events/role-invite.js
+++ b/app/routes/events/role-invite.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+
+export default Route.extend(UnauthenticatedRouteMixin, {
+  titleToken() {
+    return this.get('l10n').t('Role-Invite');
+  },
+
+  beforeModel(transition) {
+    this.controllerFor('events.role-invite').accept(transition.queryParams.id);
+  }
+});

--- a/app/templates/events/role-invite.hbs
+++ b/app/templates/events/role-invite.hbs
@@ -1,0 +1,9 @@
+{{#if success}}
+  <div class="ui icon info message eight wide column center aligned">
+    <p>Your role have been added successfully !</p>
+  </div>
+{{else}}
+  <div class="ui icon error message eight wide column center aligned">
+    <p>Error: {{t error}}</p>
+  </div>
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
- Presently there is no route to accept role invite, which is why 404 is shown when the link sent to invitee is accessed.

#### Changes proposed in this pull request:
- I have added the route, template and controller to handle role-invite.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1898, possibly fixes #1900 too

This PR requires minor backend changes: fossasia/open-event-server/pull/5565