### PR TITLE
Fix pagination line margin in manage events page.

### DIFF
--- a/app/templates/components/ui-table.hbs
+++ b/app/templates/components/ui-table.hbs
@@ -48,8 +48,8 @@
     </div>
   </div>
   {{#if showComponentFooter}}
-    <div class="{{themeInstance.classes.tfooter-wrapper}}">
-      <div class="{{themeInstance.classes.pagination-wrapper}}">
+    <div class="{{themeInstance.classes.tfooterWrapper}}">
+      <div class="{{themeInstance.classes.paginationWrapper}}">
         {{partial themeInstance.components.pagination-simple}}
       </div>
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
There was a typo in the enclosing `div` `classes` of the pagination component. By resolving those typos, the margin of pagination line is fixed in manage events page.

#### Changes proposed in this pull request:

- Fix typo of wrapper divs.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-07 01-43-20](https://user-images.githubusercontent.com/21174572/55674754-9191ae00-58d6-11e9-805f-8858502a0fc1.png)


Fixes: #2490
