### PR TITLE
make isAdmin attribute of user modifiable by admin

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -15,7 +15,7 @@ export default ModelBase.extend({
   password               : attr('string'),
   isVerified             : attr('boolean', { readOnly: true }),
   isSuperAdmin           : attr('boolean', { readOnly: true }),
-  isAdmin                : attr('boolean', { readOnly: true }),
+  isAdmin                : attr('boolean'),
   isUserOrganizer        : attr('boolean'),
   isUserCoorganizer      : attr('boolean'),
   isUserTrackOrganizer   : attr('boolean'),


### PR DESCRIPTION
The current implementation prevents even an admin from making someone else an admin. This change will enable an admin to make other users admin.