### PR TITLE
make SMTP username and password field optional.

### DIFF
--- a/app/components/forms/admin/settings/system-form.js
+++ b/app/components/forms/admin/settings/system-form.js
@@ -162,26 +162,6 @@ export default Component.extend(FormMixin, {
           ]
         },
 
-        smtpUsername: {
-          identifier : 'smtp_username',
-          rules      : [
-            {
-              type   : 'empty',
-              prompt : this.get('l10n').t('Please enter the username for SMTP')
-            }
-          ]
-        },
-
-        smtpPassword: {
-          identifier : 'smtp_password',
-          rules      : [
-            {
-              type   : 'empty',
-              prompt : this.get('l10n').t('Please enter the password for SMTP')
-            }
-          ]
-        },
-
         sendgridToken: {
           identifier : 'sendgrid_token',
           rules      : [


### PR DESCRIPTION
Fixes: #2238

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This makes the username and password field in the SMTP host server settings optional.

#### Changes proposed in this pull request:

- make username and password optional in SMTP host settings.
