### PR TITLE
Added a white-space at the required place

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -181,6 +181,7 @@
           </h3>
         {{/if}}
       </div>
+      <br>
       <button type="button" class="ui blue small button" {{action 'addTicket' 'free' data.event.tickets.length}}>
         <i class="large icons basic-details">
           <i class="smile icon"></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It introduces a white-space between the textfield and the buttons. Shown in the screenshot attached below

#### Changes proposed in this pull request:

- Update `basic-details-step.hbs`


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2528 

#### Screenshot

BEFORE
![Screenshot 2019-04-08 12:15:40](https://user-images.githubusercontent.com/35539313/55705808-48884980-59fd-11e9-9353-01592d3e7d9b.png)

AFTER
![Screenshot 2019-04-08 12:17:52](https://user-images.githubusercontent.com/35539313/55705816-4de59400-59fd-11e9-8ad3-40b94066cae9.png)


