### PR TITLE
Fixed Clicking on View Session in notification panel redirects to Not defined

### DIFF
--- a/app/templates/notifications/all.hbs
+++ b/app/templates/notifications/all.hbs
@@ -32,14 +32,14 @@
       <div class="row">
         <div class="ten wide column">
           {{#each notification.notificationActions as |action|}}
-            {{#if action.link}}
-              <a href={{action.link}} class="ui blue button">
-                {{t action.buttonTitle}}
-              </a>
-            {{else}}
+            {{#if action.buttonRoute}}
               {{#link-to action.buttonRoute action.subjectId tagName='button' class='ui blue button'}}
                 {{t action.buttonTitle}}
               {{/link-to}}
+            {{else}}
+              <a href={{action.link}} class="ui blue button">
+                {{t action.buttonTitle}}
+              </a>
             {{/if}}
           {{/each}}
         </div>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Clicking on View Session in notification panel now redirects to correct location

#### Changes proposed in this pull request:


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2607 
