### PR TITLE
Using Event's payment currency in Add Discount Code form

### DIFF
--- a/app/templates/components/forms/events/view/create-discount-code.hbs
+++ b/app/templates/components/forms/events/view/create-discount-code.hbs
@@ -5,7 +5,7 @@
   </div>
   <div class="field">
     <label class="required">{{t 'Enter Discount'}}</label>
-    {{ui-radio label=(t 'Amount (US$)') name='discount_type'  value='amount' current=data.type onChange=(action (mut data.type))}}
+    {{ui-radio name='discount_type' label = (concat 'Amount in ' (currency-symbol data.event.paymentCurrency)) value='amount' current=data.type onChange=(action (mut data.type))}}
   </div>
   {{#if (not-eq data.type 'percent')}}
     <div class="field">


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure that event's payment currency is being used instead of default USD in add discount code sections

#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/21087061/52181941-beb1d980-281d-11e9-9c05-7fe9bc8c2444.png)

- Using event's payment currency instead of default USD


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2101 
