### PR TITLE
Redirect back to create route after login

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -97,6 +97,23 @@ export default Route.extend(ApplicationRouteMixin, {
           this.set('session.previousRouteName', null);
         }
       });
+      transition.catch(() => {
+        // to catch the aborted transition exception
+        let params = this._mergeParams(transition.params);
+        let url;
+        // generate doesn't like empty params.
+        if (isEmpty(params)) {
+          url = transition.router.generate(transition.targetName);
+        } else {
+          url = transition.router.generate(transition.targetName, params);
+        }
+        // Do not save the url of the transition to login route.
+        if (!url.includes('login') && !url.includes('reset-password')) {
+          this.set('session.previousRouteName', url);
+        } else {
+          this.set('session.previousRouteName', null);
+        }
+      });
     }
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Guest user was not redirected back to the create route after he/she successfully logins (when the guest user tries to visit ```create event``` route). Which was not correct.

#### Changes proposed in this pull request:
Now the guest user will be redirected back to create route after login

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2370 