### PR TITLE
Scheduler: standardize timezone to UTC

### DIFF
--- a/app/routes/events/view/scheduler.js
+++ b/app/routes/events/view/scheduler.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-
 export default Route.extend({
   titleToken() {
     return this.get('l10n').t('Scheduler');
@@ -106,11 +105,10 @@ export default Route.extend({
       session.speakers.forEach(function(speaker) {
         speakerNames.push(speaker.name);
       });
-
       scheduled.push({
         title      : `${session.title} | ${speakerNames.join(', ')}`,
-        start      : session.startsAt.format('YYYY-MM-DDTHH:mm:SS'),
-        end        : session.endsAt.format('YYYY-MM-DDTHH:mm:SS'),
+        start      : session.startsAt.format(),
+        end        : session.endsAt.format(),
         resourceId : session.microlocation.get('id'),
         color      : session.track.get('color'),
         serverId   : session.get('id') // id of the session on BE
@@ -136,6 +134,7 @@ export default Route.extend({
 
     return {
       header,
+      timezone        : 'UTC',
       defaultView     : 'agendaDay',
       events          : scheduled,
       eventDetails,

--- a/app/templates/events/view/scheduler.hbs
+++ b/app/templates/events/view/scheduler.hbs
@@ -19,6 +19,7 @@
       {{full-calendar events=model.events
                       aspectRatio=1.8
                       editable=true
+                      timezone=model.timezone
                       droppable=true
                       resources=model.resources
                       groupByResource=true


### PR DESCRIPTION
Ensure all values are always displayed and stored in UTC while viewing or scheduling through the scheduler.

Fixes #2559 