### PR TITLE
fix: Fix wrong submit time in sessions.

### DIFF
--- a/app/models/session.js
+++ b/app/models/session.js
@@ -5,6 +5,7 @@ import { belongsTo, hasMany } from 'ember-data/relationships';
 import { computedDateTimeSplit } from 'open-event-frontend/utils/computed-helpers';
 import { computed } from '@ember/object';
 
+const detectedTimezone = moment.tz.guess();
 
 export default ModelBase.extend({
   title         : attr('string'),
@@ -28,7 +29,7 @@ export default ModelBase.extend({
 
   createdAt      : attr('string'),
   deletedAt      : attr('string'),
-  submittedAt    : attr('string', { defaultValue: () => moment() }),
+  submittedAt    : attr('moment', { defaultValue: () => moment.tz(detectedTimezone) }),
   lastModifiedAt : attr('string'),
   sessionType    : belongsTo('session-type'),
   microlocation  : belongsTo('microlocation'),


### PR DESCRIPTION
Fixes: #3071

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


#### Short description of what this resolves:
This fixes the wrong submitted time in sessions

#### Changes proposed in this pull request:

- Correct default value of submitted at in session model.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## GIF:
![fasia](https://user-images.githubusercontent.com/21174572/59068986-65dd7500-88d3-11e9-823d-00cec96a1c30.gif)
