### PR TITLE
Making sure order's user email is displayed

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
@@ -2,7 +2,7 @@
   {{#link-to 'orders.view' record.order.identifier}}{{record.order.identifier}}{{/link-to}}
   <span class="weight-400">
     {{t 'by'}}
-    {{record.user.email}}
+    {{record.order.user.email}}
   </span>
   <div class="ui basic mini {{if (eq record.order.status 'completed') 'green'
                                  (if (or (eq record.order.status 'placed')


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure every ticket order has an email id to go with it

#### Changes proposed in this pull request:

![image](https://user-images.githubusercontent.com/21087061/52137556-d7c95780-2670-11e9-8b20-ddc3debe0ea0.png)


- Modifying `record.user.email` to `record.order.user.email`

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2070 
