### PR TITLE
Improving cell-buttons and cell-state

### DIFF
--- a/app/components/ui-table/cell/admin/events/cell-buttons.js
+++ b/app/components/ui-table/cell/admin/events/cell-buttons.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/ui-table/cell/admin/events/cell-event-state.js
+++ b/app/components/ui-table/cell/admin/events/cell-event-state.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -25,7 +25,7 @@ export default Controller.extend({
     },
     {
       propertyName : 'state',
-      template     : 'components/ui-table/cell/cell-event-state',
+      template     : 'components/ui-table/cell/admin/events/cell-event-state',
       title        : 'State'
     },
     {
@@ -58,7 +58,7 @@ export default Controller.extend({
       disableSorting : true
     },
     {
-      template       : 'components/ui-table/cell/cell-buttons',
+      template       : 'components/ui-table/cell/admin/events/cell-buttons',
       title          : 'Actions',
       disableSorting : true
     }

--- a/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
@@ -1,4 +1,3 @@
-{{record.deletedAt}}
 <div class="ui vertical compact basic buttons">
   {{#ui-popup tagName='a' click=(action moveToDetails record.identifier) content=(t 'View') class='ui icon button' position='left center'}}
     <i class="unhide icon"></i>
@@ -11,8 +10,10 @@
       <i class="undo icon"></i>
     {{/ui-popup}}
   {{else}}
-    {{#ui-popup content=(t 'Delete') click=(action openDeleteEventModal record.identifier record.name) class='ui icon button' position='left center'}}
-      <i class="trash outline icon"></i>
-    {{/ui-popup}}
+    {{#if (eq record.deletedAt null)}}
+        {{#ui-popup content=(t 'Delete') click=(action openDeleteEventModal record.identifier record.name) class='ui icon button' position='left center'}}
+        <i class="trash outline icon"></i>
+        {{/ui-popup}}
+    {{/if}}
   {{/if}}
 </div>

--- a/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
@@ -11,9 +11,9 @@
     {{/ui-popup}}
   {{else}}
     {{#if (eq record.deletedAt null)}}
-        {{#ui-popup content=(t 'Delete') click=(action openDeleteEventModal record.identifier record.name) class='ui icon button' position='left center'}}
-        <i class="trash outline icon"></i>
-        {{/ui-popup}}
+      {{#ui-popup content=(t 'Delete') click=(action openDeleteEventModal record.identifier record.name) class='ui icon button' position='left center'}}
+      <i class="trash outline icon"></i>
+      {{/ui-popup}}
     {{/if}}
   {{/if}}
 </div>

--- a/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/admin/events/cell-buttons.hbs
@@ -12,7 +12,7 @@
   {{else}}
     {{#if (eq record.deletedAt null)}}
       {{#ui-popup content=(t 'Delete') click=(action openDeleteEventModal record.identifier record.name) class='ui icon button' position='left center'}}
-      <i class="trash outline icon"></i>
+        <i class="trash outline icon"></i>
       {{/ui-popup}}
     {{/if}}
   {{/if}}

--- a/app/templates/components/ui-table/cell/admin/events/cell-event-state.hbs
+++ b/app/templates/components/ui-table/cell/admin/events/cell-event-state.hbs
@@ -1,0 +1,5 @@
+{{#if record.deletedAt}}
+    {{t 'deleted'}}
+{{else}}
+    {{get record column.propertyName}}
+{{/if}}

--- a/app/templates/components/ui-table/cell/admin/events/cell-event-state.hbs
+++ b/app/templates/components/ui-table/cell/admin/events/cell-event-state.hbs
@@ -1,5 +1,5 @@
 {{#if record.deletedAt}}
-    {{t 'deleted'}}
+  {{t 'deleted'}}
 {{else}}
-    {{get record column.propertyName}}
+  {{get record column.propertyName}}
 {{/if}}

--- a/app/templates/components/ui-table/cell/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/cell-buttons.hbs
@@ -1,4 +1,3 @@
-{{record.deletedAt}}
 <div class="ui vertical compact basic buttons">
   {{#ui-popup tagName='a' click=(action moveToDetails record.identifier) content=(t 'View') class='ui icon button' position='left center'}}
     <i class="unhide icon"></i>

--- a/tests/integration/components/ui-table/cell/admin/events/cell-buttons-test.js
+++ b/tests/integration/components/ui-table/cell/admin/events/cell-buttons-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | ui table/cell/admin/events/cell buttons', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('editEvent', () => {});
+    this.set('moveToDetails', () => {});
+    this.set('openDeleteEventModal', () => {});
+    await render(hbs`{{ui-table/cell/admin/events/cell-buttons editEvent=(action editEvent) moveToDetails=(action moveToDetails) openDeleteEventModal=(action openDeleteEventModal)}}`);
+    assert.ok(this.element.textContent.trim().includes(''));
+  });
+});

--- a/tests/integration/components/ui-table/cell/admin/events/cell-event-state-test.js
+++ b/tests/integration/components/ui-table/cell/admin/events/cell-event-state-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupIntegrationTest } from 'open-event-frontend/tests/helpers/setup-integration-test';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | ui table/cell/admin/events/cell event state', function(hooks) {
+  setupIntegrationTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs `{{ui-table/cell/admin/events/cell-event-state}}`);
+    assert.ok(this.element.innerHTML.trim().includes(''));
+  });
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This makes sure there is no delete option for deleted events and updates the status of deleted events 

#### Changes proposed in this pull request:

- Adding admin local components for the task
- Using `deleted` status for deleted events
- Removing `delete` icon from deleted event action bars
- Added the integration tests for these local components

![image](https://user-images.githubusercontent.com/21087061/52443846-d0142200-2b4c-11e9-8b5c-6bfde59a777d.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2157 
