### PR TITLE
Add link input field for website and twitter in speaker details form.

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { groupBy, orderBy } from 'lodash';
 import FormMixin from 'open-event-frontend/mixins/form';
-import { compulsoryProtocolValidUrlPattern, validTwitterProfileUrlPattern, validFacebookProfileUrlPattern,
+import { compulsoryProtocolValidUrlPattern, protocolLessValidUrlPattern, validTwitterProfileUrlPattern, validFacebookProfileUrlPattern,
   validGithubProfileUrlPattern, validLinkedinProfileUrlPattern, validPhoneNumber } from 'open-event-frontend/utils/validators';
 import { countries } from 'open-event-frontend/utils/dictionary/demography';
 import { languages } from 'open-event-frontend/utils/dictionary/languages';
@@ -360,7 +360,7 @@ export default Component.extend(FormMixin, {
             },
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
+              value  : protocolLessValidUrlPattern,
               prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]
@@ -371,7 +371,7 @@ export default Component.extend(FormMixin, {
           rules      : [
             {
               type   : 'regExp',
-              value  : compulsoryProtocolValidUrlPattern,
+              value  : protocolLessValidUrlPattern,
               prompt : this.get('l10n').t('Please enter a valid url')
             }
           ]

--- a/app/models/speaker.js
+++ b/app/models/speaker.js
@@ -1,6 +1,7 @@
 import attr from 'ember-data/attr';
 import ModelBase from 'open-event-frontend/models/base';
 import { belongsTo, hasMany } from 'ember-data/relationships';
+import { computedSegmentedLink } from 'open-event-frontend/utils/computed-helpers';
 
 export default ModelBase.extend({
 
@@ -31,6 +32,8 @@ export default ModelBase.extend({
   city               : attr('string'),
   gender             : attr('string'),
   heardFrom          : attr('string'),
+
+  segmentedLinkWebsite: computedSegmentedLink.bind(this)('website'),
 
   /**
    * Relationships

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -174,7 +174,16 @@
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
             {{else}}
-              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{#if (eq field.name 'Website')}}
+                {{widgets/forms/link-input
+                  fixedName=true
+                  inputId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))
+                  segmentedLink=data.speaker.segmentedLinkWebsite
+                  canRemoveItem=false
+                }}
+              {{else}}
+                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{/if}}
             {{/if}}
           {{/if}}
           {{#if (eq field.type 'image')}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds a link-input field for website field in speaker details form.

#### Changes proposed in this pull request:

- Add link input field.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshot
![Screenshot from 2019-04-13 12-08-25](https://user-images.githubusercontent.com/21174572/56075736-e48ec800-5de4-11e9-8417-b80fa50c721e.png)

Fixes: #2428
