### PR TITLE
fix: update text if user's account is not deletable

### DIFF
--- a/app/templates/components/settings/danger-zone.hbs
+++ b/app/templates/components/settings/danger-zone.hbs
@@ -12,8 +12,9 @@
     {{modals/confirm-user-delete-modal isLoading=isLoading isOpen=isConfirmUserDeleteModalOpen checked=checked deleteUser=(action 'deleteUser' data.user)}}
   {{else}}
     <p>
-      {{t 'Your account currently cannot be deleted as events/orders are associated with it. 
-      If you\'ve any event associated, please transfer the ownership to another organizer.'}}
+      {{t 'Your account currently cannot be deleted as active events and/or orders are associated with it. 
+      Before you can delete your account you must transfer the ownership of your event(s) to another organizer or cancel your event(s). 
+      If you have ticket orders stored in the system, please cancel your orders first too.'}}
     </p>
     <button class='ui red button disabled'>
       {{t 'Delete Your Account'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Related to https://github.com/fossasia/open-event-frontend/pull/2924#issuecomment-501006598

#### Short description of what this resolves:
Currently, the text displayed when user's account is not deletable is a little vague. 

#### Changes proposed in this pull request:
Updates the text displayed on danzer zone if user's account is not deletable

![Screenshot_2019-06-12 Danger Zone Settings Open Event](https://user-images.githubusercontent.com/25428397/59321872-64f07d00-8cf1-11e9-80b6-702013522ae7.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` tox run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
