### PR TITLE
Redesigns the session-item on public route

### DIFF
--- a/app/components/public/session-item.js
+++ b/app/components/public/session-item.js
@@ -1,5 +1,13 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-  classNames: ['ui', 'segment']
+  classNames: ['ui', 'segment'],
+
+  hideImage: false,
+
+  actions: {
+    hideSpeakerImage() {
+      this.toggleProperty('hideImage');
+    }
+  }
 });

--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -1,5 +1,5 @@
 {{#ui-accordion}}
-  <div class="title">
+  <div class="title" {{action 'hideSpeakerImage'}} role="button">
     <div class="ui">
       <h3 class="ui header">
         {{session.title}}
@@ -11,19 +11,29 @@
     </div>
     <br>
     <div class="ui grid stackable">
-      <div class="left floated eleven wide column">
-        <div class="session-speakers">
-          {{#each session.speakers as |speaker|}}
-            <img alt="speaker" class="ui mini avatar image" src="{{if speaker.photo.iconImageUrl speaker.photo.iconImageUrl '/images/placeholders/avatar.png'}}">
-          {{/each}}
+      {{#if hideImage}}
+        <div class="left floated five wide column">
+          {{#if session.startsAt}}
+            <div class=""><i class="marker icon"></i>{{session.microlocation.name}}</div>
+            <div class="small text"><i class="wait icon"></i>{{moment-format session.startsAt 'hh:mm a / DD-MM-YYYY'}}</div>
+          {{/if}}
         </div>
-      </div>
-      <div class="right floated five wide column">
-        {{#if session.startsAt}}
-          <div class=""><i class="marker icon"></i>{{session.microlocation.name}}</div>
-          <div class="small text"><i class="wait icon"></i>{{moment-format session.startsAt 'hh:mm a / DD-MM-YYYY'}}</div>
-        {{/if}}
-      </div>
+      {{else}}
+        <div class="left floated eleven wide column">
+          <div class="session-speakers">
+            {{#each session.speakers as |speaker|}}
+              <img alt="speaker" class="ui mini avatar image" src="{{if speaker.photo.iconImageUrl speaker.photo.iconImageUrl '/images/placeholders/avatar.png'}}">
+            {{/each}}
+          </div>
+        </div>
+        <div class="right floated five wide column">
+          {{#if session.startsAt}}
+            <div class=""><i class="marker icon"></i>{{session.microlocation.name}}</div>
+            <div class="small text"><i class="wait icon"></i>{{moment-format session.startsAt 'hh:mm a / DD-MM-YYYY'}}</div>
+          {{/if}}
+        </div>
+      {{/if}}
+
       <div class="row">
         <div class="column session-description">
           {{sanitize session.shortAbstract}}
@@ -33,17 +43,17 @@
   </div>
   <div class="content">
     {{#each session.speakers as |speaker|}}
-      <h3 class="ui header">{{speaker.name}}</h3>
-      <img alt="speaker" class="ui mini avatar image" src="{{if speaker.photo.iconImageUrl speaker.photo.iconImageUrl '/images/placeholders/avatar.png'}}">
+      <div class="ui divider"></div>
+      <img alt="speaker" class="ui tiny avatar image" src="{{if speaker.photo.iconImageUrl speaker.photo.iconImageUrl '/images/placeholders/avatar.png'}}">
       <p>
+        <br>
+        {{speaker.name}}
+        <br>
         {{#if speaker.shortBiography}}
-          <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
           {{sanitize speaker.shortBiography}}
         {{else if speaker.longBiography}}
-          <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
           {{sanitize speaker.longBiography}}
         {{else if speaker.speakingExperience}}
-          <h4 class="ui header">{{t 'About '}}{{speaker.name}}</h4>
           {{sanitize speaker.speakingExperience}}
         {{/if}}
       </p>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Duplicate images appearing in `session-item`.

#### Changes proposed in this pull request:
 - When the user click on the session the image on the top disappears and image should be above speaker description.

![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/25428397/54807594-bd405180-4ca3-11e9-8f18-7e889e2145a1.gif)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2361 
