### PR TITLE
html tags removed from about speaker

### DIFF
--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -39,13 +39,13 @@
       <p>
         {{#if speaker.shortBiography}}
           <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
-          {{speaker.shortBiography}}
+          {{sanitize speaker.shortBiography}}
         {{else if speaker.longBiography}}
           <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
-          {{speaker.longBiography}}
+          {{sanitize speaker.longBiography}}
         {{else if speaker.speakingExperience}}
           <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
-          {{speaker.speakingExperience}}
+          {{sanitize speaker.speakingExperience}}
         {{/if}}
       </p>
       <div class="social-icons">


### PR DESCRIPTION
#### Short description of what this resolves:
Html tags appearing in about speaker removed.

Fixes #2026 
