### PR TITLE
 feat: create a helper for order status-color

### DIFF
--- a/app/helpers/order-color.js
+++ b/app/helpers/order-color.js
@@ -1,0 +1,20 @@
+import { helper } from '@ember/component/helper';
+
+export function orderColor(params) {
+  switch (params[0]) {
+    case 'completed':
+      return 'green';
+    case 'placed':
+      return 'blue';
+    case 'initializing':
+      return 'yellow';
+    case 'pending':
+      return 'orange';
+    case 'expired':
+      return 'red';
+    default:
+      return 'grey';
+  }
+}
+
+export default helper(orderColor);

--- a/app/templates/components/order-card.hbs
+++ b/app/templates/components/order-card.hbs
@@ -9,8 +9,7 @@
   <div class="ui card thirteen wide computer ten wide tablet sixteen wide mobile column">
     <a class="main content" href="{{href-to 'orders.view' order.identifier}}">
       <div class="right floated author">
-        <div class="ui {{if (eq order.status 'completed') 'green' (if (eq order.status 'placed') 'blue' 'red')}}
-          large label">
+        <div class="ui {{order-color order.status}} large label">
           {{order.status}}
         </div>
       </div>

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -1,6 +1,6 @@
 <div class="ui segments">
   {{#if (eq session.currentRouteName 'orders.view')}}
-    <div class="ui {{if (eq data.status 'completed') 'green' 'blue'}} inverted segment center aligned">
+    <div class="ui {{order-color data.status}} inverted segment center aligned">
       <div class="ui inverted mini statistic horizontal">
         <div class="value">
           {{#if (eq data.status 'completed')}}

--- a/tests/integration/helpers/order-color-test.js
+++ b/tests/integration/helpers/order-color-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | order-color', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('orderState', 'completed');
+    await render(hbs`{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'green');
+
+    this.set('orderState', 'placed');
+    await render(hbs`{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'blue');
+
+    this.set('orderState', 'initializing');
+    await render(hbs`{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'yellow');
+
+    this.set('orderState', 'pending');
+    await render(hbs `{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'orange');
+
+    this.set('orderState', 'expired');
+    await render(hbs `{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'red');
+
+    this.set('orderState', undefined);
+    await render(hbs `{{order-color orderState}}`);
+    assert.equal(this.element.textContent.trim(), 'grey');
+  });
+});


### PR DESCRIPTION
Adds a helper with tests, to compute the colors according to the status of orders to make the color control centralized.

Fixes #3004 