### PR TITLE
Changing query from accepted to confirmed

### DIFF
--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -13,7 +13,7 @@ export default Route.extend({
             val  : {
               name : 'state',
               op   : 'eq',
-              val  : 'accepted'
+              val  : 'confirmed'
             }
           }
         ],


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Makes sure that confirmed speakers are displayed in the event speakers section 

#### Changes proposed in this pull request:

- Changing query value from `accepted` to `confirmed`

Screenshot :
(Speaker details can be find in issue) 
![image](https://user-images.githubusercontent.com/21087061/52058449-73819780-258d-11e9-9c37-57773e8cd4ac.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2059 
