### PR TITLE
saved events column removed from user tickets page

### DIFF
--- a/app/routes/admin/users/view/tickets/list.js
+++ b/app/routes/admin/users/view/tickets/list.js
@@ -8,8 +8,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
         return this.get('l10n').t('Upcoming');
       case 'past':
         return this.get('l10n').t('Past');
-      case 'saved':
-        return this.get('l10n').t('Saved');
     }
   },
   model() {

--- a/app/templates/admin/users/view/tickets.hbs
+++ b/app/templates/admin/users/view/tickets.hbs
@@ -8,9 +8,6 @@
         {{#link-to 'admin.users.view.tickets.list' 'upcoming' class='item'}}
           {{t 'Upcoming Events'}}
         {{/link-to}}
-        {{#link-to 'admin.users.view.tickets.list' 'saved' class='item'}}
-          {{t 'Saved Events'}}
-        {{/link-to}}
         {{#link-to 'admin.users.view.tickets.list' 'past' class='item'}}
           {{t 'Past Events'}}
         {{/link-to}}


### PR DESCRIPTION
#### Short description of what this resolves:
saved events column is removed from user tickets page

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2252 
