### PR TITLE
Display restore event button on admin event-all route

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -1,9 +1,8 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 export default Controller.extend({
-  isAdminEventsDeleteRoute: computed('eventsStatusParam', function() {
-    return this.get('eventsStatusParam') === 'deleted';
-
+  hasRestorePrivileges: computed('authManager.currentUser.isAdmin', function() {
+    return this.get('authManager.currentUser.isSuperAdmin') || this.get('authManager.currentUser.isAdmin');
   }),
   columns: [
     {
@@ -58,6 +57,7 @@ export default Controller.extend({
       disableSorting : true
     },
     {
+      propertyName   : 'deletedAt',
       template       : 'components/ui-table/cell/cell-buttons',
       title          : 'Actions',
       disableSorting : true

--- a/app/routes/admin/events/list.js
+++ b/app/routes/admin/events/list.js
@@ -117,10 +117,6 @@ export default Route.extend({
       'page[size]' : 10
     });
   },
-  setupController(controller, model) {
-    this._super(controller, model);
-    controller.set('eventsStatusParam', this.get('params.events_status'));
-  },
 
   actions: {
     refreshRoute() {

--- a/app/templates/admin/events/list.hbs
+++ b/app/templates/admin/events/list.hbs
@@ -8,8 +8,7 @@
     openDeleteEventModal=(action 'openDeleteEventModal')
     restoreEvent = (action 'restoreEvent')
     customGlobalFilter='name'
-    isAdminEventsDeleteRoute=isAdminEventsDeleteRoute
+    hasRestorePrivileges=hasRestorePrivileges
   }}
   {{modals/event-delete-modal isLoading=isLoading isOpen=isEventDeleteModalOpen confirmName=confirmName eventName=eventName deleteEvent=(action 'deleteEvent')}}
 </div>
-{{hello}}

--- a/app/templates/components/ui-table/cell/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/cell-buttons.hbs
@@ -5,7 +5,7 @@
   {{#ui-popup content=(t 'Edit') click=(action editEvent record.identifier) class='ui icon button' position='left center'}}
     <i class="edit icon"></i>
   {{/ui-popup}}
-  {{#if isAdminEventsDeleteRoute}}
+  {{#if (and hasRestorePrivileges (get record column.propertyName))}}
     {{#ui-popup content=(t 'Restore') click=(action restoreEvent record) class='ui icon button' position='left center'}}
       <i class="undo icon"></i>
     {{/ui-popup}}


### PR DESCRIPTION
This PR resolves the issue of  restore button was still shown for deleted buttons in admin events

Fixes #2157 