### PR TITLE
Add default text in System Images when no image is present in Admin Panel

### DIFF
--- a/app/templates/admin/content/system-images/list.hbs
+++ b/app/templates/admin/content/system-images/list.hbs
@@ -7,6 +7,10 @@
       <div class="ui hidden divider"></div>
       <button class="ui button primary" {{action 'openModal' subTopic.placeholder}} id="changebutton">{{t 'Change'}}</button>
     </div>
+  {{else}}
+    <div class="ui disabled header">
+      {{t 'No images to show'}}
+    </div>
   {{/each}}
 </div>
 {{modals/change-image-modal isOpen=isModalOpen placeholder=selectedPlaceholder}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fix Bug in System Images in Admin. Before a blank page appears if a new event topic was created without event subtopic as system images are only for subtopics. Now a text "No records to show" appears.

#### Changes proposed in this pull request:
![Screenshot 2019-04-25 at 2 45 53 AM](https://user-images.githubusercontent.com/31013104/56694505-77443680-6704-11e9-9b73-4b7c6f47994a.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2690 
