### PR TITLE
Display cancelled orders under Cancelled tab in Orders tab of Tickets

### DIFF
--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -64,6 +64,7 @@ export default Controller.extend({
       order.set('status', 'cancelled');
       order.save()
         .then(() => {
+          this.send('refreshRoute');
           this.notify.success(this.get('l10n').t('Order has been cancelled successfully.'));
         })
         .catch(() => {


### PR DESCRIPTION
…tickets

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Cancelled orders now show up under Cancelled tab in Orders tab of Tickets as soon as we cancel the order.

#### Changes proposed in this pull request:

![screenshot 2019-01-31 at 4 00 35 pm](https://user-images.githubusercontent.com/31013104/52048498-8ab28c00-2571-11e9-8eaf-fe5e20014c05.png)

-
-
-


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2037 
