### PR TITLE
Fix: Broken paypal button fixed

### DIFF
--- a/app/components/paypal-button.js
+++ b/app/components/paypal-button.js
@@ -29,14 +29,14 @@ export default Component.extend({
         shape : 'pill'    // pill, rect
       },
 
-      payment() {
+      payment: () => {
         return this.loader.post(`orders/${order.identifier}/create-paypal-payment`, createPayload)
           .then(res => {
             return res.payment_id;
           });
       },
 
-      onAuthorize(data) {
+      onAuthorize: data => {
         // this callback will be for authorizing the payments
         let chargePayload = {
           'data': {


### PR DESCRIPTION

Fixes #2999 

switches functions to arrow functions to retain `this` of the component.