### PR TITLE
fix: sorting of logs in admin reports section

### DIFF
--- a/app/routes/admin/reports/system-logs/activity-logs.js
+++ b/app/routes/admin/reports/system-logs/activity-logs.js
@@ -7,7 +7,8 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('activity', {
-      'page[size]': 10
+      'page[size]': 10,
+      sort        : '-time'
     });
   }
 });

--- a/app/routes/admin/reports/system-logs/activity-logs.js
+++ b/app/routes/admin/reports/system-logs/activity-logs.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('activity', {
-      'page[size]' : 10,
+      'page[size]' : 100,
       sort         : '-time'
     });
   }

--- a/app/routes/admin/reports/system-logs/activity-logs.js
+++ b/app/routes/admin/reports/system-logs/activity-logs.js
@@ -7,8 +7,8 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('activity', {
-      'page[size]': 10,
-      sort        : '-time'
+      'page[size]' : 10,
+      sort         : '-time'
     });
   }
 });

--- a/app/routes/admin/reports/system-logs/mail-logs.js
+++ b/app/routes/admin/reports/system-logs/mail-logs.js
@@ -7,8 +7,8 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('mail', {
-      'page[size]': 10,
-      sort        : '-time'
+      'page[size]' : 10,
+      sort         : '-time'
     });
   }
 });

--- a/app/routes/admin/reports/system-logs/mail-logs.js
+++ b/app/routes/admin/reports/system-logs/mail-logs.js
@@ -7,7 +7,8 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('mail', {
-      'page[size]': 10
+      'page[size]': 10,
+      sort        : '-time'
     });
   }
 });

--- a/app/routes/admin/reports/system-logs/mail-logs.js
+++ b/app/routes/admin/reports/system-logs/mail-logs.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
   model() {
     return this.get('store').query('mail', {
-      'page[size]' : 10,
+      'page[size]' : 100,
       sort         : '-time'
     });
   }

--- a/app/routes/admin/reports/system-logs/notification-logs.js
+++ b/app/routes/admin/reports/system-logs/notification-logs.js
@@ -9,7 +9,7 @@ export default Route.extend({
     return this.get('store').query('notification', {
       include      : 'user',
       'page[size]' : 10,
-      sort         : '-received-at' 
+      sort         : '-received-at'
     });
   }
 });

--- a/app/routes/admin/reports/system-logs/notification-logs.js
+++ b/app/routes/admin/reports/system-logs/notification-logs.js
@@ -8,7 +8,7 @@ export default Route.extend({
   model() {
     return this.get('store').query('notification', {
       include      : 'user',
-      'page[size]' : 10,
+      'page[size]' : 100,
       sort         : '-received-at'
     });
   }

--- a/app/routes/admin/reports/system-logs/notification-logs.js
+++ b/app/routes/admin/reports/system-logs/notification-logs.js
@@ -8,7 +8,8 @@ export default Route.extend({
   model() {
     return this.get('store').query('notification', {
       include      : 'user',
-      'page[size]' : 10
+      'page[size]' : 10,
+      sort         : '-received-at' 
     });
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
In the Admin Section in the Logs, it shows the oldest entries first.

#### Changes proposed in this pull request:
 - fixed sorting of logs in admin reports section

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2679 
