### PR TITLE
Code optimization : Explore route :: Remove redundant computed properties

### DIFF
--- a/app/components/event-card.js
+++ b/app/components/event-card.js
@@ -6,18 +6,6 @@ import { pascalCase } from 'open-event-frontend/utils/string';
 export default Component.extend({
   classNames: ['column'],
 
-  categoryTag: computed(function() {
-    return this.get('event.topic');
-  }),
-
-  eventTypeTag: computed(function() {
-    return this.get('event.type');
-  }),
-
-  subCategoryTag: computed(function() {
-    return this.get('event.subTopic');
-  }),
-
   tags: computed('event.type', 'event.topic', 'event.subTopic', function() {
     const tagsOriginal = this.getProperties('event.topic.name', 'event.type.name', 'event.subTopic.name');
     let tags = [];

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -35,21 +35,27 @@
         {{#if hasBlock}}
           {{yield}}
         {{else}}
-          <a href="#"
-            class="link item {{if (eq category categoryTag.name) 'active'}}"
-            {{action 'selectCategory' categoryTag.name}}>
-            {{tags.[0]}}
-          </a>
-          <a href="#"
-            class="link item {{if (eq eventType eventTypeTag.name) 'active'}}"
-            {{action 'selectEventType' eventTypeTag.name}}>
-            {{tags.[1]}}
-          </a>
-          <a href="#"
-            class="link item {{if (eq subCategory subCategoryTag.slug) 'active'}}"
-            {{action 'selectCategory' categoryTag.name subCategoryTag.slug}}>
-            {{tags.[2]}}
-          </a>
+          {{#if filterByTags}}
+            <a href="#"
+               class="link item {{if (eq category event.topic.name) 'active'}}"
+              {{action 'selectCategory' event.topic.name}}>
+              {{tags.[0]}}
+            </a>
+            <a href="#"
+               class="link item {{if (eq eventType event.type.name) 'active'}}"
+              {{action 'selectEventType' event.type.name}}>
+              {{tags.[1]}}
+            </a>
+            <a href="#"
+               class="link item {{if (eq subCategory event.subTopic.slug) 'active'}}"
+              {{action 'selectCategory' event.topic.name event.subTopic.slug}}>
+              {{tags.[2]}}
+            </a>
+          {{else}}
+            {{#each tags as |tag|}}
+              <a>{{tag}}</a>s
+            {{/each}}
+          {{/if}}
         {{/if}}
       </span>
     </div>

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -5,7 +5,7 @@
   <div class="twelve wide column">
     <h1 class="ui header">{{t 'Events'}}</h1>
     {{#each filteredEvents as |event|}}
-      {{event-card event=event isWide=true category=category subCategory=sub_category eventType=event_type shareEvent=(action 'shareEvent')}}
+      {{event-card event=event isWide=true filterByTags=true category=category subCategory=sub_category eventType=event_type shareEvent=(action 'shareEvent')}}
       <div class="ui hidden divider"></div>
     {{else}}
       <div class="ui disabled header">{{t 'No events found for selected filters'}}</div>


### PR DESCRIPTION
Follow up for PR #2183 

Removes redundant computed properties by leveraging prefetching of these values introduced in PR #2371

@shreyanshdwivedi that's why it wasn't working before -- they were never fetched while executing.