### PR TITLE
Public event page: prefetch speakers-call

### DIFF
--- a/app/routes/public.js
+++ b/app/routes/public.js
@@ -8,7 +8,7 @@ export default Route.extend({
 
   model(params) {
     return this.store.findRecord('event', params.event_id, {
-      include: 'social-links,event-copyright'
+      include: 'social-links,event-copyright,speakers-call'
     });
   }
 });


### PR DESCRIPTION
Prefetches the speakers call on the public event route so that an uncaught 404 is not generated.

#2424