### PR TITLE
External event URL fixed on public and event's general info

### DIFF
--- a/app/templates/components/public/social-links.hbs
+++ b/app/templates/components/public/social-links.hbs
@@ -1,9 +1,9 @@
 <div class="ui list">
-  {{#if eventUrl}}
+  {{#if externalUrl}}
     <div class="item">
       <i class="share square fitted disabled icon"></i>
       <div class="content">
-        <a href="{{eventUrl}}" target="_blank" rel="noopener nofollow">{{t 'External event URL'}}</a>
+        <a href="{{externalUrl}}" target="_blank" rel="noopener nofollow">{{t 'External event URL'}}</a>
       </div>
     </div>
   {{/if}}

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -40,7 +40,7 @@
       </div>
       <div class="three wide column public">
         {{#if (not-eq session.currentRouteName 'public.cfs.new-speaker')}}
-          {{public/social-links eventUrl=model.url socialLinks=model.socialLinks}}
+          {{public/social-links externalUrl=model.externalEventUrl socialLinks=model.socialLinks}}
         {{/if}}
       </div>
     </div>

--- a/tests/integration/components/public/social-links-test.js
+++ b/tests/integration/components/public/social-links-test.js
@@ -7,8 +7,8 @@ module('Integration | Component | public/social links', function(hooks) {
   setupIntegrationTest(hooks);
 
   test('it renders', async function(assert) {
-    this.set('eventUrl', 'https://example.com');
-    await render(hbs`{{public/social-links eventUrl=eventUrl}}`);
+    this.set('externalEventUrl', 'https://example.com');
+    await render(hbs`{{public/social-links externalUrl=externalEventUrl}}`);
     assert.ok(this.element.innerHTML.trim().includes('https://example.com'));
   });
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

   - Currently the External Event URL on the main page of event i.e. public, is having wrong link. It should have external link but it has same link as that of the public page
   - Also, the General Info of event is not having Exteral event URL. It only has Social Media Links.

#### Changes proposed in this pull request:

- Fixed URL on event's public route
- Included External event URL on General Info of event

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2334 
