### PR TITLE
feat: Populate searchableLocationName with event location:

### DIFF
--- a/app/components/widgets/forms/location-input.js
+++ b/app/components/widgets/forms/location-input.js
@@ -17,8 +17,17 @@ export default Component.extend({
     return values(this.address).join(' ').trim();
   }),
 
-  placeNameChanger: observer('combinedAddress', function() {
-    this.set('placeName', this.combinedAddress);
+  searchableAddress: computed('address.{city}', function() {
+    return this.address.city;
+  }),
+
+  placeNameChanger: observer('combinedAddress', 'searchableAddress', function() {
+    this.setProperties(
+      { 'placeName'      : this.combinedAddress,
+        'searchableName' : this.searchableAddress
+      }
+    );
+
   }),
 
   actions: {

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -10,6 +10,7 @@
       lat=data.event.latitude
       lng=data.event.longitude
       placeName=data.event.locationName
+      searchableName=data.event.searchableLocationName
       zoom=15
       placeholder=(t 'Location is required to make this event live')}}
       <div class="inline field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3149 

#### Short description of what this resolves:

Ensures that `searchableLocationName` is populated, when event location is being saved. The data from this field will be later used to list the most common cities.