### PR TITLE
Fix : Improving filter for admin/user active list

### DIFF
--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -32,7 +32,7 @@ export default Route.extend({
             {
               name : 'last-accessed-at',
               op   : 'ge',
-              val  : moment().subtract(1, 'M').toISOString()
+              val  : moment().subtract(1, 'Y').toISOString()
             }
           ]
         }

--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import moment from 'moment';
 
 export default Route.extend({
   titleToken() {
@@ -22,9 +23,18 @@ export default Route.extend({
     if (params.users_status === 'active') {
       filterOptions = [
         {
-          name : 'deleted-at',
-          op   : 'eq',
-          val  : null
+          and: [
+            {
+              name : 'deleted-at',
+              op   : 'eq',
+              val  : null
+            },
+            {
+              name : 'last-accessed-at',
+              op   : 'le',
+              val  : moment().add(1, 'M').toISOString()
+            }
+          ]
         }
       ];
     } else if (params.users_status === 'deleted') {

--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -31,8 +31,8 @@ export default Route.extend({
             },
             {
               name : 'last-accessed-at',
-              op   : 'le',
-              val  : moment().add(1, 'M').toISOString()
+              op   : 'ge',
+              val  : moment().subtract(1, 'M').toISOString()
             }
           ]
         }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently the non deleted users are being shown in Active tab , additional filter is required for utilising last accessed status  

#### Changes proposed in this pull request:

- Using `last-accessed-at` as a query parameter

![image](https://user-images.githubusercontent.com/21087061/52363335-7d613a00-2a68-11e9-825a-9d1ff0689468.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2134 
