### PR TITLE
Fixes the incorrect heading in sessions page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,13 +8,13 @@ about: Create a report to help us improve
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+Steps to reproduce the behaviour:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behaviour**
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -202,8 +202,7 @@
       </div>
     {{/if}}
   {{/if}}
-  {{#if hasPaidTickets}}
-
+  {{#if (and hasPaidTickets data.event.isTicketingEnabled)}}
     {{!-- Hiding discount code temporarily, till we get this feature ready to apply discount codes for events.
 
     <div class="ui section divider"></div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
  Fixes the typo.

#### Changes proposed in this pull request:

- Update `sessions-speakers-step.hbs`


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2535 
