### PR TITLE
Disable event creation buttons on invalid permissions

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -124,7 +124,7 @@ export default Component.extend(FormMixin, {
       ticket.set('orderQuantity', count);
       order.set('amount', this.get('total'));
       if (!this.get('total')) {
-        order.set('amount', null);
+        order.set('amount', 0);
       }
       if (count > 0) {
         order.tickets.addObject(ticket);

--- a/app/controllers/events/view/tickets/add-order.js
+++ b/app/controllers/events/view/tickets/add-order.js
@@ -44,7 +44,7 @@ export default Controller.extend({
       ticket.set('orderQuantity', count);
       order.set('amount', this.get('total'));
       if (!this.get('total')) {
-        order.set('amount', null);
+        order.set('amount', 0);
       }
       if (count > 0) {
         order.tickets.addObject(ticket);

--- a/app/controllers/verify.js
+++ b/app/controllers/verify.js
@@ -5,8 +5,10 @@ export default Controller.extend({
   token       : null,
   success     : false,
   error       : null,
+  isLoading   : false,
 
   verify(tokenVal) {
+    this.set('isLoading', true);
     let payload = {
       data: {
         token: tokenVal
@@ -20,6 +22,9 @@ export default Controller.extend({
       .catch(reason => {
         this.set('error', reason);
         this.set('success', false);
+      })
+      .finally(() => {
+        this.set('isLoading', false);
       });
   }
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -48,7 +48,7 @@ export default ModelBase.extend({
   lastAccessedAt : attr('moment', { readOnly: true }),
 
   status: computed('lastAccessedAt', function() {
-    return (new Date().getMonth() - new Date(this.get('lastAccessedAt')).getMonth() < 1);
+    return (new Date().getMonth() - new Date(this.get('lastAccessedAt')).getMonth() < 12);
   }),
   isAnAdmin: or('isSuperAdmin', 'isAdmin'),
 

--- a/app/routes/create.js
+++ b/app/routes/create.js
@@ -14,8 +14,10 @@ export default Route.extend(AuthenticatedRouteMixin, EventWizardMixin, {
         copyright           : this.store.createRecord('event-copyright'),
         stripeAuthorization : this.store.createRecord('stripe-authorization')
       }),
-      module : await this.get('store').queryRecord('module', {}),
-      types  : await this.store.query('event-type', {
+      module         : await this.get('store').queryRecord('module', {}),
+      permissions    : await this.store.findRecord('user-permission', 2),
+      verifiedStatus : this.get('authManager.currentUser').isVerified,
+      types          : await this.store.query('event-type', {
         sort: 'name'
       }),
       topics: await this.store.query('event-topic', {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -542,19 +542,36 @@
   </div>
   <br>
   <div class="{{unless device.isMobile 'right floated large' 'mini three'}} ui fields buttons">
-    <button class="ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'moveForward'}}>
-      {{t 'Forward'}}
-      <i class="right chevron icon"></i>
-    </button>
-    <button class="blue ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'saveDraft'}}>
-      {{t 'Save draft'}}
-      <i class="save icon"></i>
-    </button>
-    {{#if data.event.locationName}}
-      <button class="green ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'publish'}}>
-        {{t 'Publish'}}
-        <i class="check icon"></i>
+    {{#if (or (eq data.verifiedStatus true) (and (eq data.verifiedStatus false) (eq data.permissions.unverifiedUser true)))}}
+      <button class="ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'moveForward'}}>
+        {{t 'Forward'}}
+        <i class="right chevron icon"></i>
       </button>
+      <button class="blue ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'saveDraft'}}>
+        {{t 'Save draft'}}
+        <i class="save icon"></i>
+      </button>
+      {{#if data.event.locationName}}
+        <button class="green ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'publish'}}>
+          {{t 'Publish'}}
+          <i class="check icon"></i>
+        </button>
+      {{/if}}
+    {{else}}
+      <button class="ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'moveForward'}} disabled='true'>
+        {{t 'Forward'}}
+        <i class="right chevron icon"></i>
+      </button>
+      <button class="blue ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'saveDraft'}} disabled='true'>
+        {{t 'Save draft'}}
+        <i class="save icon"></i>
+      </button>
+      {{#if data.event.locationName}}
+        <button class="green ui three field right labeled icon button {{if isLoading 'disabled'}}" type="button" {{action 'publish'}} disabled='true'>
+          {{t 'Publish'}}
+          <i class="check icon"></i>
+        </button>
+      {{/if}}
     {{/if}}
   </div>
 </form>

--- a/app/templates/components/public/copyright-item.hbs
+++ b/app/templates/components/public/copyright-item.hbs
@@ -3,7 +3,7 @@
   <br>
 {{/if}}
 <div class='copyright text'>
-  <p>
-    {{t 'This event is licenced under'}} <a href="{{copyright.licenceUrl}}"> {{copyright.licence}} </a>.
-  </p>
+  {{#if copyright.licence}}
+    <p>{{t 'This event is licenced under'}} <a href="{{copyright.licenceUrl}}"> {{copyright.licence}} </a>.</p>
+  {{/if}}
 </div>

--- a/app/templates/components/ui-table.hbs
+++ b/app/templates/components/ui-table.hbs
@@ -48,8 +48,8 @@
     </div>
   </div>
   {{#if showComponentFooter}}
-    <div class="{{themeInstance.classes.tfooter-wrapper}}">
-      <div class="{{themeInstance.classes.pagination-wrapper}}">
+    <div class="{{themeInstance.classes.tfooterWrapper}}">
+      <div class="{{themeInstance.classes.paginationWrapper}}">
         {{partial themeInstance.components.pagination-simple}}
       </div>
     </div>

--- a/app/templates/components/widgets/forms/image-upload.hbs
+++ b/app/templates/components/widgets/forms/image-upload.hbs
@@ -11,7 +11,7 @@
     {{#if allowReCrop}}
 	     <div class="ui bottom attached mini buttons">
 		      <button type="button" class="ui teal button" {{action 'reCrop'}}>
-		        <i class="trash icon"></i>
+		        <i class="crop icon"></i>
 		        {{t 'Re-crop'}}
 		      </button>
 	     </div>

--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,9 +1,9 @@
 {{#if success}}
-  <div class="ui icon info message eight wide column center aligned">
+  <div class="ui {{if isLoading 'loading'}} icon info message eight wide column center aligned">
     <p>Your email has been verified successfully! Please login to continue.</p>
   </div>
 {{else}}
-  <div class="ui icon error message eight wide column center aligned">
+  <div class="ui {{if isLoading 'loading'}} icon error message eight wide column center aligned">
     <p>Error: {{t error}}</p>
   </div>
 {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It makes sure that buttons are only enabled if the user is verified or the system permissions allow unverified users to create events

#### Changes proposed in this pull request:

- include system permissions in creation route
- include user verified status in creation route
- make necessary changes on form


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2474 
