### PR TITLE
fix: Show pending orders in my tickets section

### DIFF
--- a/app/routes/my-tickets/upcoming/list.js
+++ b/app/routes/my-tickets/upcoming/list.js
@@ -26,11 +26,18 @@ export default Route.extend({
                 val  : moment().toISOString()
               }
             },
-            {
-              name : 'status',
-              op   : 'eq',
-              val  : 'completed'
-            },
+            { or: [
+              {
+                name : 'status',
+                op   : 'eq',
+                val  : 'completed'
+              },
+              {
+                name : 'status',
+                op   : 'eq',
+                val  : 'placed'
+              }
+            ] },
             {
               name : 'event',
               op   : 'has',
@@ -56,11 +63,18 @@ export default Route.extend({
                 val  : moment().toISOString()
               }
             },
-            {
-              name : 'status',
-              op   : 'eq',
-              val  : 'placed'
-            },
+            { or: [
+              {
+                name : 'status',
+                op   : 'eq',
+                val  : 'pending'
+              },
+              {
+                name : 'status',
+                op   : 'eq',
+                val  : 'initializing'
+              }
+            ] },
             {
               name : 'event',
               op   : 'has',


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3001 

#### Short description of what this resolves:
Adds pending and initializing orders to open orders tab of my-tickets route

