### PR TITLE
Fixed bug in start date

### DIFF
--- a/app/components/widgets/forms/date-picker.js
+++ b/app/components/widgets/forms/date-picker.js
@@ -14,12 +14,13 @@ export default Component.extend({
   format        : FORM_DATE_FORMAT,
 
   options: {},
-
   didInsertElement() {
     this._super(...arguments);
+    const mindate = new Date();
     const defaultOptions = {
       type      : 'date',
       today     : this.get('today'),
+      minDate   : mindate,
       formatter : {
         date: date => {
           if (!date) {return ''}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixed bug in start date. Now the user cannot select a start date before the current date.

#### Changes proposed in this pull request:
![Screenshot 2019-03-15 at 11 02 24 PM](https://user-images.githubusercontent.com/31013104/54445246-f1cd7e00-4776-11e9-8290-4899ff001284.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2301 
