### PR TITLE
Use latest version (Master branch)  for ember-router-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.0.0",
     "ember-route-action-helper": "^2.0.7",
-    "ember-router-scroll": "1.1.0",
+    "ember-router-scroll": "DockYard/ember-router-scroll#695d894",
     "ember-scroll-to": "^0.6.5",
     "ember-simple-auth": "^1.8.2",
     "ember-simple-auth-token": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6249,9 +6249,9 @@ ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-router-scroll@1.1.0:
+ember-router-scroll@DockYard/ember-router-scroll#695d894:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-router-scroll/-/ember-router-scroll-1.1.0.tgz#17f7ead22a4e9f43a8956d942ca37b5e507bada5"
+  resolved "https://codeload.github.com/DockYard/ember-router-scroll/tar.gz/695d89485927f6637a9c2631904b67bbc3f3087a"
   dependencies:
     ember-app-scheduler "^1.0.5"
     ember-cli-babel "^7.1.2"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #275 

#### Short description of what this resolves:
Uses the latest version (master branch), since the last release was in 2018, a newer one hasn't been released yet.



Please open more specific follow up issues if some buggy scroll behavior is still present.