### PR TITLE
Adding cross icon for `Mark As Read` in "Notification Dropdown"

### DIFF
--- a/app/templates/components/notification-dropdown.hbs
+++ b/app/templates/components/notification-dropdown.hbs
@@ -21,6 +21,11 @@
             {{#link-to 'notifications' invokeAction=(action 'markRead' notification)}}
               {{notification.title}}
             {{/link-to}}
+            <div class="right floated content" >
+              <a href="#" {{action 'markRead' notification}}>
+                <i class="close icon"></i>
+              </a>
+            </div>
           </div>
           <div class="content weight-400">
             {{sanitize notification.message}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Addition of `Cross Icon` for individual notification in notification dropdown to mark it as read

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2788 

**Screenshot**

![image](https://user-images.githubusercontent.com/44091822/56621157-10157c00-6649-11e9-883d-bcb546b2e25e.png)

