### PR TITLE
feat: implement email threshold in admin message-setting

### DIFF
--- a/app/controllers/admin/messages/list.js
+++ b/app/controllers/admin/messages/list.js
@@ -27,6 +27,10 @@ export default Controller.extend({
       template : 'components/ui-table/cell/admin/messages/cell-options'
     },
     {
+      title    : 'Threshold [Msg/Hr]',
+      template : 'components/ui-table/cell/admin/messages/cell-threshold'
+    },
+    {
       propertyName : 'sentAt',
       title        : 'Time/Date sent out',
       template     : 'components/ui-table/cell/cell-simple-date',

--- a/app/models/message-setting.js
+++ b/app/models/message-setting.js
@@ -15,5 +15,6 @@ export default ModelBase.extend({
   emailSubject        : attr('string'),
   notificationTitle   : attr('string'),
   notificationMessage : attr('string'),
-  sentAt              : attr('string')
+  sentAt              : attr('string'),
+  threshold           : attr('number')
 });

--- a/app/templates/components/ui-table/cell/admin/messages/cell-threshold.hbs
+++ b/app/templates/components/ui-table/cell/admin/messages/cell-threshold.hbs
@@ -1,0 +1,5 @@
+<div class="ui form">
+  <div class="field">
+    {{input type='number' name='threshold' value=record.threshold min=1}}
+  </div>
+</div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3128 

#### Changes proposed in this pull request:
Add the following:
Threshold [number of max. messages/hour] to the right side of `Options` in message-settings in admin section

![Screenshot_2019-06-22 Messages Administration Open Event](https://user-images.githubusercontent.com/25428397/59962812-fccb4380-9507-11e9-9dde-2cb2bf935009.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
