### PR TITLE
fix: pre-fetch event currency to render on edit discount code route

### DIFF
--- a/app/routes/events/view/tickets/discount-codes/edit.js
+++ b/app/routes/events/view/tickets/discount-codes/edit.js
@@ -1,17 +1,18 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import RSVP from 'rsvp';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   titleToken(model) {
     let discount_code = model.discountCode.get('code');
     return this.l10n.t(discount_code.concat('-Edit'));
   },
-  model(params) {
-    return RSVP.hash({
-      discountCode : this.store.findRecord('discount-code', params.discount_code_id, {}),
-      tickets      : this.modelFor('events.view').query('tickets', {})
-    });
+  async model(params) {
+    let event = this.modelFor('events.view');
+    return {
+      discountCode : await this.store.findRecord('discount-code', params.discount_code_id, {}),
+      tickets      : await this.modelFor('events.view').query('tickets', {}),
+      event
+    };
   },
 
   async afterModel(model) {

--- a/app/templates/events/view/tickets/discount-codes/edit.hbs
+++ b/app/templates/events/view/tickets/discount-codes/edit.hbs
@@ -4,7 +4,7 @@
   </div>
   <div class="row">
     <div class="sixteen wide column">
-      {{forms/events/view/create-discount-code save='saveCode' data=model.discountCode tickets=model.tickets}}
+      {{forms/events/view/create-discount-code save='saveCode' data=model.discountCode event=model.event tickets=model.tickets}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3065  

#### Short description of what this resolves:

- Removes RSVP hash from the route model
- Fixes the discount code issue