### PR TITLE
fix: make accepted sessions visible on public route

### DIFF
--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -42,9 +42,18 @@ export default Route.extend({
                 val  : moment().endOf('day').toISOString()
               },
               {
-                name : 'state',
-                op   : 'eq',
-                val  : 'confirmed'
+                or: [
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'confirmed'
+                  },
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'accepted'
+                  }
+                ]
               }
             ]
           }
@@ -75,9 +84,18 @@ export default Route.extend({
                 val  : moment().endOf('week').toISOString()
               },
               {
-                name : 'state',
-                op   : 'eq',
-                val  : 'confirmed'
+                or: [
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'confirmed'
+                  },
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'accepted'
+                  }
+                ]
               }
             ]
           }
@@ -108,9 +126,18 @@ export default Route.extend({
                 val  : moment().add('month').toISOString()
               },
               {
-                name : 'state',
-                op   : 'eq',
-                val  : 'confirmed'
+                or: [
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'confirmed'
+                  },
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'accepted'
+                  }
+                ]
               }
             ]
           }
@@ -131,9 +158,18 @@ export default Route.extend({
                 }
               },
               {
-                name : 'state',
-                op   : 'eq',
-                val  : 'confirmed'
+                or: [
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'confirmed'
+                  },
+                  {
+                    name : 'state',
+                    op   : 'eq',
+                    val  : 'accepted'
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently, `accepted` sessions are not visible in `Sessions` tab of public route e.g. on `/e/<event id>/sessions/s/all`.

#### Changes proposed in this pull request:
 - `accepted` sessions made visible

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2359 
