### PR TITLE
enh: Avoid using sync relationship for event-tax

### DIFF
--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -107,13 +107,13 @@ export default Controller.extend({
 
     },
 
-    placeOrder() {
+    async placeOrder() {
       if (!this.get('session.isAuthenticated')) {
         this.set('isLoginModalOpen', true);
         return;
       }
       let { order, event } = this.model;
-      let { tax } =  event;
+      let tax =  await event.get('tax');
       if (tax) {
         if (!tax.get('isTaxIncludedInPrice')) {
           let taxedPrice  = (order.amount) * (tax.rate) / 100 + (order.amount);

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -108,7 +108,7 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
   speakersCall           : belongsTo('speakers-call'),
   stripeAuthorization    : belongsTo('stripe-authorization'),
   eventStatisticsGeneral : belongsTo('event-statistics-general'),
-  tax                    : belongsTo('tax', { async: false }),
+  tax                    : belongsTo('tax'),
   copyright              : belongsTo('event-copyright'),
   sessionTypes           : hasMany('session-type'),
   user                   : belongsTo('user', { inverse: 'events' }),


### PR DESCRIPTION
Sync relationships have the advantage of not returning a proxy object when needed, but then ember expects the tax to be included every time an event record is supplied.