### PR TITLE
fix: tracks and sessionTypes loads on editing session

### DIFF
--- a/app/routes/public/cfs/edit-session.js
+++ b/app/routes/public/cfs/edit-session.js
@@ -15,7 +15,9 @@ export default Route.extend({
       }),
       session: await this.store.findRecord('session', params.session_id, {
         include: 'session-type,track'
-      })
+      }),
+      tracks       : await eventDetails.query('tracks', {}),
+      sessionTypes : await eventDetails.query('sessionTypes', {})
     };
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3056 

#### Short description of what this resolves:
When user edit the session for proposal, sessions and tracks are not loaded so that user cannot change it

#### Changes proposed in this pull request:
 - Adds `tracks` and `sessionTypes` to `edit-session` route

![Screenshot from 2019-06-04 12-45-33](https://user-images.githubusercontent.com/25428397/58859310-1591c780-86c7-11e9-8f1f-b5088a1ebd43.png)

![Screenshot from 2019-06-04 12-45-36](https://user-images.githubusercontent.com/25428397/58859314-16c2f480-86c7-11e9-8ed5-abb17119af03.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
