### PR TITLE
enh : modify sessions filter to shows all states

### DIFF
--- a/app/routes/my-sessions/list.js
+++ b/app/routes/my-sessions/list.js
@@ -17,9 +17,27 @@ export default Route.extend(AuthenticatedRouteMixin, {
     if (params.session_status === 'upcoming') {
       filterOptions = [
         {
-          name : 'starts-at',
-          op   : 'ge',
-          val  : moment().toISOString()
+          or: [
+            {
+              name : 'starts-at',
+              op   : 'ge',
+              val  : moment().toISOString()
+            },
+            {
+              and: [
+                {
+                  name : 'starts-at',
+                  op   : 'eq',
+                  val  : null
+                },
+                {
+                  name : 'ends-at',
+                  op   : 'eq',
+                  val  : null
+                }
+              ]
+            }
+          ]
         }
       ];
     } else {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds a new tab which shows all the sessions of the concerned user by setting the filter to `[ ]` for that `token` 

#### Changes proposed in this pull request:

- Add a new tab in my-sessions
- Add corresponding route
![image](https://user-images.githubusercontent.com/21087061/53886748-b6c89d80-4046-11e9-961d-938f7687828b.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2262 
