### PR TITLE
Changing Allowed Password Length in 'Settings/Password' from 6 to 8

### DIFF
--- a/app/components/settings/password-section.js
+++ b/app/components/settings/password-section.js
@@ -25,7 +25,7 @@ export default Component.extend(FormMixin, {
               prompt : this.get('l10n').t('Please enter a new password')
             },
             {
-              type   : 'minLength[6]',
+              type   : 'minLength[8]',
               prompt : this.get('l10n').t('Your password must have at least {ruleValue} characters')
             }
           ]


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Fixes #2774 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2774 
