### PR TITLE
feat: Add instagram & address fields to speaker custom-forms

### DIFF
--- a/app/mixins/custom-form.js
+++ b/app/mixins/custom-form.js
@@ -146,6 +146,14 @@ export default Mixin.create(MutableArray, {
         event           : parent
       }),
       this.store.createRecord('custom-form', {
+        fieldIdentifier : 'address',
+        form            : 'speaker',
+        type            : 'text',
+        isRequired      : false,
+        isIncluded      : false,
+        event           : parent
+      }),
+      this.store.createRecord('custom-form', {
         fieldIdentifier : 'country',
         form            : 'speaker',
         type            : 'select',
@@ -251,6 +259,14 @@ export default Mixin.create(MutableArray, {
       }),
       this.store.createRecord('custom-form', {
         fieldIdentifier : 'linkedin',
+        form            : 'speaker',
+        type            : 'text',
+        isRequired      : false,
+        isIncluded      : false,
+        event           : parent
+      }),
+      this.store.createRecord('custom-form', {
+        fieldIdentifier : 'instagram',
         form            : 'speaker',
         type            : 'text',
         isRequired      : false,

--- a/app/models/custom-form.js
+++ b/app/models/custom-form.js
@@ -34,6 +34,7 @@ export default ModelBase.extend({
     photoUrl            : 'Photo',
     organisation        : 'Organisation',
     position            : 'Position',
+    address             : 'Address',
     country             : 'Country',
     city                : 'City',
     longBiography       : 'Long Biography',
@@ -47,7 +48,8 @@ export default ModelBase.extend({
     facebook            : 'Facebook',
     twitter             : 'Twitter',
     github              : 'GitHub',
-    linkedin            : 'Linkedin'
+    linkedin            : 'Linkedin',
+    instagram           : 'Instagram'
   },
 
   attendee: {


### PR DESCRIPTION
Fixes #2981 

#### Short description of what this resolves:
Adds instagram and address fields to custom-forms model **[Only for the events created henceforth]**
