### PR TITLE
Improve customGlobalFilter in ember tables: include null values by default

### DIFF
--- a/app/components/ui-table-server.js
+++ b/app/components/ui-table-server.js
@@ -120,11 +120,13 @@ export default ModelsTable.extend({
 
     let globalFilter = get(this, 'customGlobalFilter');
     if (globalFilter) {
-      query.filter.pushObject({
-        name : globalFilter,
-        op   : 'ilike',
-        val  : `%${filterString}%`
-      });
+      if (filterString) {
+        query.filter.pushObject({
+          name : globalFilter,
+          op   : 'ilike',
+          val  : `%${filterString}%`
+        });
+      }
     } else {
       query.filter.removeObject({
         name : globalFilter,


### PR DESCRIPTION
Currently null values are ignored, and anything with null for a column like name is not displayed at all.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2112 
