### PR TITLE
fix: hides 'use ticketing system' to prevent spam

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -143,13 +143,17 @@
   </div>
   {{#if data.module.ticketInclude}}
     <div class="ui section divider"></div>
-    <div class="field">
-      <div class="ui slider checkbox">
-        {{input type='checkbox' checked=data.event.isTicketingEnabled id='use_ticketing_system'}}
-        <label for="use_ticketing_system">{{t 'Use ticketing system'}}</label>
+    {{!-- Hiding toggle ticket feature temporarily
+      <div class="field">
+        <div class="ui slider checkbox">
+          {{input type='checkbox' checked=data.event.isTicketingEnabled id='use_ticketing_system'}}
+          <label for="use_ticketing_system">{{t 'Use ticketing system'}}</label>
+        </div>
       </div>
-    </div>
-    {{#if data.event.isTicketingEnabled}}
+    --}}
+    <div class="field">
+      <label class="required">{{t 'Ticketing System'}}</label>
+      {{!-- {{#if data.event.isTicketingEnabled}} --}}
       <div class="ui attached segment {{unless data.event.tickets 'center aligned'}}">
         {{#if data.event.tickets}}
           <div class="ui stackable celled five column grid ticket-header">
@@ -179,7 +183,7 @@
           {{/each}}
         {{else}}
           <h3 class="text muted weight-500">
-            {{t 'You don\'t have any tickets added. Add one of your choice.'}}
+            {{t 'You don\'t have any tickets added. Please add atleast one ticket to publish your event.'}}
           </h3>
         {{/if}}
       </div>
@@ -197,14 +201,15 @@
         </i>
         {{t 'Paid Ticket'}}
       </button>
-    {{else}}
-      <div class="field">
-        <label for="ticket_url">{{t 'Ticket URL'}}</label>
-        {{widgets/forms/link-input inputId='ticket_url' segmentedLink=data.event.segmentedTicketUrl}}
-      </div>
-    {{/if}}
+      {{!-- {{else}}
+        <div class="field">
+          <label for="ticket_url">{{t 'Ticket URL'}}</label>
+          {{widgets/forms/link-input inputId='ticket_url' segmentedLink=data.event.segmentedTicketUrl}}
+        </div>
+      {{/if}} --}}
+    </div>
   {{/if}}
-  {{#if (and hasPaidTickets data.event.isTicketingEnabled)}}
+  {{#if hasPaidTickets}}
     {{!-- Hiding discount code temporarily, till we get this feature ready to apply discount codes for events.
     <div class="ui section divider"></div>
     <div class="field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2482 , Related to #2920 

#### Short description of what this resolves:
The option "use ticketing system" is a nice feature to add events of external websites. The options has been abused though to add spam events. 

#### Changes proposed in this pull request:
 - Comments option `use ticketing system` 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
