### PR TITLE
Add "Event is over" label to event cards which are over.

### DIFF
--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -27,6 +27,9 @@
         {{event.shortLocationName}}
       {{/smart-overflow}}
     </a>
+    {{#if (is-before event.startsAt [now])}}
+      <div class="ui red top right attached label">Event is over</div>
+    {{/if}}
     <div class="extra content small text">
       <span class="right floated">
         <i role="button" class="share alternate link icon" {{action shareEvent event}}></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently if an event is over, there is no indication that it is over except checking for the date and time.

#### Changes proposed in this pull request:

- Add an "Event is over" label to the card.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-15 17-59-22](https://user-images.githubusercontent.com/21174572/56132675-3a5f9d80-5fa8-11e9-90b5-770d139834cd.png)


Fixes: #2651
