### PR TITLE
Adding refresh of dashboard after deletion of event

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -84,6 +84,7 @@ export default Controller.extend({
         .then(() => {
           this.set('isLoading', false);
           this.notify.success(this.get('l10n').t('Event has been deleted successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
           this.set('isLoading', false);

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -75,6 +75,7 @@ export default Controller.extend({
       })
         .then(() => {
           this.notify.success(this.get('l10n').t('Event has been deleted successfully.'));
+          this.send('refreshRoute');
         })
         .catch(() => {
           this.notify.error(this.get('l10n').t('An unexpected error has occurred.'));

--- a/app/routes/events/list.js
+++ b/app/routes/events/list.js
@@ -93,5 +93,10 @@ export default Route.extend({
       objectType : 'events'
     };
 
+  },
+  actions: {
+    refreshRoute() {
+      this.refresh();
+    }
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Refreshes dashboard after deletion of event.
#### Changes proposed in this pull request:

- Added *refreshRoute* after success of deletion of event

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2483 
