### PR TITLE
fix: redirect to event cfs page if clicked on event-card in cfs section

### DIFF
--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -2,7 +2,7 @@
   {{#if isWide}}
     {{#unless device.isMobile}}
       <div class="ui card three wide computer six wide tablet column">
-        <a class="image" href="{{href-to 'public' event.identifier}}">
+        <a class="image" href="{{href-to (if isCFS 'public.cfs' 'public') event.identifier}}">
           {{widgets/safe-image src=(if event.thumbnailImageUrl event.thumbnailImageUrl event.originalImageUrl)}}
         </a>
       </div>
@@ -10,11 +10,11 @@
   {{/if}}
   <div class="ui card {{unless isWide 'event fluid' 'thirteen wide computer ten wide tablet sixteen wide mobile column'}}">
     {{#unless isWide}}
-      <a class="image" href="{{href-to 'public' event.identifier}}">
+      <a class="image" href="{{href-to (if isCFS 'public.cfs' 'public') event.identifier}}">
         {{widgets/safe-image src=(if event.thumbnailImageUrl event.thumbnailImageUrl event.originalImageUrl)}}
       </a>
     {{/unless}}
-    <a class="main content" href="{{href-to 'public' event.identifier}}">
+    <a class="main content" href="{{href-to (if isCFS 'public.cfs' 'public') event.identifier}}">
       {{#smart-overflow class='header'}}
         {{event.name}}
       {{/smart-overflow}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -23,7 +23,7 @@
     <h2 class="main-heading">{{t 'Call for speakers'}}</h2>
     <div class="ui stackable three column grid">
       {{#each callForSpeakersEvents as |event|}}
-        {{event-card event=event shareEvent=(action 'shareEvent')}}
+        {{event-card event=event isCFS=true shareEvent=(action 'shareEvent')}}
       {{/each}}
     </div>
   {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3099 

#### Changes proposed in this pull request:
On the front page in the call for speakers section please direct the listed events in that section directly to the "Call for Speakers" page of the event.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
