### PR TITLE
Upgrade ember-full-calendar to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ember-exam": "^2.0.2",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "6.5.1",
-    "ember-fullcalendar": "^1.7.0",
+    "ember-fullcalendar": "^1.8.0",
     "ember-g-map": "0.0.25",
     "ember-href-to": "3.1.0",
     "ember-infinity": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6008,9 +6008,10 @@ ember-fetch@6.5.1, "ember-fetch@^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0":
     node-fetch "^2.3.0"
     whatwg-fetch "^3.0.0"
 
-ember-fullcalendar@^1.7.0:
+ember-fullcalendar@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ember-fullcalendar/-/ember-fullcalendar-1.8.0.tgz#264da8513da5d0db355dcad713111c72d50cc0b9"
+  integrity sha512-cGhbuR7FUrQz1+Pmkm5kLtp/lD0IhRc8d2kSm58+XVfV2325fjXBa+1c/Kcv9Av94MwwSUczu3SFMq1xiTWECA==
   dependencies:
     ember-cli-babel "^6.7.2"
     ember-cli-htmlbars "^2.0.1"


### PR DESCRIPTION
This dependency was missed in the refactor.