### PR TITLE
Fix current password error in password reset settings.

### DIFF
--- a/app/controllers/settings/password.js
+++ b/app/controllers/settings/password.js
@@ -16,8 +16,8 @@ export default Controller.extend({
           this.get('notify').success(this.get('l10n').t('Password updated successfully'));
         })
         .catch(error => {
-          if (error.error) {
-            this.get('notify').error(this.get('l10n').t(error.error));
+          if (error.errors) {
+            this.get('notify').error(this.get('l10n').t(`${error.errors[0].detail}`));
           } else {
             this.get('notify').error(this.get('l10n').t('Unexpected error. Password did not change.'));
           }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR fixes the error shown to the user when incorrect current password is entered during password reset process.

#### Changes proposed in this pull request:

The if block checking for if error is returned by the server was checking for wrong attribute. The attribute received from server is `errors` while `error` was being checked in the frontend code. I fixed the attribute checked in `if` block and displayed the error along with added extra custom error message.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-09 22-16-37](https://user-images.githubusercontent.com/21174572/55819703-fa676900-5b16-11e9-9e0d-3ddcdb251b21.png)


Fixes: #2546
