### PR TITLE
Add scroll to Add event topic, type and subtopic in Admin to avoid overflow.

### DIFF
--- a/app/templates/admin/content/events.hbs
+++ b/app/templates/admin/content/events.hbs
@@ -15,11 +15,11 @@
           </div>
         </div>
         <div class="ui divider"></div>
-        <table class="ui celled table">
-          <tbody>
+        <table class="ui celled table" style="max-height: 1056px;display: inline-block;overflow-y:auto">
+          <tbody style="display: block">
             {{#each model.eventTypes as |eventType|}}
-              <tr>
-                <td>
+              <tr style="display: block">
+                <td style="display: block">
                   <div class="ui grid">
                     <div class="middle aligned content eight wide column left aligned">
                       {{eventType.name}}
@@ -57,11 +57,11 @@
           </div>
         </div>
         <div class="ui divider"></div>
-        <table class="ui celled table">
-          <tbody>
+        <table class="ui celled table" style="max-height: 1056px;display: inline-block;overflow-y:auto">
+          <tbody style="display: block">
             {{#each model.eventTopics as |eventTopic|}}
-              <tr>
-                <td>
+              <tr style="display: block">
+                <td style="display: block">
                   <div class="ui grid">
                     <div class="middle aligned content eight wide column left aligned">
                       {{eventTopic.name}}
@@ -112,11 +112,11 @@
           {{/ui-dropdown}}
         </div>
         {{#if model.eventSubTopics}}
-          <table class="ui celled table">
-            <tbody>
+          <table class="ui celled table" style="max-height: 1056px;display: inline-block;overflow-y:auto">
+            <tbody style="display: block">
               {{#each model.eventSubTopics as |subTopic|}}
-                <tr>
-                  <td>
+                <tr style="display: block">
+                  <td style="display: block">
                     <div class="ui grid">
                       <div class="middle aligned content eight wide column left aligned">
                         {{subTopic.name}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add scroll to Add event topic,type and subtopic in Admin to avoid overflow.
#### Changes proposed in this pull request:

![Screenshot 2019-04-16 at 10 04 08 PM](https://user-images.githubusercontent.com/31013104/56227702-b682df80-6093-11e9-8798-fb68e6ec92e9.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2689 
