### PR TITLE
feat: Show appropriate currency in stripe checkout

### DIFF
--- a/app/templates/orders/pending.hbs
+++ b/app/templates/orders/pending.hbs
@@ -29,6 +29,7 @@
         <div class = 'ui right floated'>
           {{stripe-checkout
             image="https://stripe.com/img/documentation/checkout/marketplace.png"
+            currency=model.order.event.paymentCurrency
             locale='auto'
             name="Open Event"
             class="ui teal submit button"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3037 
Use event currency to determine payment currency.

![image](https://user-images.githubusercontent.com/17252805/58571085-ad2c8b80-826b-11e9-8ee4-bd1b6a17b7e0.png)
