### PR TITLE
Fix: Side Menu - invalid operation on null string

### DIFF
--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -10,6 +10,6 @@ export default Component.extend({
       speakersCall.announcement && (speakersCall.privacy === 'public'));
   },
   isSchedulePublished: computed('event.schedulePublishedOn', function() {
-    return this.get('event.schedulePublishedOn').toISOString() !== moment(0).toISOString();
+    return this.get('event.schedulePublishedOn') && this.get('event.schedulePublishedOn').toISOString() !== moment(0).toISOString();
   })
 });


### PR DESCRIPTION
Makes sure that `toISOString()` is not called on a null string.

Fixes #2435