### PR TITLE
fix : add location removal in explore filter

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -11,8 +11,8 @@ export default Component.extend({
 
   customEndDate: null,
 
-  hideClearFilters: computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', function() {
-    return !(this.get('category') || this.get('sub_category') || this.get('event_type') || this.get('startDate') || this.get('endDate'));
+  hideClearFilters: computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', 'location', function() {
+    return !(this.get('category') || this.get('sub_category') || this.get('event_type') || this.get('startDate') || this.get('endDate') || this.get('location') !== null);
   }),
 
   dateRanges: computed(function() {
@@ -103,6 +103,7 @@ export default Component.extend({
       this.set('category', null);
       this.set('sub_category', null);
       this.set('event_type', null);
+      this.set('location', null);
     }
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
after this commit, `event_location` can be cleared by clear filter option

#### Changes proposed in this pull request:

- use `location` as a filter disabling factor

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2332 
