### PR TITLE
Remove the edit button if the user is deleted

### DIFF
--- a/app/templates/components/ui-table/cell/admin/users/cell-actions.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-actions.hbs
@@ -3,9 +3,11 @@
     <i class="unhide icon"></i>
   {{/ui-popup}}
   {{#unless record.isSuperAdmin}}
-    {{#ui-popup content=(t 'Edit') click=(action openEditModal record) class='ui icon button'}}
-      <i class="edit icon"></i>
-    {{/ui-popup}}
+    {{#if (not record.deletedAt)}}
+      {{#ui-popup content=(t 'Edit') click=(action openEditModal record) class='ui icon button'}}
+        <i class="edit icon"></i>
+      {{/ui-popup}}
+    {{/if}}
     {{#if (and hasRestorePrivileges record.deletedAt)}}
       {{#ui-popup content=(t 'Restore') click=(action restoreUser record) class='ui icon button' position='left center'}}
         <i class="undo icon"></i>


### PR DESCRIPTION
#### Short description of what this resolves:
Edit button removed if user is deleted

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2573 
