### PR TITLE
fix : use my-sessions.view instead of edit route

### DIFF
--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -70,7 +70,7 @@ export default Controller.extend({
       this.transitionToRoute('events.view.sessions.edit', id);
     },
     viewSession(id) {
-      this.transitionToRoute('events.view.sessions.edit', id);
+      this.transitionToRoute('my-sessions.view', id);
     },
     acceptProposal(session, sendEmail) {
       session.set('sendEmail', sendEmail);


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This makes sure that view sessions doesn't re route to edit session link

#### Changes proposed in this pull request:

- use `my-sessions.view` route instead of edit route

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2293 
