### PR TITLE
Fix inconsistency in visibility of facebook icon in connect with facebook button.

### DIFF
--- a/app/templates/components/settings/application-section.hbs
+++ b/app/templates/components/settings/application-section.hbs
@@ -1,13 +1,10 @@
 <h4>{{t 'Connect with Facebook'}}</h4>
-{{!--
-<div class="ui fluid labeled action input">
-  {{#if data.facebookId}}
+  {{!-- {{#if data.facebookId}}
     {{t 'Successfully linked with Facebook'}}
   {{else}}
     <button type="button" class="ui facebook button {{if isLoading 'loading'}}" {{action 'auth' 'facebook'}}>
-      <i class="facebook icon"></i>
+      <i class="facebook icon inverted"></i>
       {{t 'Connect with Facebook'}}
     </button>
   {{/if}}
-</div>
---}}
+ --}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
I have removed the div with class `ui action fluid input` as it wasn't needed.
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This fixes the visibility of facebook icon in connect with facebook button.

#### Changes proposed in this pull request:

- Add inverted class

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-23 16-27-21](https://user-images.githubusercontent.com/21174572/56576082-14a84900-65e5-11e9-9cdc-b81707d4beb6.png)


Fixes: #2779
