### PR TITLE
Event Start Time

### DIFF
--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -30,7 +30,7 @@ export default Component.extend({
 
     switch (this.get('rangePosition')) {
       case 'start':
-        defaultOptions.endCalendar = this.$().closest('.fields').find('.ui.calendar.time.picker');
+        defaultOptions.Calendar = this.$().closest('.fields').find('.ui.calendar.time.picker');
         break;
       case 'end':
         defaultOptions.startCalendar = this.$().closest('.fields').find('.ui.calendar.time.picker');


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It resolved the Time Picker issue in the event start time .

#### Changes proposed in this pull request:

- I was going through the semantic UI Calendar and there the keyword 'end' used for time attribute 
  sets default time to 00:00.
- This was creating issues in setting a proper start time.
- I just removed the 'end' , Project built well and i tried to create some events too and everything was   finely running.



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2077 
