### PR TITLE
Modifying order-card to resolve Invalid date

### DIFF
--- a/app/templates/components/order-card.hbs
+++ b/app/templates/components/order-card.hbs
@@ -37,7 +37,7 @@
           {{t 'order'}}
         </span>
         <span>#{{order.identifier}}</span>
-        <span>{{t 'on'}} {{moment-format order.completedAt 'MMMM DD, YYYY h:mm A'}}</span>
+        <span>{{t 'on'}} {{moment-format order.createdAt 'MMMM DD, YYYY h:mm A'}}</span>
       </span>
     </div>
   </div>


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It resolves the Invalid date error

#### Changes proposed in this pull request:

- Can be a subject of discussion. using order's creation time instead of completion time to show date on order-card

![proof](https://user-images.githubusercontent.com/21087061/52177601-48937f80-27e9-11e9-9761-0f02dc8a34a5.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2084 
