### PR TITLE
Add the country's flag infront of it's name in the drop-down in order-form

### DIFF
--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -105,6 +105,7 @@
               <div class="menu">
                 {{#each countries as |country|}}
                   <div data-value="{{map-value mapper country.name}}" class="item">
+                    <i class="{{lowercase country.code}} flag"></i>
                     {{country.name}}
                   </div>
                 {{/each}}


### PR DESCRIPTION

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)



#### Changes proposed in this pull request:

Adds a flag icon infront of the country name in the drop-down to select a country in the order-form.


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2672 
