### PR TITLE
Revert "feat: company data possible to be added without ticking 'Send tax invoice'"

### DIFF
--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -44,30 +44,32 @@
         </label>
       </div>
     </div>
-    <div class="field">
-      <label class="required">{{t 'Registered Company'}}</label>
-      {{input type='text' id='tax_invoice_company' value=tax.registeredCompany}}
-    </div>
-    <div class="field">
-      <label class="required">{{t 'Business Address'}}</label>
-      {{textarea rows=3 id='tax_invoice_address' value=tax.address}}
-    </div>
-    <div class="field">
-      <label class="required">{{t 'City'}}</label>
-      {{input type='text' id='tax_invoice_city' value=tax.city}}
-    </div>
-    <div class="field">
-      <label class="required">{{t 'State'}}</label>
-      {{input type='text' id='tax_invoice_state' value=tax.state}}
-    </div>
-    <div class="field">
-      <label class="required">{{t 'Zipcode'}}</label>
-      {{input type='text' id='tax_invoice_zipcode' value=tax.zip}}
-    </div>
-    <div class="field">
-      <label>{{t 'Text for invoice footer (optional)'}}</label>
-      {{textarea rows=3 id='tax_invoice_footer' value=tax.invoiceFooter}}
-    </div>
+    {{#if tax.shouldSendInvoice}}
+      <div class="field">
+        <label class="required">{{t 'Registered Company'}}</label>
+        {{input type='text' id='tax_invoice_company' value=tax.registeredCompany}}
+      </div>
+      <div class="field">
+        <label class="required">{{t 'Business Address'}}</label>
+        {{textarea rows=3 id='tax_invoice_address' value=tax.address}}
+      </div>
+      <div class="field">
+        <label class="required">{{t 'City'}}</label>
+        {{input type='text' id='tax_invoice_city' value=tax.city}}
+      </div>
+      <div class="field">
+        <label class="required">{{t 'State'}}</label>
+        {{input type='text' id='tax_invoice_state' value=tax.state}}
+      </div>
+      <div class="field">
+        <label class="required">{{t 'Zipcode'}}</label>
+        {{input type='text' id='tax_invoice_zipcode' value=tax.zip}}
+      </div>
+      <div class="field">
+        <label>{{t 'Text for invoice footer (optional)'}}</label>
+        {{textarea rows=3 id='tax_invoice_footer' value=tax.invoiceFooter}}
+      </div>
+    {{/if}}
     <div class="grouped fields">
       <label for="privacy">{{t 'Add or Include Tax Fee'}}</label>
       <div class="field">


### PR DESCRIPTION
Reverts fossasia/open-event-frontend#3121

Reason To Revert : 
- Try to type into any of the tax fields which are after `Tax ID`, as soon as you type any letter, An overflow is created.
- UI has been depreciated.

Find a way to tackle the UI OVERFLOW, created by those fields and create new PR, As of now reverting it seems the best possible solution

#### Screenshot : 
![image](https://user-images.githubusercontent.com/44091822/59809185-0775b500-931d-11e9-99d4-0affc538b43b.png)
