### PR TITLE
standardize timezone to UTC on public schedule

### DIFF
--- a/app/routes/public/schedule.js
+++ b/app/routes/public/schedule.js
@@ -74,8 +74,8 @@ export default Route.extend({
 
       scheduled.push({
         title      : `${session.title} | ${speakerNames.join(', ')}`,
-        start      : session.startsAt.format('YYYY-MM-DDTHH:mm:SS'),
-        end        : session.endsAt.format('YYYY-MM-DDTHH:mm:SS'),
+        start      : session.startsAt.format(),
+        end        : session.endsAt.format(),
         resourceId : session.microlocation.get('id'),
         color      : session.track.get('color'),
         serverId   : session.get('id') // id of the session on BE
@@ -97,6 +97,7 @@ export default Route.extend({
       header,
       defaultView     : 'agendaDay',
       events          : scheduled,
+      timezone        : 'UTC',
       event,
       resources,
       minTime         : event.startsAt.format('HH:mm:ss'),

--- a/app/templates/public/schedule.hbs
+++ b/app/templates/public/schedule.hbs
@@ -6,6 +6,7 @@
                   resources=model.resources
                   resourceLabelText= 'Rooms'
                   header=model.header
+                  timezone=model.timezone
                   views=model.views
                   viewName='agendaDay'
                   defaultView='timelineDay'


### PR DESCRIPTION
Ensures scheduler view is independent of the timezone it is being viewed from.