### PR TITLE
My Session: Fixes timestamp of accepted and pending sessions

### DIFF
--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -49,7 +49,11 @@
             {{speaker.name}}
           {{/each}}
         </h4>
-        <h2 class="ui sub header"> <div class="ui gray-text">{{t 'From '}}{{moment-format model.startAt 'ddd, MMM DD h:mm A'}}{{t ' to '}}{{moment-format model.endsAt 'ddd, MMM DD h:mm A'}}</div> </h2>
+        {{#if (not-eq model.startsAt null)}}
+          <h2 class="ui sub header"> <div class="ui gray-text">{{t 'From '}}{{moment-format model.startsAt 'ddd, MMM DD h:mm A'}}{{t ' to '}}{{moment-format model.endsAt 'ddd, MMM DD h:mm A'}}</div> </h2>
+        {{else}}
+          <h2 class="ui sub header"> <div class="ui gray-text">{{t 'Session Not Yet Scheduled'}}</div></h2>
+        {{/if}}
       </div>
       <div class="ui divider"></div>
       {{#if model.shortAbstract}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently, the start timestamp for any scheduled session is incorrect.
Also, if the session is not scheduled, it shows `From Invalid date to Invalid date`

#### Changes proposed in this pull request:
    - For accepted session, the timestamp should be correct.
    - For session which is not scheduled, it should show Session Not Yet Scheduled

_Pending Session_
![Screenshot_2019-03-20 Sessions My sessions Open Event(2)](https://user-images.githubusercontent.com/25428397/54680099-ff945200-4b2e-11e9-8bb0-4344a8f929e4.png)

_Accepted Session_
![Screenshot_2019-03-20 Sessions My sessions Open Event(3)](https://user-images.githubusercontent.com/25428397/54680103-002ce880-4b2f-11e9-8982-985693d00a5a.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2349 
