### PR TITLE
fix: removes download and invoice buttons from placed orders

### DIFF
--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -34,16 +34,18 @@
         </div>
       </div>
       <br>
-      <a class="ui labeled icon {{if isLoadingTickets 'loading'}} button" href="#" {{action downloadTickets model.event.name model.order.identifier}} target="_blank" rel="noopener nofollow">
-        <i class="ticket alternate icon"></i>
-        {{t 'Download Tickets'}}
-      </a>
-      <br>
-      <br>
-      <a href="#" {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button">
-        <i class="print alternate icon"></i>
-        {{t 'Print Invoice'}}
-      </a>
+      {{#if (eq model.order.status 'completed')}}
+        <a class="ui labeled icon {{if isLoadingTickets 'loading'}} button" href="#" {{action downloadTickets model.event.name model.order.identifier}} target="_blank" rel="noopener nofollow">
+          <i class="ticket alternate icon"></i>
+          {{t 'Download Tickets'}}
+        </a>
+        <br>
+        <br>
+        <a href="#" {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button">
+          <i class="print alternate icon"></i>
+          {{t 'Print Invoice'}}
+        </a>
+      {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes fossasia/open-event-server#5956

#### Short description of what this resolves:
Removes the download and invoice buttons from after the discussion here :
https://github.com/fossasia/open-event-server/issues/5956#issuecomment-495939739