### PR TITLE
Using completed orders instead of total orders

### DIFF
--- a/app/templates/components/ui-table/cell/cell-tickets.hbs
+++ b/app/templates/components/ui-table/cell/cell-tickets.hbs
@@ -1,7 +1,7 @@
 {{#if record.tickets}}
   <div class="ui list">
     {{#each record.tickets as |ticket|}}
-      <div class="item">{{ticket.name}} ({{ticket.orderStatistics.tickets.total}}/{{ticket.quantity}}) <span class="item muted text">[{{ticket.type}}]</span></div>
+      <div class="item">{{ticket.name}} ({{ticket.orderStatistics.tickets.completed}}/{{ticket.quantity}}) <span class="item muted text">[{{ticket.type}}]</span></div>
     {{/each}}
   </div>
 {{else}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It uses completed order statistics instead of initially used total order statistics

![image](https://user-images.githubusercontent.com/21087061/52644773-73768580-2f05-11e9-9a15-74a41d287557.png)

#### Changes proposed in this pull request:

- Using `completed` orders instead of `total` orders

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2187 
