### PR TITLE
Add spacing between buttons and tickets in create event page.

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -181,6 +181,7 @@
           </h3>
         {{/if}}
       </div>
+      <br>
       <button type="button" class="ui blue small button" {{action 'addTicket' 'free' data.event.tickets.length}}>
         <i class="large icons basic-details">
           <i class="smile icon"></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds a space after the tickets box to separate ticket box and buttons.

#### Changes proposed in this pull request:

- Add a `<br>` to introduce the spacing.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![screenshot from 2019-03-08 14-23-35](https://user-images.githubusercontent.com/21174572/54018167-f6f66000-41ad-11e9-8dcd-71fb588ec0d0.png)


Fixes: #2275 
