### PR TITLE
Remove google plus from share events

### DIFF
--- a/app/templates/components/modals/event-share-modal.hbs
+++ b/app/templates/components/modals/event-share-modal.hbs
@@ -10,9 +10,6 @@
     <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/tweet?url={{url-encode event.url}}&text={{url-encode event.name}}">
       <i class="bordered link inverted colored twitter large icon"></i>
     </a>
-    <a target="_blank" rel="noopener noreferrer" href="https://plus.google.com/share?url={{url-encode event.url}}">
-      <i class="bordered link inverted colored google plus large icon"></i>
-    </a>
     <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/shareArticle?url={{url-encode event.url}}&title={{url-encode event.name}}">
       <i class="bordered link inverted colored linkedin large icon"></i>
     </a>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
As google plus will shut down on April 2, 2019, it is no longer needed in 'share events'

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2299 
