### PR TITLE
Add fragment identifier to scroll to links part of page

### DIFF
--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -62,7 +62,7 @@
               {{if (not-eq index 0) ','}} <a href="{{socialLink.link}}" target="_blank" rel="noopener noreferrer">{{socialLink.name}}</a>
             {{/each}}
           {{else}}
-            {{t 'No social links present. '}} <a href="{{href-to 'events.view.edit.basic-details'}}">{{t 'Click here to add'}}</a>
+            {{t 'No social links present. '}} <a href="{{href-to 'events.view.edit.basic-details'}}#social-links">{{t 'Click here to add'}}</a>
           {{/if}}
         </td>
       </tr>

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -114,7 +114,7 @@
     </div>
   {{/if}}
   <div class="ui section divider"></div>
-  <div class="grouped fields">
+  <div class="grouped fields" id="social-links">
     <label>{{t 'Links & Social Media'}}</label>
     {{widgets/forms/link-input
       hasLinkName=true


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
When clicking on the option to add social links, it takes us to that part of the page.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2627 
