### PR TITLE
Fixes the incorrect message popped to the unverified users

### DIFF
--- a/app/templates/components/unverified-user-message.hbs
+++ b/app/templates/components/unverified-user-message.hbs
@@ -5,7 +5,7 @@
     <div class="content">
       {{#if isMailSent}}
         <div class="header">
-          {{t 'Cofirmation mail has been sent again successfully!'}}
+          {{t 'Confirmation mail has been sent again successfully!'}}
         </div>
       {{else}}
         <div class="header">

--- a/tests/integration/components/unverified-user-message-test.js
+++ b/tests/integration/components/unverified-user-message-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | unverified user message', function(hooks) {
     this.set('shouldShowMessage', true);
     this.set('isMailSent', true);
     await render(hbs`{{unverified-user-message shouldShowMessage=shouldShowMessage isMailSent=isMailSent}}`);
-    assert.ok(this.element.innerHTML.trim().includes('Cofirmation mail has been sent again successfully'));
+    assert.ok(this.element.innerHTML.trim().includes('Confirmation mail has been sent again successfully'));
   });
 
   test('it renders', async function(assert) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves: 

Incorrect message has been displayed to the user while verifying their acoount .

#### Changes proposed in this pull request:

- corrected the popout message



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2437 

#### Additional text
Please see the commit
