### PR TITLE
Singapore only once in timezone

### DIFF
--- a/app/utils/dictionary/date-time.js
+++ b/app/utils/dictionary/date-time.js
@@ -1,6 +1,8 @@
 import moment from 'moment';
 
-export const timezones = moment.tz.names();
+export const timezones = moment.tz.names().filter(function(timezone) {
+  return timezone !== 'Singapore';
+});
 
 export const FORM_DATE_FORMAT = 'MM/DD/YYYY';
 export const FORM_TIME_FORMAT = 'HH:mm';


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Singapore appeared twice as Asia/Singapore and Singapore which is change only to Asia/Singapore

#### Changes proposed in this pull request:
Singapore appears once in timezone


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2218 
![screenshot from 2019-02-22 14-17-29](https://user-images.githubusercontent.com/36128751/53230419-a27ebb00-36ac-11e9-936c-df83130d3ab5.png)

