### PR TITLE
Private CFS no longer being shown in index

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -19,7 +19,8 @@ export default Controller.extend({
       }
       const startDateTime = callForPapers.get('startsAt');
       const endDateTime = callForPapers.get('endsAt');
-      return (moment().isBetween(startDateTime, endDateTime) && (sessionEnabled));
+      const privacyState = callForPapers.get('privacy');
+      return (moment().isBetween(startDateTime, endDateTime) && (sessionEnabled) && (privacyState === 'public'));
     });
   }),
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure that private call for speakers are no longer listed in the index page

#### Changes proposed in this pull request:

- Adding `privacyState` conditional in CFS display

Before : 
![initial](https://user-images.githubusercontent.com/21087061/52527051-6af53380-2ce8-11e9-9ab7-a4744284367b.png)

After: 
![after](https://user-images.githubusercontent.com/21087061/52527056-747e9b80-2ce8-11e9-8594-195a6c06ecb2.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2176 
