### PR TITLE
Modifying event sessions filters

### DIFF
--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -44,7 +44,7 @@ export default Route.extend({
               {
                 name : 'state',
                 op   : 'eq',
-                val  : 'accepted'
+                val  : 'confirmed'
               }
             ]
           }
@@ -77,7 +77,7 @@ export default Route.extend({
               {
                 name : 'state',
                 op   : 'eq',
-                val  : 'accepted'
+                val  : 'confirmed'
               }
             ]
           }
@@ -110,7 +110,7 @@ export default Route.extend({
               {
                 name : 'state',
                 op   : 'eq',
-                val  : 'accepted'
+                val  : 'confirmed'
               }
             ]
           }
@@ -133,7 +133,7 @@ export default Route.extend({
               {
                 name : 'state',
                 op   : 'eq',
-                val  : 'accepted'
+                val  : 'confirmed'
               }
             ]
           }


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure that `confirmed` sessions are shown in public page of an event instead of `accepted` ones

#### Changes proposed in this pull request:

- Using `confirmed` instead of `accepted` as required state

After the filter change:

![image](https://user-images.githubusercontent.com/21087061/52053742-37940580-2580-11e9-890e-76e77dd2b79d.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2053 
