### PR TITLE
Fix typo in fee removal modal prompt.

### DIFF
--- a/app/templates/components/forms/admin/settings/ticket-fees-form.hbs
+++ b/app/templates/components/forms/admin/settings/ticket-fees-form.hbs
@@ -74,7 +74,7 @@
       <div class="field one wide column centered row" style="margin-top: 24px;">
         {{#ui-popup content=(t 'Delete')
                     class='ui icon button'
-                    click=(action (confirm (t 'Are you sure you would like to remove this ticket?') (action 'deleteTicket' ticketFee)))}}
+                    click=(action (confirm (t 'Are you sure you would like to remove this event fee?') (action 'deleteTicket' ticketFee)))}}
           <i class="trash outline icon"></i>
         {{/ui-popup}}
       </div>


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
There is a typo in fee removal modal, it asks for remove this ticket instead of fee.

#### Changes proposed in this pull request:

- Fix typo

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

## Screenshots
![Screenshot from 2019-04-23 17-03-15](https://user-images.githubusercontent.com/21174572/56577846-b29e1280-65e9-11e9-8e22-aae75fb69842.png)


Fixes: #2781
