### PR TITLE
Change default page size to 18 events on landing page

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -117,7 +117,7 @@ export default Route.extend({
       sort         : 'starts-at',
       include      : 'event-topic,event-sub-topic,event-type,speakers-call',
       filter       : filterOptions,
-      perPage      : 6,
+      perPage      : 18,
       startingPage : 1,
       perPageParam : 'page[size]',
       pageParam    : 'page[number]'


### PR DESCRIPTION
Preload 18 events in once, at index page.