### PR TITLE
Inline editing tools in responsive view.

### DIFF
--- a/app/templates/components/widgets/forms/rich-text-editor.hbs
+++ b/app/templates/components/widgets/forms/rich-text-editor.hbs
@@ -1,14 +1,14 @@
 <div id="{{textareaIdGenerated}}-toolbar">
-  <div class="ui icon buttons">
+  <div class="{{if device.isMobile 'compact'}} ui icon buttons">
     <a href="#" class="ui button" data-content="{{t 'Bold (Ctrl+B)'}}" data-wysihtml5-command="bold"><i class="bold icon"></i></a>
     <a href="#" class="ui button" data-content="{{t 'Italic (Ctrl+I)'}}" data-wysihtml5-command="italic"><i class="italic icon"></i></a>
     <a href="#" class="ui button" data-content="{{t 'Underline (Ctrl+U)'}}" data-wysihtml5-command="underline"><i class="underline icon"></i></a>
   </div>
-  <div class="ui icon buttons">
+  <div class="{{if device.isMobile 'compact'}} ui icon buttons">
     <a href="#" class="ui button" data-content="{{t 'Numbered List'}}" data-wysihtml5-command="insertOrderedList"><i class="ordered list icon"></i></a>
     <a href="#" class="ui button" data-content="{{t 'Bullet List'}}" data-wysihtml5-command="insertUnorderedList"><i class="unordered list icon"></i></a>
   </div>
-  <div class="ui icon buttons">
+  <div class="{{if device.isMobile 'compact'}} ui icon buttons">
     <a href="#" class="ui button" data-content="{{t 'Undo (Ctrl+Z)'}}" data-wysihtml5-command="undo"><i class="undo icon"></i></a>
     <a href="#" class="ui button" data-content="{{t 'Redo (Ctrl+Y)'}}" data-wysihtml5-command="redo"><i class="repeat icon"></i></a>
   </div>


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Currently the editor tools split in different lines for mobile view. This PR makes the editor tools inline for mobile view.

#### Changes proposed in this pull request:

- Use `compact` semantic ui class for buttons in mobile view.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
## Screenshots
![Screenshot from 2019-04-23 00-19-56](https://user-images.githubusercontent.com/21174572/56518628-8d63c280-655d-11e9-8e01-f375bf4d144a.png)

![Screenshot from 2019-04-23 00-19-51](https://user-images.githubusercontent.com/21174572/56518632-8dfc5900-655d-11e9-94d9-19ef6efc97ab.png)


Fixes: #2755