### PR TITLE
updateDates function refactored to apply timezone correctly

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -410,10 +410,13 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     },
 
     updateDates() {
-      const { timezone, startsAt, endsAt } = this.get('data.event').getProperties('timezone', 'startsAt', 'endsAt');
+      const { startsAtDate, endsAtDate, startsAtTime, endsAtTime, timezone } = this.get('data.event').getProperties('startsAtDate', 'endsAtDate', 'startsAtTime', 'endsAtTime', 'timezone');
+      
+      var startsAtConcatenated = moment(startsAtDate +' '+ startsAtTime);
+      var endsAtConcatenated = moment(endsAtDate +' '+ endsAtTime);
       this.get('data.event').setProperties({
-        startsAt : moment.tz(startsAt, timezone),
-        endsAt   : moment.tz(endsAt, timezone)
+        startsAt : moment.tz(startsAtConcatenated, timezone),
+        endsAt   : moment.tz(endsAtConcatenated, timezone)
       });
     },
 

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -411,9 +411,8 @@ export default Component.extend(FormMixin, EventWizardMixin, {
 
     updateDates() {
       const { startsAtDate, endsAtDate, startsAtTime, endsAtTime, timezone } = this.get('data.event').getProperties('startsAtDate', 'endsAtDate', 'startsAtTime', 'endsAtTime', 'timezone');
-      
-      var startsAtConcatenated = moment(startsAtDate +' '+ startsAtTime);
-      var endsAtConcatenated = moment(endsAtDate +' '+ endsAtTime);
+      var startsAtConcatenated = moment(startsAtDate.concat(' ', startsAtTime));
+      var endsAtConcatenated = moment(endsAtDate.concat(' ', endsAtTime));
       this.get('data.event').setProperties({
         startsAt : moment.tz(startsAtConcatenated, timezone),
         endsAt   : moment.tz(endsAtConcatenated, timezone)


### PR DESCRIPTION
fixes - #2834

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This makes sure that the event's start and end timings are correctly stored

#### Changes proposed in this pull request:
Since the date and time pickers use `startAtDate` and `startAtTime` etc, concatenate them and then set them as startsAt and endsAt attribute


![Screenshot from 2019-04-29 12-01-19](https://user-images.githubusercontent.com/21087061/56879524-beb92280-6a76-11e9-92b7-2458d8f745ec.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
