### PR TITLE
Align System Images as two per row

### DIFF
--- a/app/templates/admin/content/system-images/list.hbs
+++ b/app/templates/admin/content/system-images/list.hbs
@@ -1,10 +1,12 @@
-<div class="ui segment">
+<div class="ui grid segment">
   {{#each data as |subTopic|}}
-    <h4>{{subTopic.name}}</h4>
-    {{widgets/safe-image isAvatar=true class='ui big image' src=(if subTopic.placeholder.originalImageUrl subTopic.placeholder.originalImageUrl
-      '/images/placeholders/avatar.png')}}
-    <div class="ui hidden divider"></div>
-    <button class="ui button primary" {{action 'openModal' subTopic.placeholder}} id="changebutton">{{t 'Change'}}</button>
+    <div class="eight wide column">
+      <h4>{{subTopic.name}}</h4>
+      {{widgets/safe-image isAvatar=true class='ui big image' src=(if subTopic.placeholder.originalImageUrl subTopic.placeholder.originalImageUrl
+        '/images/placeholders/avatar.png')}}
+      <div class="ui hidden divider"></div>
+      <button class="ui button primary" {{action 'openModal' subTopic.placeholder}} id="changebutton">{{t 'Change'}}</button>
+    </div>
   {{/each}}
 </div>
 {{modals/change-image-modal isOpen=isModalOpen placeholder=selectedPlaceholder}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Align System Images as two per row
#### Changes proposed in this pull request:
![Screenshot 2019-03-19 at 12 23 38 PM](https://user-images.githubusercontent.com/31013104/54582095-0e510b00-4a42-11e9-9965-bfd86e31b644.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2321 
