### PR TITLE
Improve the edit speaker functionality in my-sessions

### DIFF
--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -7,12 +7,14 @@
       {{/if}}
     {{/link-to}}
     {{#each model.speakers as |speaker|}}
-      {{#link-to 'events.view.speakers.edit' model.event.id speaker.id}}
-        <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
-        {{#if device.isMobile}}
-          <div class="ui hidden fitted divider"></div>
-        {{/if}}
-      {{/link-to}}
+      {{#if (eq speaker.email authManager.currentUser.email)}}
+        {{#link-to 'events.view.speakers.edit' model.event.id speaker.id}}
+          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
+          {{#if device.isMobile}}
+            <div class="ui hidden fitted divider"></div>
+          {{/if}}
+        {{/link-to}}
+      {{/if}}
     {{/each}}
     {{#if isUpcoming}}
       <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}" {{action 'openProposalDeleteModal'}}>{{t 'Withdraw Proposal'}}</button>
@@ -42,9 +44,11 @@
       <div class="field">
         <div class="ui divider"></div>
         <h1 class="ui header"> {{model.title}} </h1>
-        {{#each model.speakers as |speaker|}}
-          <h4 class="ui header"> {{speaker.name}} </h4>
-        {{/each}}
+        <h4 class="ui header">
+          {{#each model.speakers as |speaker|}}
+            {{speaker.name}}
+          {{/each}}
+        </h4>
         <h2 class="ui sub header"> <div class="ui gray-text">{{t 'From '}}{{moment-format model.startAt 'ddd, MMM DD h:mm A'}}{{t ' to '}}{{moment-format model.endsAt 'ddd, MMM DD h:mm A'}}</div> </h2>
       </div>
       <div class="ui divider"></div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


#### Changes proposed in this pull request:

- In my-sessions the edit speaker button only appears if the user is a speaker of that session (as in v1).
- All the speakers are listed in a line under the session title instead of coming as individual headings.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2149 
