### PR TITLE
fix: Refactor buyer name fields in order-form

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -14,14 +14,26 @@ import {
 export default Component.extend(FormMixin, {
   router: service(),
 
+  buyerFirstName: computed('buyerHasFirstName', function() {
+    if (this.buyerHasFirstName) {
+      return this.get('data.user.firstName');
+    } else {
+      return '';
+    }
+  }),
+  buyerLastName: computed('buyerHasLastName', function() {
+    if (this.buyerHasLastName) {
+      return this.get('data.user.lastName');
+    } else {
+      return '';
+    }
+  }),
   buyer: computed('data.user', function() {
     return this.get('data.user');
   }),
-
   buyerHasFirstName: computed(function() {
     return this.get('data.user.firstName');
   }),
-
   buyerHasLastName: computed(function() {
     return this.get('data.user.lastName');
   }),
@@ -474,13 +486,16 @@ export default Component.extend(FormMixin, {
   actions: {
     submit(data) {
       this.onValid(() => {
+        let currentUser = this.get('data.user');
+        currentUser.set('firstName', this.buyerFirstName);
+        currentUser.set('lastName', this.buyerLastName);
         this.sendAction('save', data);
       });
     },
     modifyHolder(holder) {
       if (this.sameAsBuyer) {
-        holder.set('firstname', this.buyer.content.firstName);
-        holder.set('lastname', this.buyer.content.lastName);
+        holder.set('firstname', this.buyerFirstName);
+        holder.set('lastname', this.buyerLastName);
         holder.set('email', this.buyer.content.email);
       } else {
         holder.set('firstname', '');

--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { readOnly, oneWay } from '@ember/object/computed';
 import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import FormMixin from 'open-event-frontend/mixins/form';
@@ -14,30 +15,12 @@ import {
 export default Component.extend(FormMixin, {
   router: service(),
 
-  buyerFirstName: computed('buyerHasFirstName', function() {
-    if (this.buyerHasFirstName) {
-      return this.get('data.user.firstName');
-    } else {
-      return '';
-    }
-  }),
-  buyerLastName: computed('buyerHasLastName', function() {
-    if (this.buyerHasLastName) {
-      return this.get('data.user.lastName');
-    } else {
-      return '';
-    }
-  }),
-  buyer: computed('data.user', function() {
-    return this.get('data.user');
-  }),
-  buyerHasFirstName: computed(function() {
-    return this.get('data.user.firstName');
-  }),
-  buyerHasLastName: computed(function() {
-    return this.get('data.user.lastName');
-  }),
-  holders: computed('data.attendees', function() {
+  buyerFirstName    : oneWay('buyerHasFirstName'),
+  buyerLastName     : oneWay('buyerHasLastName'),
+  buyer             : readOnly('data.user'),
+  buyerHasFirstName : readOnly('data.user.firstName'),
+  buyerHasLastName  : readOnly('data.user.lastName'),
+  holders           : computed('data.attendees', function() {
     this.get('data.attendees').forEach(attendee => {
       attendee.set('firstname', '');
       attendee.set('lastname', '');

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -22,11 +22,11 @@
       </h4>
       <div class="field {{if buyerHasFirstName 'disabled'}}">
         <label class="required" for="firstname">{{t 'First Name'}}</label>
-        {{input type='text' name='first_name' value=buyer.firstName}}
+        {{input type='text' name='first_name' value=buyerFirstName}}
       </div>
       <div class="field {{if buyerHasLastName 'disabled'}}">
         <label class="required" for="lastname">{{t 'Last Name'}}</label>
-        {{input type='text' name='last_name' value=buyer.lastName}}
+        {{input type='text' name='last_name' value=buyerLastName}}
       </div>
       <div class="field disabled">
         <label class="required" for="email">{{t 'Email'}}</label>


### PR DESCRIPTION
- This avoid name changes in the nav bar because the name has been pre loaded

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2707

#### Short description of what this resolves:
This utilises computed property to make sure that user name doesn't change during filling of forms.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
