### PR TITLE
fix: display of pre-existing event tax details in edit wizard

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -115,9 +115,6 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     if (!this.get('isCreate') && this.get('data.event.copyright') && !this.get('data.event.copyright.content')) {
       this.set('data.event.copyright', this.store.createRecord('event-copyright'));
     }
-    if (!this.get('isCreate') && this.get('data.event.tax') && !this.get('data.event.tax.content')) {
-      this.set('data.event.tax', this.store.createRecord('tax'));
-    }
     if (!this.get('isCreate') && this.get('data.event.stripeAuthorization') && !this.get('data.event.stripeAuthorization.content')) {
       this.set('data.event.stripeAuthorization', this.store.createRecord('stripe-authorization'));
     }
@@ -383,7 +380,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
       ticket.set('position', direction === 'up' ? (index - 1) : (index + 1));
     },
 
-    openTaxModal() {
+    openTaxModal(isNewTax) {
+      if (!this.isCreate && isNewTax) {
+        this.set('data.event.tax', this.store.createRecord('tax'));
+      }
       this.set('taxModalIsOpen', true);
     },
 

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -428,7 +428,7 @@
               </div>
             </div>
             <div class="ui bottom attached small buttons">
-              <button class="ui button" type="button" {{action 'openTaxModal'}}>
+              <button class="ui button" type="button" {{action 'openTaxModal' false}}>
                 <i class="pencil icon"></i>
                 {{t 'Edit'}}
               </button>
@@ -440,7 +440,7 @@
             </div>
           </div>
         {{else}}
-          <button type="button" class="ui right labeled icon button" {{action 'openTaxModal'}}>
+          <button type="button" class="ui right labeled icon button" {{action 'openTaxModal' true}}>
             <i class="percent icon"></i>
             {{t 'Add Tax Information'}}
           </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2985 

Ensures empty tax record does not replace the actual tax of the event.