### PR TITLE
Adding 'Inactive User' Tab in Admin/Users

### DIFF
--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -8,12 +8,14 @@ export default Route.extend({
         return this.get('l10n').t('Active');
       case 'deleted':
         return this.get('l10n').t('Deleted');
+      case 'inactive':
+        return this.get('l10n').t('Inactive');
     }
   },
   beforeModel(transition) {
     this._super(...arguments);
     const userState = transition.params[transition.targetName].users_status;
-    if (!['all', 'deleted', 'active'].includes(userState)) {
+    if (!['all', 'deleted', 'active', 'inactive'].includes(userState)) {
       this.replaceWith('admin.users.view', userState);
     }
   },
@@ -43,6 +45,23 @@ export default Route.extend({
           name : 'deleted-at',
           op   : 'ne',
           val  : null
+        }
+      ];
+    } else if (params.users_status === 'inactive') {
+      filterOptions = [
+        {
+          or: [
+            {
+              name : 'last-accessed-at',
+              op   : 'eq',
+              val  : null
+            },
+            {
+              name : 'last-accessed-at',
+              op   : 'lt',
+              val  : moment().subtract(1, 'Y').toISOString()
+            }
+          ]
         }
       ];
     }

--- a/app/templates/admin/users.hbs
+++ b/app/templates/admin/users.hbs
@@ -9,6 +9,9 @@
           {{#link-to 'admin.users.list' 'active' class='item'}}
             {{t 'Active Users'}}
           {{/link-to}}
+          {{#link-to 'admin.users.list' 'inactive' class='item'}}
+            {{t 'Inactive Users'}}
+          {{/link-to}}
           {{#link-to 'admin.users.list' 'deleted' class='item'}}
             {{t 'Deleted Users'}}
           {{/link-to}}


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds an `Inactive User` tab in Admin/Users

#### Changes proposed in this pull request:

- Creating new parameter for inactive users

![image](https://user-images.githubusercontent.com/21087061/52526729-ff5c9780-2ce2-11e9-87b6-5ac44b2f8318.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2174 
