### PR TITLE
Public side menu: Avoid referencing null speakers-call

### DIFF
--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -7,7 +7,7 @@ export default Component.extend({
     this._super(...arguments);
     let speakersCall = await this.get('event.speakersCall');
     this.set('shouldShowCallforSpeakers',
-      speakersCall.announcement && (speakersCall.privacy === 'public'));
+      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
   },
   isSchedulePublished: computed('event.schedulePublishedOn', function() {
     return this.get('event.schedulePublishedOn').toISOString() !== moment(0).toISOString();


### PR DESCRIPTION
Fixes the uncaught exception generated due to referencing of a null speakers-call on the public page.

Fixes #2421
