### PR TITLE
Remove SCSS lint warning

### DIFF
--- a/app/styles/components/ui-table.scss
+++ b/app/styles/components/ui-table.scss
@@ -13,5 +13,5 @@
 }
 
 .table-body {
-  vertical-align: 0px;
+  vertical-align: 0;
 }


### PR DESCRIPTION
A zero value should not have a unit suffix.