### PR TITLE
fix: social media color in public route

### DIFF
--- a/app/styles/partials/colors.scss
+++ b/app/styles/partials/colors.scss
@@ -1,30 +1,48 @@
 i.facebook {
-  &:not(.colored.inverted) {
-    color: #3b5998;
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #3b5998;
+    }
   }
 }
 
 i.twitter {
-  &:not(.colored.inverted) {
-    color: #3cf;
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #3cf;
+    }
+  }
+}
+
+i.github {
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #333;
+    }
   }
 }
 
 i.google.plus {
-  &:not(.colored.inverted) {
-    color: #63cd2d;
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #63cd2d;
+    }
   }
 }
 
 i.linkedin {
-  &:not(.colored.inverted) {
-    color: #4875b4;
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #4875b4;
+    }
   }
 }
 
 i.reddit {
-  &:not(.colored.inverted) {
-    color: #ff4500;
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #ff4500;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently, social media links in `public` route is not applicable due to incorrect scss code.

#### Changes proposed in this pull request:
- fixed scss code
- added github color code

_Featured Speakers_
![Screenshot_2019-03-21 APK19 Open Event(1)](https://user-images.githubusercontent.com/25428397/54742844-793c4680-4be8-11e9-8da0-95a26a05765d.png)

_Sessions_
![Screenshot_2019-03-21 Sessions APK19 Open Event(1)](https://user-images.githubusercontent.com/25428397/54751302-86fdc600-4c00-11e9-8772-16a176f057a5.png)



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2357 
