### PR TITLE
Reload active and inactive tabs in Access and Discount codes when it is toggled

### DIFF
--- a/app/controllers/events/view/tickets/access-codes/list.js
+++ b/app/controllers/events/view/tickets/access-codes/list.js
@@ -50,6 +50,7 @@ export default Controller.extend({
       accessCode.save()
         .then(() => {
           this.notify.success(this.get('l10n').t('Access Code has been updated successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
           this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));

--- a/app/controllers/events/view/tickets/discount-codes/list.js
+++ b/app/controllers/events/view/tickets/discount-codes/list.js
@@ -55,6 +55,7 @@ export default Controller.extend({
       discountCode.save()
         .then(() => {
           this.notify.success(this.get('l10n').t('Discount Code has been updated successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
           discountCode.toggleProperty('isActive');

--- a/app/routes/events/view/tickets/access-codes/list.js
+++ b/app/routes/events/view/tickets/access-codes/list.js
@@ -46,5 +46,11 @@ export default Route.extend({
       query      : queryObject,
       objectType : 'accessCodes'
     };
+  },
+
+  actions: {
+    refreshRoute() {
+      this.refresh();
+    }
   }
 });

--- a/app/routes/events/view/tickets/discount-codes/list.js
+++ b/app/routes/events/view/tickets/discount-codes/list.js
@@ -47,5 +47,11 @@ export default Route.extend({
       query      : queryObject,
       objectType : 'discountCodes'
     };
+  },
+
+  actions: {
+    refreshRoute() {
+      this.refresh();
+    }
   }
 });


### PR DESCRIPTION
#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Reload active and inactive tabs in Access and Discount codes when it is toggled.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2107 
