### PR TITLE
Manage Events: Makes values of Access Code URL in Tickets section a link

### DIFF
--- a/app/controllers/events/view/tickets/access-codes/list.js
+++ b/app/controllers/events/view/tickets/access-codes/list.js
@@ -9,6 +9,7 @@ export default Controller.extend({
     {
       propertyName   : 'accessUrl',
       title          : 'Access Code URL',
+      template       : 'components/ui-table/cell/events/view/tickets/access-codes/cell-url',
       disableSorting : true
     },
     {

--- a/app/templates/components/ui-table/cell/events/view/tickets/access-codes/cell-url.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/access-codes/cell-url.hbs
@@ -1,0 +1,1 @@
+<a href='{{record.accessUrl}}' target='_blank' rel='noopener'> {{record.accessUrl}} </a>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently, the `Access Code URL` column in `Access Codes` of `Tickets` section in Manage Events is not a link. It is simply a text

#### Changes proposed in this pull request:

- Makes values of Access Code URL in Tickets section a link

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2329 
