### PR TITLE
feat: company data possible to be added without ticking 'Send tax invoice'

### DIFF
--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -44,32 +44,30 @@
         </label>
       </div>
     </div>
-    {{#if tax.shouldSendInvoice}}
-      <div class="field">
-        <label class="required">{{t 'Registered Company'}}</label>
-        {{input type='text' id='tax_invoice_company' value=tax.registeredCompany}}
-      </div>
-      <div class="field">
-        <label class="required">{{t 'Business Address'}}</label>
-        {{textarea rows=3 id='tax_invoice_address' value=tax.address}}
-      </div>
-      <div class="field">
-        <label class="required">{{t 'City'}}</label>
-        {{input type='text' id='tax_invoice_city' value=tax.city}}
-      </div>
-      <div class="field">
-        <label class="required">{{t 'State'}}</label>
-        {{input type='text' id='tax_invoice_state' value=tax.state}}
-      </div>
-      <div class="field">
-        <label class="required">{{t 'Zipcode'}}</label>
-        {{input type='text' id='tax_invoice_zipcode' value=tax.zip}}
-      </div>
-      <div class="field">
-        <label>{{t 'Text for invoice footer (optional)'}}</label>
-        {{textarea rows=3 id='tax_invoice_footer' value=tax.invoiceFooter}}
-      </div>
-    {{/if}}
+    <div class="field">
+      <label class="required">{{t 'Registered Company'}}</label>
+      {{input type='text' id='tax_invoice_company' value=tax.registeredCompany}}
+    </div>
+    <div class="field">
+      <label class="required">{{t 'Business Address'}}</label>
+      {{textarea rows=3 id='tax_invoice_address' value=tax.address}}
+    </div>
+    <div class="field">
+      <label class="required">{{t 'City'}}</label>
+      {{input type='text' id='tax_invoice_city' value=tax.city}}
+    </div>
+    <div class="field">
+      <label class="required">{{t 'State'}}</label>
+      {{input type='text' id='tax_invoice_state' value=tax.state}}
+    </div>
+    <div class="field">
+      <label class="required">{{t 'Zipcode'}}</label>
+      {{input type='text' id='tax_invoice_zipcode' value=tax.zip}}
+    </div>
+    <div class="field">
+      <label>{{t 'Text for invoice footer (optional)'}}</label>
+      {{textarea rows=3 id='tax_invoice_footer' value=tax.invoiceFooter}}
+    </div>
     <div class="grouped fields">
       <label for="privacy">{{t 'Add or Include Tax Fee'}}</label>
       <div class="field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3115 

#### Short description of what this resolves:
The tax invoice data of a registered company can only be added if the field "Send Tax Invoice.." is ticked. 

#### Changes proposed in this pull request:
 - Made it possible to enter the data even if the field is not ticked.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
