### PR TITLE
fix: ensures sessions are listed in public/speakers by handling errors

### DIFF
--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -48,19 +48,21 @@
             {{#if session.startsAt}}
               {{moment-format session.startsAt 'DD MMM YY'}}
             {{/if}}
-            <br>
-            <span class="session-location">
-              <strong>
-                {{session.microlocation.name}}
-              </strong>
-            </span>
+            {{#if session.microlocation}}
+              <br>
+              <span class="session-location">
+                <strong>
+                  {{concat (t 'Microlocation - ') session.microlocation.name}}
+                </strong>
+              </span>
+            {{/if}}
           </p>
-          <div class="ui fluid padded" style={{-html-safe (concat "color: " session.track.fontColor "px; background-color: " session.track.color ";")}}>
+          <div class="ui fluid padded" style={{concat "color: " session.track.fontColor "px; background-color: " session.track.color ";"}}>
             <h3 class="item">
               {{#if (and session.startsAt session.endsAt)}}
                 {{moment-format session.startsAt 'HH:mm'}} - {{moment-format session.endsAt 'hh:mm'}}
+                <br>
               {{/if}}
-              <br>
               &bull;&nbsp; {{session.title}}
               <br>
             </h3>

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -57,7 +57,7 @@
               </span>
             {{/if}}
           </p>
-          <div class="ui fluid padded" style={{concat "color: " session.track.fontColor "px; background-color: " session.track.color ";"}}>
+          <div class="ui fluid padded" style={{css color=session.track.fontColor background-color=session.track.color}}>
             <h3 class="item">
               {{#if (and session.startsAt session.endsAt)}}
                 {{moment-format session.startsAt 'HH:mm'}} - {{moment-format session.endsAt 'hh:mm'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3043 

#### Short description of what this resolves:
Session of the Speaker are not getting listed under Its Heading on Public Pages due to :
 - `html-safe` not a helper error

#### Changes proposed in this pull request:
 - removes `html-safe` helper
 - adds a condition to add a subheading `Microlocation` on speaker-item to increase the understanding.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
