### PR TITLE
using default USD currency in admin/sales location

### DIFF
--- a/app/templates/admin/sales/locations.hbs
+++ b/app/templates/admin/sales/locations.hbs
@@ -26,11 +26,11 @@
             <tr>
               <td>{{entry.locationName}}</td>
               <td class="right aligned">{{entry.sales.completed.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{number-format entry.sales.completed.sales_total}}</td>
+              <td class="right aligned">US$ {{number-format entry.sales.completed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.placed.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{number-format entry.sales.placed.sales_total}}</td>
+              <td class="right aligned">US$ {{number-format entry.sales.placed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.pending.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{number-format entry.sales.pending.sales_total}}</td>
+              <td class="right aligned">US$ {{number-format entry.sales.pending.sales_total}}</td>
             </tr>
           {{/each}}
         </tbody>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
We can't use paymentCurrency of an event based on location because on a location, different events with different  currencies maybe present and they can't be displayed under a single tab using a single payment Currency unless standardised.

#### Changes proposed in this pull request:

- Use USD as default rendering currency

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2402 
