### PR TITLE
Adds hidden divider between image inputs

### DIFF
--- a/app/components/widgets/forms/image-upload.js
+++ b/app/components/widgets/forms/image-upload.js
@@ -5,8 +5,9 @@ import { v4 } from 'ember-uuid';
 
 export default Component.extend({
 
-  selectedImage : null,
-  allowDragDrop : true,
+  selectedImage   : null,
+  allowDragDrop   : true,
+  requiresDivider : false,
 
   inputIdGenerated: computed('inputId', function() {
     return this.get('inputId') ? this.get('inputId') : v4();

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -92,7 +92,8 @@
         icon='camera'
         hint=(t 'Select Event Image')
         maxSizeInKb=10000
-        helpText=(t 'We recommend using at least a 2160x1080px (2:1 ratio) image')}}
+        helpText=(t 'We recommend using at least a 2160x1080px (2:1 ratio) image')
+        requiresDivider=true}}
     </div>
   </div>
 

--- a/app/templates/components/widgets/forms/image-upload.hbs
+++ b/app/templates/components/widgets/forms/image-upload.hbs
@@ -1,4 +1,7 @@
 {{#if selectedImage}}
+  {{#if (and requiresDivider device.isMobile)}}
+    <div class="ui hidden divider"></div>
+  {{/if}}
   <div class="ui card">
     {{#if uploadingImage}}
       <div class="ui active dimmer">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Short description of what this resolves:
Adds a conditional divider between image pickers in mobile mode

Fixes #2513 
