### PR TITLE
Add tooltip to event overview when in mobile view

### DIFF
--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -20,14 +20,20 @@
       <div class="twelve wide column {{unless device.isMobile 'right aligned'}}">
         {{#if device.isMobile}}
           <div class="ui icon fluid buttons">
-            <a href="{{href-to 'public' model.id}}" class="ui button">
-              <i class="unhide icon"></i>
-            </a>
-            <button class="ui button" {{action 'togglePublishState'}}>
+            {{#ui-popup content=(t 'Preview') class='ui icon button' position='bottom center'}}
+              <a href="{{href-to 'public' model.id}}" style="color:inherit">
+                <i class="unhide icon"></i>
+              </a>
+            {{/ui-popup}}
+            {{#ui-popup content=(t 'Publish') class='ui icon button' position='bottom center' click=(action 'togglePublishState')}}
               <i class="{{if (eq model.state 'published') 'ban' 'check'}} icon"></i>
-            </button>
-            <button class="ui button"><i class="copy icon"></i></button>
-            <button class="ui red button" {{action 'openDeleteEventModal'}}><i class="trash icon"></i></button>
+            {{/ui-popup}}
+            {{#ui-popup content=(t 'Copy') class='ui icon button' position='bottom center'}}
+              <i class="copy icon"></i>
+            {{/ui-popup}}
+            {{#ui-popup content=(t 'Delete') class='ui red icon button' position='bottom center' click=(action 'openDeleteEventModal')}}
+              <i class="trash icon"></i>
+            {{/ui-popup}}
           </div>
         {{else}}
           <a href="{{href-to 'public' model.id}}" class="ui button labeled icon small">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add tooltip to event overview when in mobile view

#### Changes proposed in this pull request:
![Screenshot 2019-03-27 at 8 12 36 PM](https://user-images.githubusercontent.com/31013104/55085769-3b9a5a80-50cd-11e9-9cae-c999688bd626.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2409 
