### PR TITLE
Extra space in Event View Page

### DIFF
--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -41,7 +41,7 @@
       <div class="ten wide column">
         {{outlet}}
       </div>
-      <div class="three wide column {{if device.isMobile 'public'}}">
+      <div class="three wide column">
         {{#if (not-eq session.currentRouteName 'public.cfs.new-speaker')}}
           {{public/social-links externalUrl=model.externalEventUrl socialLinks=model.socialLinks}}
         {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2694 

#### Short description of what this resolves:
Extra space in Event View Page after External Event Url.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
