### PR TITLE
Speaker Table:Disable sorting on speaker-logo and remove null on mobile

### DIFF
--- a/app/controllers/events/view/speakers/list.js
+++ b/app/controllers/events/view/speakers/list.js
@@ -3,9 +3,10 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   columns: [
     {
-      propertyName : 'thumbnailImageUrl',
-      title        : ' ',
-      template     : 'components/ui-table/cell/events/view/speakers/speaker-logo'
+      propertyName   : 'thumbnailImageUrl',
+      title          : ' ',
+      template       : 'components/ui-table/cell/events/view/speakers/speaker-logo',
+      disableSorting : true
     },
     {
       propertyName : 'name',
@@ -17,6 +18,7 @@ export default Controller.extend({
     },
     {
       propertyName : 'mobile',
+      template     : 'components/ui-table/cell/events/view/speakers/speaker-mobile',
       title        : 'Phone'
     },
     {

--- a/app/templates/components/ui-table/cell/events/view/speakers/speaker-mobile.hbs
+++ b/app/templates/components/ui-table/cell/events/view/speakers/speaker-mobile.hbs
@@ -1,0 +1,5 @@
+{{#if (not-eq record.mobile null)}}
+  {{record.mobile}}
+{{else}}
+  {{t 'Not Provided'}}
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
   - Sorting in not disabled for speakers-logo
   - If Phone Number is not present, null should be removed

#### Changes proposed in this pull request:
   - Sorting disabled on Speakers Logo
   - If mobile is not present, `null` is removed

![Screenshot_2019-03-20 Speakers APK19 Events Open Event(2)](https://user-images.githubusercontent.com/25428397/54675708-15047e80-4b25-11e9-9b40-dd3bbcc1a511.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2342 
