### PR TITLE
Handle Sponsor Url Validation rules without use of Id

### DIFF
--- a/app/components/forms/wizard/sponsors-step.js
+++ b/app/components/forms/wizard/sponsors-step.js
@@ -27,9 +27,8 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
-        sponsorUrl: {
-          identifier : 'sponsor_url',
-          rules      : [
+        url: {
+          rules: [
             {
               type   : 'regExp',
               value  : protocolLessValidUrlPattern,

--- a/app/templates/components/forms/wizard/sponsors-step.hbs
+++ b/app/templates/components/forms/wizard/sponsors-step.hbs
@@ -45,7 +45,7 @@
         </div>
         <div class="six wide field">
           <label>{{t 'URL'}}</label>
-          {{widgets/forms/link-input segmentedLink=sponsor.segmentedLink inputId='sponsor_url' name='url'}}
+          {{widgets/forms/link-input segmentedLink=sponsor.segmentedLink name='url'}}
         </div>
       </div>
       <div class="fields">


### PR DESCRIPTION
#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Handle validation rules of Sponsor Url as of Sponsor Name without the use of inputId as it may lead to repeated Id as there can be more than one Sponsor. 

Fixes #2737 
