### PR TITLE
Fixes the width of both the components

### DIFF
--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -53,7 +53,7 @@
           <label>{{t 'Description'}}</label>
           {{widgets/forms/rich-text-editor value=sponsor.description name='description'}}
         </div>
-        <div class="sponsors-step eleven wide computer eight wide tablet field {{if device.isMobile 'less padding'}}">
+        <div class="sponsors-step eight wide computer eight wide tablet field {{if device.isMobile 'less padding'}}">
           {{widgets/forms/image-upload
             label=(t 'Logo')
             imageUrl=sponsor.logoUrl


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
 It sets equal widths to both the components enhancing the UI of sponsor page

#### Changes proposed in this pull request:

- Update `sponsor-step.hbs` 



<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2522 

![Screenshot 2019-04-08 07:37:34](https://user-images.githubusercontent.com/35539313/55695174-f16e7e80-59d4-11e9-902b-bf7aacc3e7a4.png)

