### PR TITLE
fix: Wrong route defined in user accounts for admin

### DIFF
--- a/app/controllers/admin/users.js
+++ b/app/controllers/admin/users.js
@@ -5,7 +5,7 @@ import { computed } from '@ember/object';
 export default Controller.extend({
   onSessionRoute: computed('routing.currentRouteName', function() {
     let currentRouteName = this.get('routing.currentRouteName');
-    const routes = ['admin.users.view.index', 'admin.users.view.sessions.list', 'admin.users.view.tickets.list', 'admin.users.view.events.list', 'admin.users.view.account.contact-info', 'admin.users.view.account.email-preferences', 'admin.users.view.account.applications'];
+    const routes = ['admin.users.view.index', 'admin.users.view.sessions.list', 'admin.users.view.tickets.list', 'admin.users.view.events.list', 'admin.users.view.account.profile', 'admin.users.view.account.email-preferences', 'admin.users.view.account.applications'];
     return !routes.includes(currentRouteName);
   })
 });

--- a/app/templates/admin/users/view/account.hbs
+++ b/app/templates/admin/users/view/account.hbs
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="sixteen wide column">
       {{#tabbed-navigation}}
-        {{#link-to 'admin.users.view.account.contact-info' model.user.id class='item'}}
+        {{#link-to 'admin.users.view.account.profile' model.user.id class='item'}}
           {{t 'Profile Info'}}
         {{/link-to}}
         {{#link-to 'admin.users.view.account.email-preferences' model.user.id class='item'}}

--- a/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
+++ b/app/templates/components/ui-table/cell/admin/users/cell-user-links.hbs
@@ -9,6 +9,6 @@
     {{#link-to 'admin.users.view.tickets' record.id}} {{t 'Tickets'}} {{/link-to}}
   </div>
   <div class="item">
-    {{#link-to 'admin.users.view.account.contact-info' record.id}} {{t 'Accounts'}} {{/link-to}}
+    {{#link-to 'admin.users.view.account.profile' record.id}} {{t 'Accounts'}} {{/link-to}}
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3181 

#### Short description of what this resolves:
Wrong route is defined for Accounts Link in admin panel of users

#### Changes proposed in this pull request:
Defined the route properly so that admin can see user details

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
