### PR TITLE
Fix add another sponsor button text when all sponsors are removed.

### DIFF
--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -66,7 +66,7 @@
         <div class="ui section divider"></div>
       {{/if}}
     {{/each}}
-    <button type="button" class="ui primary {{if device.isMobile 'small'}} button" {{action 'addSponsor'}}>{{t 'Add another sponsor'}}</button>
+    <button type="button" class="ui primary {{if device.isMobile 'small'}} button" {{action 'addSponsor'}}>{{t (if sponsors.length 'Add another sponsor' 'Add sponsor')}}</button>
     <div class="spacer-50"></div>
   {{else}}
     <div class="spacer-50"></div>


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR fixes the sponsor button text when all sponsors are removed.

#### Changes proposed in this pull request:

- Add if condition to check for sponsor length for button to be rendered.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-08 19-17-19](https://user-images.githubusercontent.com/21174572/55729318-8c964100-5a33-11e9-867a-753032405174.png)
![Screenshot from 2019-04-08 19-17-10](https://user-images.githubusercontent.com/21174572/55729319-8c964100-5a33-11e9-9f3e-2a7a7e842100.png)


Fixes: #2532
