### PR TITLE
Refactor: Use createObjectURL for saving blob as file

### DIFF
--- a/app/controllers/admin/content/translations.js
+++ b/app/controllers/admin/content/translations.js
@@ -11,7 +11,7 @@ export default Controller.extend({
         .then(res => {
           const anchor = document.createElement('a');
           anchor.style.display = 'none';
-          anchor.href = `data:text/plain;charset=utf-8,${encodeURIComponent(res)}`;
+          anchor.href = URL.createObjectURL(new Blob([res], { type: 'octet/stream' }));
           anchor.download = 'Translations.zip';
           anchor.click();
           this.get('notify').success(this.get('l10n').t('Translations Zip generated successfully.'));

--- a/app/controllers/orders/view.js
+++ b/app/controllers/orders/view.js
@@ -21,7 +21,7 @@ export default Controller.extend({
       .then(res => {
         const anchor = document.createElement('a');
         anchor.style.display = 'none';
-        anchor.href = `data:text/plain;charset=utf-8,${encodeURIComponent(res)}`;
+        anchor.href = URL.createObjectURL(new Blob([res], { type: 'application/pdf' }));
         anchor.download = 'Tickets.pdf';
         anchor.click();
         this.get('notify').success(this.get('l10n').t('Here are your tickets'));


### PR DESCRIPTION
Fixes the bug which led to files having an inconsistent format while downloading in production.

Fixes #2914 