### PR TITLE
Inconsistency in slides text while viewing session.

### DIFF
--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -11,6 +11,15 @@ export default Controller.extend({
     return true;
   }),
 
+  slideText: computed('model.slidesUrl', function() {
+    let fileUploadRegex = /((https|http):\/\/)?.*\/static\/media\/events\/.*/;
+    let slidesUrl = this.get('model.slidesUrl');
+    if (fileUploadRegex.test(slidesUrl)) {
+      return false;
+    }
+    return true;
+  }),
+
   actions: {
     openProposalDeleteModal() {
       this.set('isProposalDeleteModalOpen', true);

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -70,7 +70,7 @@
       {{/if}}
       {{#if model.slidesUrl}}
         <h3 class="ui left aligned header">Slide</h3>
-        <a href="{{model.slidesUrl}}">{{t 'Download'}}</a>
+        <a href="{{model.slidesUrl}}">{{t (if slideText 'Link to Slides' 'Download')}}</a>
       {{/if}}
     </div>
   </div>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR fixes the inconsistency in slides text.

#### Changes proposed in this pull request:

- Do a regex match for the path used to save uploaded file.
- If regex matches then show `download` else `Link to slides`.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-10 14-22-03](https://user-images.githubusercontent.com/21174572/55865556-3f81ae80-5b9c-11e9-9a0a-280a03b5e562.png)

![Screenshot from 2019-04-10 14-21-37](https://user-images.githubusercontent.com/21174572/55865558-401a4500-5b9c-11e9-8f45-6752a76309be.png)

Fixes: #2558
