### PR TITLE
add speaker state breakdown in general info tab of event overview

### DIFF
--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -66,7 +66,13 @@
       </tr>
       <tr>
         <td><strong>{{t 'No. of Speakers'}}</strong></td>
-        <td>{{data.statistics.speakers}}</td>
+        <td>
+          {{t 'All'}}: {{data.statistics.speakers}}
+          | {{t 'Accepted'}}: {{data.statistics.speakersAccepted}}
+          | {{t 'Pending'}}: {{data.statistics.speakersPending}}
+          | {{t 'Rejected'}}: {{data.statistics.speakersRejected}}
+          | {{t 'Confirmed'}}: {{data.statistics.speakersConfirmed}}
+        </td>
       </tr>
       <tr>
         <td><strong>{{t 'No. of Sessions'}}</strong></td>
@@ -76,6 +82,7 @@
           | {{t 'Pending'}}: {{data.statistics.sessionsPending}}
           | {{t 'Rejected'}}: {{data.statistics.sessionsRejected}}
           | {{t 'Draft'}}: {{data.statistics.sessionsDraft}}
+          | {{t 'Confirmed'}}: {{data.statistics.sessionsConfirmed}}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It adds a breakdown of speakers along the lines of breakdown of number of sesssions

#### Changes proposed in this pull request:

- using newly revamped event-statistics for the task

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2388 
