### PR TITLE
Change salesEndDate on event start date change.

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -346,6 +346,15 @@ export default Component.extend(FormMixin, EventWizardMixin, {
       }));
     },
 
+    updateSalesEndDate(eventStartDate) {
+      eventStartDate = moment(new Date(eventStartDate));
+      this.get('data.event.tickets').forEach(ticket => {
+        if (moment(eventStartDate).isBefore(ticket.get('salesEndsAt'))) {
+          ticket.set('salesEndsAt', moment(eventStartDate, 'MM/DD/YYYY').toDate());
+        }
+      });
+    },
+
     removeTicket(deleteTicket) {
       const index = deleteTicket.get('position');
       this.get('data.event.tickets').forEach(ticket => {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -27,7 +27,8 @@
                                   inputId='start_date'
                                   placeholder='MM/DD/YYYY'
                                   rangePosition='start'
-                                  value=data.event.startsAtDate}}
+                                  value=data.event.startsAtDate
+                                  onChange=(action 'updateSalesEndDate')}}
     </div>
     <div class="three wide field">
       <label for="start_time">&nbsp;</label>


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently the sales end date of tickets doesn't change when the start date of the event is changed to a time earlier than the current time.

#### Changes proposed in this pull request:

- Add an action which makes the sales end date to the event start date when the event is preponed.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fix/es: #2649
