### PR TITLE
Fix typo in ui-table/cell/cell-sessions

### DIFF
--- a/app/templates/components/ui-table/cell/cell-sessions.hbs
+++ b/app/templates/components/ui-table/cell/cell-sessions.hbs
@@ -1,6 +1,6 @@
 <div class="ui list">
   <div class="item">{{t 'Draft'}}: {{record.eventStatisticsGeneral.sessionsDraft}}</div>
-  <div class="item">{{t 'Submitted'}}: {{record.eventStatisticsGeneral.sessionsSubmited}}</div>
+  <div class="item">{{t 'Submitted'}}: {{record.eventStatisticsGeneral.sessionsSubmitted}}</div>
   <div class="item">{{t 'Accepted'}}: {{record.eventStatisticsGeneral.sessionsAccepted}}</div>
   <div class="item">{{t 'Confirmed'}}: {{record.eventStatisticsGeneral.sessionsConfirmed}}</div>
   <div class="item">{{t 'Pending'}}: {{record.eventStatisticsGeneral.sessionsPending}}</div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
this fixes the variable typo in sessionsSubmitted present in ui-table/cell-sessions

#### Changes proposed in this pull request:

- fix spelling of sessionsSubmitted


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2610 
