### PR TITLE
Explore route: Pre-fetch event-topics, sub-topics, event-types

### DIFF
--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -146,8 +146,9 @@ export default Route.extend({
     }
 
     return this.store.query('event', {
-      sort   : 'starts-at',
-      filter : filterOptions
+      sort    : 'starts-at',
+      filter  : filterOptions,
+      include : 'event-topic,event-sub-topic,event-type'
     });
   },
 


### PR DESCRIPTION
Prevents the explore route from making separate network requests to event-topic, sub-topic, and types APIs and thus 404s for non-defined objects are handled automatically.