### PR TITLE
feat: Add filter to filter events by ticket type.

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -12,8 +12,8 @@ export default Component.extend({
   customEndDate : null,
   showFilters   : false,
 
-  hideClearFilters: computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', 'location', function() {
-    return !(this.category || this.sub_category || this.event_type || this.startDate || this.endDate || this.location !== null);
+  hideClearFilters: computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', 'location', 'ticket_type', function() {
+    return !(this.category || this.sub_category || this.event_type || this.startDate || this.endDate || this.location || this.ticket_type !== null);
   }),
 
   dateRanges: computed(function() {
@@ -39,6 +39,10 @@ export default Component.extend({
 
     selectEventType(eventType) {
       this.set('event_type', eventType === this.event_type ? null : eventType);
+    },
+
+    selectTicketType(ticketType) {
+      this.set('ticket_type', ticketType === this.ticket_type ? null : ticketType);
     },
 
     dateValidate(date) {
@@ -116,6 +120,7 @@ export default Component.extend({
       this.set('sub_category', null);
       this.set('event_type', null);
       this.set('location', null);
+      this.set('ticket_type', null);
     },
 
     toggleFilters() {

--- a/app/controllers/explore.js
+++ b/app/controllers/explore.js
@@ -1,13 +1,14 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  queryParams  : ['category', 'sub_category', 'event_type', 'start_date', 'end_date', 'location'],
+  queryParams  : ['category', 'sub_category', 'event_type', 'start_date', 'end_date', 'location', 'ticket_type'],
   category     : null,
   sub_category : null,
   event_type   : null,
   start_date   : null,
   end_date     : null,
   location     : null,
+  ticket_type  : null,
 
   actions: {
     shareEvent(event) {
@@ -32,6 +33,9 @@ export default Controller.extend({
       }
       if (filterType === 'location') {
         this.set('location', null);
+      }
+      if (filterType === 'ticket_type') {
+        this.set('ticket_type', null);
       }
     }
   }

--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -57,6 +57,18 @@ export default Route.extend({
       });
     }
 
+    if (params.ticket_type) {
+      filterOptions.push({
+        name : 'tickets',
+        op   : 'any',
+        val  : {
+          name : 'type',
+          op   : 'eq',
+          val  : params.ticket_type
+        }
+      });
+    }
+
     if (params.location) {
       filterOptions.push({
         name : 'location_name',

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -96,6 +96,26 @@
       </div>
     {{/ui-accordion}}
   </div>
+  <div class="item">
+    {{#ui-accordion}}
+      <span class="title">
+        <i class="dropdown icon"></i>
+        {{t 'Ticket Type' }}
+      </span>
+      <div class="content menu">
+          <a href="#"
+            class="link item {{if (eq ticket_type 'free') 'active'}}"
+            {{action 'selectTicketType' 'free'}}>
+            {{t 'Free'}}
+          </a>
+          <a href="#"
+            class="link item {{if (eq ticket_type 'paid') 'active'}}"
+            {{action 'selectTicketType' 'paid'}}>
+            {{t 'Paid'}}
+          </a>
+      </div>
+    {{/ui-accordion}}
+  </div>
 {{/if}}
 <div class="item">
   <button class="ui red button {{if hideClearFilters 'disabled'}}" {{action 'clearFilters'}}>{{t 'Clear Filters'}}</button>

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -103,16 +103,16 @@
         {{t 'Ticket Type' }}
       </span>
       <div class="content menu">
-          <a href="#"
-            class="link item {{if (eq ticket_type 'free') 'active'}}"
-            {{action 'selectTicketType' 'free'}}>
-            {{t 'Free'}}
-          </a>
-          <a href="#"
-            class="link item {{if (eq ticket_type 'paid') 'active'}}"
-            {{action 'selectTicketType' 'paid'}}>
-            {{t 'Paid'}}
-          </a>
+        <a href="#"
+          class="link item {{if (eq ticket_type 'free') 'active'}}"
+          {{action 'selectTicketType' 'free'}}>
+          {{t 'Free'}}
+        </a>
+        <a href="#"
+          class="link item {{if (eq ticket_type 'paid') 'active'}}"
+          {{action 'selectTicketType' 'paid'}}>
+          {{t 'Paid'}}
+        </a>
       </div>
     {{/ui-accordion}}
   </div>

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -1,6 +1,6 @@
 <div class="ui stackable grid">
   <div class="four wide column">
-    {{explore/side-bar model=model category=category sub_category=sub_category event_type=event_type startDate=start_date endDate=end_date location=location}}
+    {{explore/side-bar model=model category=category sub_category=sub_category event_type=event_type startDate=start_date endDate=end_date location=location ticket_type=ticket_type}}
   </div>
   <div class="twelve wide column">
     <h1 class="ui header">{{t 'Events'}}</h1>
@@ -33,6 +33,12 @@
         <div class="ui mini label">
           {{moment-format filters.end_date 'ddd, MMM DD'}}
           <a role="button" {{action 'clearFilter' 'end_date'}}><i class="icon close"></i></a>
+        </div>
+      {{/if}}
+      {{#if filters.ticket_type}}
+        <div class="ui mini label">
+          {{ticket_type}}
+          <a role="button" {{action 'clearFilter' 'ticket_type'}}><i class="icon close"></i></a>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
Reference: #3098


#### Short description of what this resolves:
This PR adds an additional filter to filter events by ticket type i.e `free` or `paid`.

#### Changes proposed in this pull request:

- Add an accordion in sidebar of explore route with free and paid as options.
- In the js of sidebar, implement action to set `ticket_type` variable.
- In the route of explore, add an `if` block  to check for ticket type params.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

![Screenshot from 2019-06-18 23-29-28](https://user-images.githubusercontent.com/21174572/59707789-f9db0500-9220-11e9-99ef-fd811f57eb7e.png)
