### PR TITLE
initialise user system role modal using user.isAdmin

### DIFF
--- a/app/templates/components/modals/edit-user-modal.hbs
+++ b/app/templates/components/modals/edit-user-modal.hbs
@@ -7,8 +7,8 @@
     <h4 class="ui header">{{t 'Provide admin access?'}}</h4>
     <div class="grouped inline fields">
       <div class="field">
-        {{ui-radio name="isAdmin" label="No" value=false onChange=(action 'createAdmin' data false)}}
-        {{ui-radio name="isAdmin" label="Yes" value=true onChange=(action 'createAdmin' data true)}}
+        {{ui-radio name="isAdmin" label="No" value=false onChange=(action 'createAdmin' data false) current=data.isAdmin}}
+        {{ui-radio name="isAdmin" label="Yes" value=true onChange=(action 'createAdmin' data true) current=data.isAdmin}}
       </div>
     </div>
     <h4 class="ui header">{{t 'Custom system roles'}}</h4>
@@ -16,8 +16,9 @@
       {{ui-checkbox label='Sales Admin' class='toggle' checked=data.isSalesAdmin onChange=(action 'toggleSalesAdmin' data)}}
       {{ui-checkbox label='Marketer' class='toggle' checked=data.isMarketer onChange=(action 'toggleMarketer' data)}}
     </div>
-    <button class="ui teal right floated submit button update-changes" {{action 'saveRole' data.id}}>
-      {{t 'Save'}}
-    </button>
   </div>
+  <button class="ui teal right floated submit button update-changes" {{action 'saveRole' data.id}}>
+    {{t 'Save'}}
+  </button>
+  <div class="ui hidden divider"></div>
 </div>


### PR DESCRIPTION
- Add hidden divider to make a space between modal and button

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Makes sure that user.isAdmin is being reflected in radio buttons and the save buttton and modal has some space


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2761
