### PR TITLE
fix: Show speaker image in session card.

### DIFF
--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -22,7 +22,7 @@
         <div class="left floated eleven wide column">
           <div class="session-speakers">
             {{#each session.speakers as |speaker|}}
-              <img alt="speaker" class="ui mini avatar image" src="{{if speaker.photo.iconImageUrl speaker.photo.iconImageUrl '/images/placeholders/avatar.png'}}">
+              <img alt="speaker" class="ui mini avatar image" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
             {{/each}}
           </div>
         </div>


### PR DESCRIPTION
Fixes: #3061

#### Short description of what this resolves:
This shows the speaker image in the session card in event listing.

#### Changes proposed in this pull request:

- Fix the image url reference.
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
