### PR TITLE
Add the confirmation message dialog box to activate/deactivate access code

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/tickets/access-codes/cell-actions.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/access-codes/cell-actions.hbs
@@ -4,11 +4,11 @@
   {{/ui-popup}}
   {{#if (not record.isExpired)}}
     {{#if record.isActive}}
-      {{#ui-popup content=(t 'Deactivate') click=(action toggleStatus record) class='ui icon button' position='left center'}}
+      {{#ui-popup content=(t 'Deactivate') click=(action (confirm (t 'Are you sure you would like to deactivate this Access Code?') (action toggleStatus record))) class='ui icon button' position='left center'}}
         <i class="remove icon"></i>
       {{/ui-popup}}
     {{else}}
-      {{#ui-popup content=(t 'Activate') click=(action toggleStatus record) class='ui icon button' position='left center'}}
+      {{#ui-popup content=(t 'Activate') click=(action (confirm (t 'Are you sure you would like to activate this Access Code?') (action toggleStatus record))) class='ui icon button' position='left center'}}
         <i class="check icon"></i>
       {{/ui-popup}}
     {{/if}}


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Added the confirmation message dialog box to activate/deactivate access code like done in the discount code.

#### Changes proposed in this pull request:

- Update `cell-actions.hbs` of access code


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2648 

#### Screenshot/GIF:
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/35539313/56259628-54f15e00-60f1-11e9-8083-e477ab1d7a20.gif)

