### PR TITLE
admin users:removes deleted users from inactive user filter

### DIFF
--- a/app/routes/admin/users/list.js
+++ b/app/routes/admin/users/list.js
@@ -50,16 +50,25 @@ export default Route.extend({
     } else if (params.users_status === 'inactive') {
       filterOptions = [
         {
-          or: [
+          and: [
             {
-              name : 'last-accessed-at',
-              op   : 'eq',
-              val  : null
+              or: [
+                {
+                  name : 'last-accessed-at',
+                  op   : 'eq',
+                  val  : null
+                },
+                {
+                  name : 'last-accessed-at',
+                  op   : 'lt',
+                  val  : moment().subtract(1, 'Y').toISOString()
+                }
+              ]
             },
             {
-              name : 'last-accessed-at',
-              op   : 'lt',
-              val  : moment().subtract(1, 'Y').toISOString()
+              name : 'deleted-at',
+              op   : 'eq',
+              val  : null
             }
           ]
         }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When logged in as an admin, in the users tab under inactive users, deleted user is shown along with inactive user

#### Changes proposed in this pull request:
- fixed the `filterOptions` for `Inactive` users


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2455 
