### PR TITLE
Place the editing tools in a single row in mobile view

### DIFF
--- a/app/templates/components/widgets/forms/rich-text-editor.hbs
+++ b/app/templates/components/widgets/forms/rich-text-editor.hbs
@@ -1,16 +1,16 @@
 <div id="{{textareaIdGenerated}}-toolbar">
   <div class="ui icon buttons">
-    <a href="#" class="ui button" data-content="{{t 'Bold (Ctrl+B)'}}" data-wysihtml5-command="bold"><i class="bold icon"></i></a>
-    <a href="#" class="ui button" data-content="{{t 'Italic (Ctrl+I)'}}" data-wysihtml5-command="italic"><i class="italic icon"></i></a>
-    <a href="#" class="ui button" data-content="{{t 'Underline (Ctrl+U)'}}" data-wysihtml5-command="underline"><i class="underline icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Bold (Ctrl+B)'}}" data-wysihtml5-command="bold" style="padding:6px 6px"><i class="bold icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Italic (Ctrl+I)'}}" data-wysihtml5-command="italic" style="padding:6px 6px"><i class="italic icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Underline (Ctrl+U)'}}" data-wysihtml5-command="underline" style="padding:6px 6px"><i class="underline icon"></i></a>
   </div>
   <div class="ui icon buttons">
-    <a href="#" class="ui button" data-content="{{t 'Numbered List'}}" data-wysihtml5-command="insertOrderedList"><i class="ordered list icon"></i></a>
-    <a href="#" class="ui button" data-content="{{t 'Bullet List'}}" data-wysihtml5-command="insertUnorderedList"><i class="unordered list icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Numbered List'}}" data-wysihtml5-command="insertOrderedList" style="padding:6px 6px"><i class="ordered list icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Bullet List'}}" data-wysihtml5-command="insertUnorderedList" style="padding:6px 6px"><i class="unordered list icon"></i></a>
   </div>
   <div class="ui icon buttons">
-    <a href="#" class="ui button" data-content="{{t 'Undo (Ctrl+Z)'}}" data-wysihtml5-command="undo"><i class="undo icon"></i></a>
-    <a href="#" class="ui button" data-content="{{t 'Redo (Ctrl+Y)'}}" data-wysihtml5-command="redo"><i class="repeat icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Undo (Ctrl+Z)'}}" data-wysihtml5-command="undo" style="padding:6px 6px"><i class="undo icon"></i></a>
+    <a href="#" class="ui button" data-content="{{t 'Redo (Ctrl+Y)'}}" data-wysihtml5-command="redo" style="padding:6px 6px"><i class="repeat icon"></i></a>
   </div>
 </div>
 {{textarea id=textareaIdGenerated value=value placeholder=placeholder name=name}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
It places all the editing including `undo` and `redo` in a row in the mobile view (especially in iPhone5/SE)

#### Changes proposed in this pull request:

- Update `rich-text-picker.hbs`

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2755 

**Screenshots**
![Screenshot 2019-04-21 12:55:50](https://user-images.githubusercontent.com/35539313/56466937-28617d00-6436-11e9-8151-22b01946db80.png)
iPhone X
![Screenshot 2019-04-21 12:53:35](https://user-images.githubusercontent.com/35539313/56466939-2e575e00-6436-11e9-8adc-07eebb187412.png)
iPhone 5/SE
**
