### PR TITLE
Add event end time to event details page.

### DIFF
--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -73,6 +73,11 @@
             margin: 0;
           }
 
+          .event.time.ends {
+            font-size: 1.25rem;
+            margin: 0;
+          }
+
           .event.location {
             font-size: 1.5rem;
             margin: 0;
@@ -89,6 +94,10 @@
 
             .event.time {
               font-size: 1.25rem;
+            }
+
+            .event.time.ends {
+              font-size: 1rem;
             }
 
             .event.location {

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -12,6 +12,7 @@
           <div class="one wide column"></div>
           <div class="fifteen wide column">
             <h4 class="event time">{{header-date model.startsAt model.timezone}}</h4>
+            <h5 class="event time ends">{{t 'To'}} {{header-date model.endsAt model.timezone}}</h5>
             <h1 class="event name">{{model.name}}</h1>
             <h4 class="event location"><i class="marker icon"></i>{{model.locationName}}</h4>
           </div>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds event ending time to event details page.

#### Changes proposed in this pull request:

- Add event end time as a `h5`.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
## Screenshots
![Screenshot from 2019-04-15 15-23-24](https://user-images.githubusercontent.com/21174572/56123622-6e2fc880-5f92-11e9-849e-045a057c0ffa.png)


Fixes: #2650
