### PR TITLE
Added the missing tooltip for toggle eye in login form

### DIFF
--- a/app/templates/components/forms/login-form.hbs
+++ b/app/templates/components/forms/login-form.hbs
@@ -33,9 +33,13 @@
               <div class="ui small basic icon buttons">
                 <button type="button" class="ui button" id="eye1" {{action 'showPassword'}}>
                   {{#if showPass}}
-                    <i class="hide basic icon"></i>
+                    <div class="ui icon button" data-tooltip="Hide Password" data-position="top left" data-inverted="">
+                      <i class="hide basic icon"></i>
+                    </div>
                   {{else}}
-                    <i class="unhide basic icon"></i>
+                    <div class="ui icon button" data-tooltip="Show Password" data-position="top left" data-inverted="">
+                      <i class="unhide basic icon"></i>
+                    </div>
                   {{/if}}
                 </button>
               </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Similar to Gmail implementation, added the tooltip for toggle eye icon to avoid the confusion  of the  show or hide password on login form

#### Changes proposed in this pull request:

- update `login-form.hbs`


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2896 

**Screenshots**
Gmail implementation

![Screenshot 2019-05-12 05:02:12](https://user-images.githubusercontent.com/35539313/57576001-19d61680-7474-11e9-802e-2cf15e74faec.png)

My Implementation

![Screenshot 2019-05-12 05:05:12](https://user-images.githubusercontent.com/35539313/57576002-25294200-7474-11e9-9d40-ff9dab5619e2.png)


