### PR TITLE
Only display events who the User is an Organizer of.

### DIFF
--- a/app/templates/components/ui-table/cell/admin/users/cell-event-roles.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-event-roles.hbs
@@ -24,7 +24,7 @@
     </div>
   {{else}}
     {{#if record.isUserOrganizer}}
-      {{#each record.organizerEvents as |event|}}
+      {{#each record.events as |event|}}
         <div class="item">
           {{#link-to 'events.view' event.identifier}}{{event.name}}{{/link-to}} - <span class="ui tiny basic black label">{{t 'Organizer'}}</span>
         </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2390 

#### Short description of what this resolves:
Admin panel of Users displays user as an organizer of every event.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
