### PR TITLE
Show payment section in events only when a paid ticket is added along with ticketing enabled.

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -202,8 +202,7 @@
       </div>
     {{/if}}
   {{/if}}
-  {{#if hasPaidTickets}}
-
+  {{#if (and hasPaidTickets data.event.isTicketingEnabled)}}
     {{!-- Hiding discount code temporarily, till we get this feature ready to apply discount codes for events.
 
     <div class="ui section divider"></div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This hides the payment section when a paid ticket was added but later ticketing was disabled.

#### Changes proposed in this pull request:

- Modify the payment section if condition.

## GIF
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/21174572/55682051-8f1d6b80-594b-11e9-8e5d-159681c7aa27.gif)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes: #2506 
