### PR TITLE
Resolving event refresh after event is deleted

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -84,6 +84,7 @@ export default Controller.extend({
         .then(() => {
           this.set('isLoading', false);
           this.notify.success(this.get('l10n').t('Event has been deleted successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
           this.set('isLoading', false);

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -73,14 +73,15 @@ export default Controller.extend({
         event.destroyRecord();
       })
         .then(() => {
-          this.set('isLoading', false);
           this.notify.success(this.get('l10n').t('Event has been deleted successfully.'));
           this.send('refreshRoute');
         })
         .catch(() => {
-          this.set('isLoading', false);
           this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
-        });
+        })
+        .finally(() => {
+          this.set('isLoading', false);
+        }
       this.set('isEventDeleteModalOpen', false);
     }
   }

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -81,7 +81,7 @@ export default Controller.extend({
         })
         .finally(() => {
           this.set('isLoading', false);
-        }
+        });
       this.set('isEventDeleteModalOpen', false);
     }
   }

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -73,13 +73,13 @@ export default Controller.extend({
         event.destroyRecord();
       })
         .then(() => {
+          this.set('isLoading', false);
           this.notify.success(this.get('l10n').t('Event has been deleted successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
-          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
-        })
-        .finally(() => {
           this.set('isLoading', false);
+          this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));
         });
       this.set('isEventDeleteModalOpen', false);
     }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Whenever an event is deleted from 'Admin/Events' Or from 'Events/Live' , It stays in cache until the page is refreshed.

#### Changes proposed in this pull request:

-Page reloads after any event is deleted or restored.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2259 
