### PR TITLE
fix: Show discount only when there are discount code for an event and ticket.

### DIFF
--- a/app/components/orders/order-summary.js
+++ b/app/components/orders/order-summary.js
@@ -14,12 +14,17 @@ export default Component.extend(FormMixin, {
     );
   }),
 
+  discountCode: computed('data.discountCode', function() {
+    return this.get('data.discountCode');
+  }),
+
   async didInsertElement() {
     let discountCode = await this.get('data.discountCode');
+    console.log(discountCode);
     let tickets = await this.get('data.tickets');
-    tickets.forEach(ticket => {
-      ticket.set('discount', 0);
-    });
+    // tickets.forEach(ticket => {
+    //   ticket.set('discount', 0);
+    // });
     if (discountCode) {
       let discountCodeTickets = await discountCode.get('tickets');
       let discountType = discountCode.get('type');

--- a/app/components/orders/order-summary.js
+++ b/app/components/orders/order-summary.js
@@ -20,11 +20,7 @@ export default Component.extend(FormMixin, {
 
   async didInsertElement() {
     let discountCode = await this.get('data.discountCode');
-    console.log(discountCode);
     let tickets = await this.get('data.tickets');
-    // tickets.forEach(ticket => {
-    //   ticket.set('discount', 0);
-    // });
     if (discountCode) {
       let discountCodeTickets = await discountCode.get('tickets');
       let discountType = discountCode.get('type');

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -44,7 +44,9 @@
         <tr>
           <th class="four wide">{{t 'Ticket Type'}}</th>
           <th class="four wide">{{t 'Price'}}</th>
-          <th class="ui aligned two wide">{{t 'Discount'}}</th>
+          {{#if discountCode}}
+            <th class="ui aligned two wide">{{t 'Discount'}}</th>
+          {{/if}}
           <th class="one wide">{{t 'Quantity'}}</th>
           <th class="ui aligned two wide">{{t 'Subtotal'}}</th>
           {{#if event.tax}}
@@ -61,7 +63,9 @@
               </div>
             </td>
             <td>{{currency-symbol eventCurrency}} {{format-number ticket.price}}</td>
-            <td>{{currency-symbol eventCurrency}} {{format-number ticket.discount}}</td>
+            {{#if ticket.discount}}
+              <td>{{currency-symbol eventCurrency}} {{format-number ticket.discount}}</td>
+            {{/if}}
             <td>{{ticket-attendees data.attendees ticket.attendees}}</td>
             <td>
               {{currency-symbol eventCurrency}} {{format-number (mult (sub ticket.price ticket.discount) (ticket-attendees data.attendees ticket.attendees))}}

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -86,7 +86,9 @@
         <tr>
           <th></th>
           <th></th>
-          <th></th>
+          {{#if discountCode}}
+            <th></th>
+          {{/if}}
           <th>
             <div class="ui aligned small primary icon">
               {{t 'Grand Total'}}:


### PR DESCRIPTION
Reference: #2993

#### Short description of what this resolves:
This PR shows discount column in order summary only when discount exists.

#### Changes proposed in this pull request:

- Prefetch discount codes and check if they are present or not.
- Check if discount code was applied to ticket.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## GIF
![discounthide](https://user-images.githubusercontent.com/21174572/59126965-04c1aa00-8984-11e9-8d63-005900a50ff0.gif)
