### PR TITLE
Added placeholder in the header filter box on manage event page

### DIFF
--- a/app/templates/components/ui-table/header-row-filtering.hbs
+++ b/app/templates/components/ui-table/header-row-filtering.hbs
@@ -13,7 +13,7 @@
                 {{#if column.filterWithSelect}}
                   {{models-select options=column.filterOptions cssPropertyName=column.cssPropertyName value=column.filterString class=(concat themeInstance.input 'changeFilterForColumn')}}
                 {{else}}
-                  {{input type='text' value=column.filterString class=themeInstance.input placeholder=''}}
+                  {{input type='text' value=column.filterString class=themeInstance.input placeholder='search event here'}}
                 {{/if}}
               </div>
             {{else}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Add `search event here` as watermark text in both the text field as currently nothing is mentioned here and a new user only comes to know after giving input to them.

#### Changes proposed in this pull request:

- Update `header-row-filtering.hbs`


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2727 

#### Screenshots

Before
![Screenshot 2019-04-18 18:05:04](https://user-images.githubusercontent.com/35539313/56395655-15458600-6259-11e9-882a-0735f09c4f84.png)

After
![Screenshot 2019-04-19 04:05:34](https://user-images.githubusercontent.com/35539313/56395657-1aa2d080-6259-11e9-95b5-2d7a5b8ea87d.png)

