### PR TITLE
Add currency symbol to item total of Add order form

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
@@ -1,1 +1,1 @@
-{{number-format (mult record.orderQuantity record.price)}}
+{{currency-symbol paymentCurrency}} {{number-format (mult record.orderQuantity record.price)}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add currency symbol to item total of Add order form

#### Changes proposed in this pull request:
![screenshot 2019-02-23 at 2 42 28 am](https://user-images.githubusercontent.com/31013104/53271585-eb6a5a00-3714-11e9-82cc-e1c0ee634312.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2224 
