### PR TITLE
Add phone number field validation using regex.

### DIFF
--- a/app/components/settings/contact-info-section.js
+++ b/app/components/settings/contact-info-section.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import FormMixin from 'open-event-frontend/mixins/form';
+import { validPhoneNumber } from 'open-event-frontend/utils/validators';
 
 export default Component.extend(FormMixin, {
 
@@ -31,7 +32,12 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'empty',
-              prompt : this.get('l10n').t('Please enter your phone')
+              prompt : this.get('l10n').t('Please enter a phone number.')
+            },
+            {
+              type   : 'regExp',
+              value  : validPhoneNumber,
+              prompt : this.get('l10n').t('Please enter a valid phone number.')
             }
           ]
         }

--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -73,6 +73,10 @@ export const validLinkedinProfileUrlPattern = new RegExp(
   + '?(?:www.)?(linkedin\\.com\\/)((([\\w]{2,3})?)|([^\\/]+\\/(([\\w|\\d-&#?=])+\\/?){1,}))$'
 );
 
+export const validPhoneNumber = new RegExp(
+  '^\\s*(?:\\+?(\\d{1,3}))?([-. (]*(\\d{3})[-. )]*)?((\\d{3})[-. ]*(\\d{2,4})(?:[-.x ]*(\\d+))?)\\s*$'
+);
+
 export const isValidUrl = str => {
   return validUrlPattern.test(str);
 };


### PR DESCRIPTION
Reference Link for the regex:
https://stackoverflow.com/a/29835355
https://regexr.com/38pvb

This regex doesn't checks for helpline number like `1800-MY-APPLE`.
I guess we need to assume to some extent the kind of phone number to be entered.

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds phone number field validation using regex.

#### Changes proposed in this pull request:

- Add regex for phone number field validation.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes: #2345
