### PR TITLE
Fix discount code creation for ongoing events

### DIFF
--- a/app/routes/events/view/tickets/discount-codes/create.js
+++ b/app/routes/events/view/tickets/discount-codes/create.js
@@ -32,7 +32,7 @@ export default Route.extend({
     let currentDiscountCode = model.discountCode;
     let event = this.modelFor('events.view');
     currentDiscountCode.set('validFrom', moment().toISOString());
-    currentDiscountCode.set('validTill', event.startsAt);
+    currentDiscountCode.set('validTill', event.endsAt);
     currentDiscountCode.set('minQuantity', 1);
     currentDiscountCode.set('maxQuantity', 1);
   }


### PR DESCRIPTION
sets the default `validTill` value to the end of the event instead of the start.

Fixes #2425 