### PR TITLE
Align Amount and Percent in Enter Discount on the same line

### DIFF
--- a/app/templates/components/forms/events/view/create-discount-code.hbs
+++ b/app/templates/components/forms/events/view/create-discount-code.hbs
@@ -6,15 +6,14 @@
   <div class="field">
     <label class="required">{{t 'Enter Discount'}}</label>
     {{ui-radio label=(t 'Amount (US$)') name='discount_type'  value='amount' current=data.type onChange=(action (mut data.type))}}
+    &nbsp;
+    {{ui-radio label=(t 'Percent (%)') name='discount_type'  value='percent' current=data.type onChange=(action (mut data.type))}}
   </div>
   {{#if (not-eq data.type 'percent')}}
     <div class="field">
       {{input type='number' name='discount_amount' min=1 step=0.1 value=data.value}}
     </div>
   {{/if}}
-  <div class="field">
-    {{ui-radio label=(t 'Percent (%)') name='discount_type'  value='percent' current=data.type onChange=(action (mut data.type))}}
-  </div>
   {{#if (eq data.type 'percent')}}
     <div class="field">
       {{input type='number' name='discount_percent' min=1 max=100 step=0.1 value=data.value}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Align Amount and Percent in Enter Discount on the same line

#### Changes proposed in this pull request:
![Screenshot 2019-03-19 at 4 21 52 PM](https://user-images.githubusercontent.com/31013104/54594488-5c2a3b00-4a63-11e9-9347-01d216d1cf0c.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2322 
