### PR TITLE
responsive events table view for tablet screens.

### DIFF
--- a/app/templates/components/ui-table.hbs
+++ b/app/templates/components/ui-table.hbs
@@ -13,7 +13,7 @@
     {{/if}}
   </div>
   <div class="ui row">
-    <div class="{{themeInstance.classes.innerTableWrapper}}">
+    <div class="{{themeInstance.classes.innerTableWrapper}} x-scrollable">
       <table class="{{themeInstance.classes.table}}">
         <thead class="{{if noHeaderFilteringAndSorting 'table-header-no-filtering-and-sorting'}} {{themeInstance.classes.thead}}">
           {{#if groupedHeaders.length}}

--- a/app/themes/semantic.js
+++ b/app/themes/semantic.js
@@ -22,7 +22,7 @@ export default Default.extend({
   classes: {
     outerTableWrapper              : 'ui ui-table',
     innerTableWrapper              : 'ui segment column sixteen wide inner-table-wrapper',
-    table                          : 'ui tablet stackable very basic table',
+    table                          : 'ui very basic table',
     globalFilterWrapper            : 'ui row',
     columnsDropdownWrapper         : 'right floated columns-dropdown',
     columnsDropdownButtonWrapper   : 'buttons',


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This makes the tablet screen view responsive by adding an x-scroll to table for `events/live` page.

#### Changes proposed in this pull request:

- add the `x-scrollable` class to the table and make table not `tablet stackable`.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2209 
![screenshot from 2019-02-27 20-59-33](https://user-images.githubusercontent.com/21174572/53501852-ed486a80-3ad2-11e9-8faf-a9d21bfd18a0.png)
