### PR TITLE
fix: adds date and time column to organizer dashboard ticket section

### DIFF
--- a/app/components/ui-table/cell/events/view/tickets/orders/cell-date.js
+++ b/app/components/ui-table/cell/events/view/tickets/orders/cell-date.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -9,6 +9,12 @@ export default Controller.extend({
       disableSorting : true
     },
     {
+      propertyName : 'completedAt',
+      template     : 'components/ui-table/cell/events/view/tickets/orders/cell-date',
+      dateFormat   : 'MMMM DD, YYYY - HH:mm A',
+      title        : 'Date And Time'
+    },
+    {
       propertyName : 'amount',
       template     : 'components/ui-table/cell/events/view/tickets/orders/cell-amount',
       title        : 'Total Amount'

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
@@ -1,0 +1,9 @@
+{{#if record.completedAt}}
+  <div>
+    {{moment-format record.completedAt 'MMMM DD, YYYY - hh:mm A'}}
+  </div>
+{{else}}
+  <div>
+    {{moment-format record.createdAt 'MMMM DD, YYYY - hh:mm A'}}
+  </div>
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2938 

#### Short description of what this resolves:
It is important for organizers to view tickets according to the date. The Date Column in the Orders and Attendees table is missing though.

#### Changes proposed in this pull request:
 - Adds date and time  column to organizer dashboard
 - Displays `completedAt` attribute. If its missing `createdAt` attribute is displayed

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
