### PR TITLE
fix: Admin wizard: Persist smtp encryption settings

### DIFF
--- a/app/templates/components/forms/admin/settings/system/mail-settings.hbs
+++ b/app/templates/components/forms/admin/settings/system/mail-settings.hbs
@@ -41,8 +41,8 @@
   </div>
   <div class="less padding field">
     <label>{{t 'Encryption'}}</label>
-    {{#ui-dropdown class='fluid selection' }}
-      {{input type='hidden' id='encryption_select'}}
+    {{#ui-dropdown class='fluid selection' selected=settings.smtpEncryption}}
+      {{input type='hidden' id='encryption_select' value=settings.smtpEncryption}}
       <div class="default text">
         {{t 'Choose Encryption type'}}
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3105 
Ensures that smtp encryptions settings persist, the field was previously not linked to the model.