### PR TITLE
fix: remove unnecessary hidden divider from upload image widget

### DIFF
--- a/app/templates/components/widgets/forms/image-upload.hbs
+++ b/app/templates/components/widgets/forms/image-upload.hbs
@@ -1,5 +1,4 @@
 {{#if selectedImage}}
-  <div class="ui hidden divider"></div>
   <div class="ui card">
     {{#if uploadingImage}}
       <div class="ui active dimmer">


### PR DESCRIPTION
Makes the user profile form columns begin at the same height.
See discussion in #2513