### PR TITLE
Hides ticketing section in Create Event section, if disabled from Admin

### DIFF
--- a/app/routes/create.js
+++ b/app/routes/create.js
@@ -14,7 +14,8 @@ export default Route.extend(AuthenticatedRouteMixin, EventWizardMixin, {
         copyright           : this.store.createRecord('event-copyright'),
         stripeAuthorization : this.store.createRecord('stripe-authorization')
       }),
-      types: await this.store.query('event-type', {
+      module : await this.get('store').queryRecord('module', {}),
+      types  : await this.store.query('event-type', {
         sort: 'name'
       }),
       topics: await this.store.query('event-topic', {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -139,66 +139,68 @@
       }}
     {{/each}}
   </div>
-  <div class="ui section divider"></div>
-  <div class="field">
-    <div class="ui slider checkbox">
-      {{input type='checkbox' checked=data.event.isTicketingEnabled id='use_ticketing_system'}}
-      <label for="use_ticketing_system">{{t 'Use ticketing system'}}</label>
+  {{#if data.module.ticketInclude}}
+    <div class="ui section divider"></div>
+    <div class="field">
+      <div class="ui slider checkbox">
+        {{input type='checkbox' checked=data.event.isTicketingEnabled id='use_ticketing_system'}}
+        <label for="use_ticketing_system">{{t 'Use ticketing system'}}</label>
+      </div>
     </div>
-  </div>
-  {{#if data.event.isTicketingEnabled}}
-    <div class="ui attached segment {{unless data.event.tickets 'center aligned'}}">
-      {{#if data.event.tickets}}
-        <div class="ui stackable celled five column grid ticket-header">
-          <div class="row weight-600">
-            <div class="six wide column">
-              <label class="required">{{t 'Ticket Name'}}</label>
-            </div>
-            <div class="column">
-              <label class="required">{{t 'Price'}}</label>
-            </div>
-            <div class="column">
-              <label class="required">{{t 'Quantity'}}</label>
-            </div>
-            <div class="column">
-              <label>{{t 'Options'}}</label>
+    {{#if data.event.isTicketingEnabled}}
+      <div class="ui attached segment {{unless data.event.tickets 'center aligned'}}">
+        {{#if data.event.tickets}}
+          <div class="ui stackable celled five column grid ticket-header">
+            <div class="row weight-600">
+              <div class="six wide column">
+                <label class="required">{{t 'Ticket Name'}}</label>
+              </div>
+              <div class="column">
+                <label class="required">{{t 'Price'}}</label>
+              </div>
+              <div class="column">
+                <label class="required">{{t 'Quantity'}}</label>
+              </div>
+              <div class="column">
+                <label>{{t 'Options'}}</label>
+              </div>
             </div>
           </div>
-        </div>
-        {{#each tickets as |ticket index|}}
-          {{widgets/forms/ticket-input ticket=ticket
-                                       timezone=data.event.timezone
-                                       canMoveUp=(not-eq index 0)
-                                       canMoveDown=(not-eq ticket.position (dec data.event.tickets.length))
-                                       moveTicketUp=(action 'moveTicket' ticket 'up')
-                                       moveTicketDown=(action 'moveTicket' ticket 'down')
-                                       removeTicket=(confirm 'Are you sure you wish to delete this ticket ?' (action 'removeTicket' ticket))}}
-        {{/each}}
-      {{else}}
-        <h3 class="text muted weight-500">
-          {{t 'You don\'t have any tickets added. Add one of your choice.'}}
-        </h3>
-      {{/if}}
-    </div>
-    <button type="button" class="ui blue small button" {{action 'addTicket' 'free' data.event.tickets.length}}>
-      <i class="large icons basic-details">
-        <i class="smile icon"></i>
-        <i class="inverted corner add icon"></i>
-      </i>
-      {{t 'Free Ticket'}}
-    </button>
-    <button type="button" class="ui blue small button" {{action 'addTicket' 'paid' data.event.tickets.length}}>
-      <i class="large icons basic-details">
-        <i class="dollar icon"></i>
-        <i class="inverted corner add icon"></i>
-      </i>
-      {{t 'Paid Ticket'}}
-    </button>
-  {{else}}
-    <div class="field">
-      <label for="ticket_url">{{t 'Ticket URL'}}</label>
-      {{widgets/forms/link-input inputId='ticket_url' segmentedLink=data.event.segmentedTicketUrl}}
-    </div>
+          {{#each tickets as |ticket index|}}
+            {{widgets/forms/ticket-input ticket=ticket
+                                        timezone=data.event.timezone
+                                        canMoveUp=(not-eq index 0)
+                                        canMoveDown=(not-eq ticket.position (dec data.event.tickets.length))
+                                        moveTicketUp=(action 'moveTicket' ticket 'up')
+                                        moveTicketDown=(action 'moveTicket' ticket 'down')
+                                        removeTicket=(confirm 'Are you sure you wish to delete this ticket ?' (action 'removeTicket' ticket))}}
+          {{/each}}
+        {{else}}
+          <h3 class="text muted weight-500">
+            {{t 'You don\'t have any tickets added. Add one of your choice.'}}
+          </h3>
+        {{/if}}
+      </div>
+      <button type="button" class="ui blue small button" {{action 'addTicket' 'free' data.event.tickets.length}}>
+        <i class="large icons basic-details">
+          <i class="smile icon"></i>
+          <i class="inverted corner add icon"></i>
+        </i>
+        {{t 'Free Ticket'}}
+      </button>
+      <button type="button" class="ui blue small button" {{action 'addTicket' 'paid' data.event.tickets.length}}>
+        <i class="large icons basic-details">
+          <i class="dollar icon"></i>
+          <i class="inverted corner add icon"></i>
+        </i>
+        {{t 'Paid Ticket'}}
+      </button>
+    {{else}}
+      <div class="field">
+        <label for="ticket_url">{{t 'Ticket URL'}}</label>
+        {{widgets/forms/link-input inputId='ticket_url' segmentedLink=data.event.segmentedTicketUrl}}
+      </div>
+    {{/if}}
   {{/if}}
   {{#if hasPaidTickets}}
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Earlier, if the ticketing was disabled from Admin, the `Create Event` section still showed `Ticketing` section.

#### Changes proposed in this pull request:

- Passed `module` in `create` route
- Disabled Ticketing if it is disabled from Admin 

#### Ticketing Enabled
![screenshot_2019-02-01 create an event open event](https://user-images.githubusercontent.com/25428397/52128518-2c61d800-265b-11e9-8006-ba08933bce33.png)

#### Ticketing Disabled
![screenshot_2019-02-01 create an event open event 1](https://user-images.githubusercontent.com/25428397/52128519-2c61d800-265b-11e9-91d7-5fe8dafccf4e.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1907 
