### PR TITLE
Show correct standard size of available area for Logo in Admin's image settings

### DIFF
--- a/app/templates/components/forms/admin/settings/images-form.hbs
+++ b/app/templates/components/forms/admin/settings/images-form.hbs
@@ -78,7 +78,7 @@
       {{input type='number' name='logo_height' value=image.eventImageSize.logoHeight min=1}}
     </div>
   </div>
-  {{t 'Standard Size of the available area is 500px X 200px'}}
+  {{t 'Standard Size of the available area is 32px X 32px'}}
   <div class="ui divider"></div>
   <h2 class="ui header">{{t 'Profile/Speaker Images'}}</h2>
   <h3 class="ui header">{{t 'Thumbnail Size'}}</h3>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Wrong standard size of available area was shown in the ```Logo Size (Event Wizard)``` section in the Admin's image settings.

#### Changes proposed in this pull request:
Show standard size as already filled in input fields (```Width``` and ```Height```). Like in other sections.
 
![standard-size-fix](https://user-images.githubusercontent.com/43299408/54934275-3bbb1e80-4f44-11e9-8248-14e4cdd24365.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2384 
