### PR TITLE
fix : Add all sessions tab in my-sessions

### DIFF
--- a/app/routes/my-sessions/list.js
+++ b/app/routes/my-sessions/list.js
@@ -14,7 +14,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
   model(params) {
     this.set('params', params);
     let filterOptions = [];
-    if (params.session_status === 'upcoming') {
+    if (params.session_status === 'all') {
+      filterOptions = [];
+    } else if (params.session_status === 'upcoming') {
       filterOptions = [
         {
           name : 'starts-at',

--- a/app/templates/my-sessions.hbs
+++ b/app/templates/my-sessions.hbs
@@ -5,11 +5,14 @@
     <div class="row">
       <div class="sixteen wide column">
         {{#tabbed-navigation}}
+          {{#link-to 'my-sessions.list' 'all' class='item'}}
+            {{t 'All Sessions'}}
+          {{/link-to}}
           {{#link-to 'my-sessions.list' 'upcoming' class='item'}}
-            {{t 'Upcoming Sessions'}}
+            {{t 'Upcoming Scheduled Sessions'}}
           {{/link-to}}
           {{#link-to 'my-sessions.list' 'past' class='item'}}
-            {{t 'Past Sessions'}}
+            {{t 'Past Scheduled Sessions'}}
           {{/link-to}}
         {{/tabbed-navigation}}
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds a new tab which shows all the sessions of the concerned user by setting the filter to `[ ]` for that `token` 

#### Changes proposed in this pull request:

- Add a new tab in my-sessions
- Add corresponding route
![image](https://user-images.githubusercontent.com/21087061/53886748-b6c89d80-4046-11e9-961d-938f7687828b.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2262 
