### PR TITLE
Fix: Broken event update

### DIFF
--- a/app/adapters/event.js
+++ b/app/adapters/event.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default ApplicationAdapter.extend({
   buildURL(modelName, id, snapshot, requestType, query) {
     let url = this._super(modelName, id, snapshot, requestType, query);
-    if (requestType === 'updateRecord' && snapshot.adapterOptions.getTrashed) {
+    if (requestType === 'updateRecord' && snapshot.adapterOptions && snapshot.adapterOptions.getTrashed) {
       url = `${url}?get_trashed=true`;
     }
     return url;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Short description of what this resolves:

Adds a check in the adapter, to ensure adapter options are accessed only when they have been defined.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2103 
