### PR TITLE
Change default text styles for Event type dropdowns

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -457,9 +457,9 @@
 
   <div class="field">
     <label>{{t 'Event Type'}}</label>
-    {{#ui-dropdown class='search selection' onChange=(action (mut data.event.type)) as |execute mapper|}}
+    {{#ui-dropdown class='search selection' selected=data.event.type.name onChange=(action (mut data.event.type)) as |execute mapper|}}
       <i class="dropdown icon"></i>
-      <div class="default text">{{if data.event.type.name data.event.type.name (t 'Select Event Type')}}</div>
+      <div class="default text">{{t 'Select Event Type'}}</div>
       <div class="menu">
         {{#each data.types as |type|}}
           <div class="item" data-value="{{map-value mapper type}}">{{sanitize type.name}}</div>
@@ -469,9 +469,9 @@
   </div>
   <div class="field">
     <label>{{t 'Event Topic'}}</label>
-    {{#ui-dropdown class='search selection' onChange=(action (mut data.event.topic)) as |execute mapper|}}
+    {{#ui-dropdown class='search selection' selected=data.event.topic.name onChange=(action (mut data.event.topic)) as |execute mapper|}}
       <i class="dropdown icon"></i>
-      <div class="default text">{{if data.event.topic.name data.event.topic.name (t 'Select Event Topic')}}</div>
+      <div class="default text">{{t 'Select Event Topic'}}</div>
       <div class="menu">
         {{#each data.topics as |topic|}}
           <div class="item" data-value="{{map-value mapper topic}}">{{sanitize topic.name}}</div>
@@ -481,10 +481,10 @@
   </div>
   <div class="field">
     <label>{{t 'Event Sub-topic'}}</label>
-    {{#ui-dropdown class='search selection' onChange=(action (mut data.event.subTopic)) as |execute mapper|}}
+    {{#ui-dropdown class='search selection' selected=data.event.subTopic.name onChange=(action (mut data.event.subTopic)) as |execute mapper|}}
       <i class="dropdown icon"></i>
 
-      <div class="default text">{{if data.event.subTopic.name data.event.subTopic.name (t 'Select Event Sub-Topic')}}</div>
+      <div class="default text">{{t 'Select Event Sub-Topic'}}</div>
       <div class="menu">
         {{#each subTopics as |subTopic|}}
           <div class="item" data-value="{{map-value mapper subTopic}}">{{sanitize subTopic.name}}</div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Make the event type, subtopic and topic dropdowns similar in design to Event Copyright

#### Changes proposed in this pull request:

- use `selected` attribute in dropdown 
- change DefaultText conditions


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2626 
