### PR TITLE
fix: Event location display on landing page

### DIFF
--- a/app/models/event.js
+++ b/app/models/event.js
@@ -153,10 +153,16 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   segmentedTicketUrl        : computedSegmentedLink.bind(this)('ticketUrl'),
 
   shortLocationName: computed('locationName', function() {
-    if (!this.get('locationName')) {
+    let eventLocation = this.get('locationName');
+    if (!eventLocation) {
       return '';
     }
-    return this.get('locationName').split(',')[0];
+    let splitLocations = eventLocation.split(',');
+    if (splitLocations.length <= 3) {
+      return eventLocation;
+    } else {
+      return splitLocations.splice(1, splitLocations.length).join();
+    }
   }),
 
   url: computed('identifier', function() {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2967 

#### Short description of what this resolves:
Omits venue if the multiple fields of locations are present else prints the entire address so, city and country is always displayed.