### PR TITLE
Fix numerical ordering in user roles in event table

### DIFF
--- a/app/templates/components/ui-table/cell/cell-roles.hbs
+++ b/app/templates/components/ui-table/cell/cell-roles.hbs
@@ -1,17 +1,17 @@
-<div class="ui list">
-  {{#each record.organizers as |role index|}}
-    <div class="item">{{add index 1}}. {{role.email}} ({{t 'Organizer'}})</div>
+<div class="ui ordered list">
+  {{#each record.organizers as |role|}}
+    <div class="item">{{role.email}} ({{t 'Organizer'}})</div>
   {{/each}}
-  {{#each record.coorganizers as |role index|}}
-    <div class="item">{{add index 1}}. {{role.email}} ({{t 'Co-organizers'}})</div>
+  {{#each record.coorganizers as |role|}}
+    <div class="item">{{role.email}} ({{t 'Co-organizers'}})</div>
   {{/each}}
-  {{#each record.trackOrganizers as |role index|}}
-    <div class="item">{{add index 1}}. {{role.email}} ({{t 'Track-organizers'}})</div>
+  {{#each record.trackOrganizers as |role|}}
+    <div class="item">{{role.email}} ({{t 'Track-organizers'}})</div>
   {{/each}}
-  {{#each record.registrars as |role index|}}
-    <div class="item">{{add index 1}}. {{role.email}} ({{t 'Registrars'}})</div>
+  {{#each record.registrars as |role|}}
+    <div class="item">{{role.email}} ({{t 'Registrars'}})</div>
   {{/each}}
-  {{#each record.moderators as |role index|}}
-    <div class="item">{{add index 1}}. {{role.email}} ({{t 'Moderators'}})</div>
+  {{#each record.moderators as |role|}}
+    <div class="item">{{role.email}} ({{t 'Moderators'}})</div>
   {{/each}}
 </div>


### PR DESCRIPTION
Fixes - #2770

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Remove ordering error caused due to hardcoded numbering

#### Changes proposed in this pull request:

- Use sematic UI ordered list class
- Remove hardcoded numbering

