### PR TITLE
enh: Making company details optional in tax modal

### DIFF
--- a/app/components/modals/tax-info-modal.js
+++ b/app/components/modals/tax-info-modal.js
@@ -52,6 +52,7 @@ export default ModalBase.extend(FormMixin, {
         },
         taxInvoiceCompany: {
           identifier : 'tax_invoice_company',
+          optional   : true,
           depends    : 'send_tax_invoices',
           rules      : [
             {
@@ -62,6 +63,7 @@ export default ModalBase.extend(FormMixin, {
         },
         taxInvoiceAddress: {
           identifier : 'tax_invoice_address',
+          optional   : true,
           depends    : 'send_tax_invoices',
           rules      : [
             {
@@ -73,6 +75,7 @@ export default ModalBase.extend(FormMixin, {
 
         taxInvoiceCity: {
           identifier : 'tax_invoice_city',
+          optional   : true,
           rules      : [
             {
               type   : 'empty',
@@ -83,6 +86,7 @@ export default ModalBase.extend(FormMixin, {
 
         taxInvoiceState: {
           identifier : 'tax_invoice_state',
+          optional   : true,
           rules      : [
             {
               type   : 'empty',
@@ -93,6 +97,7 @@ export default ModalBase.extend(FormMixin, {
 
         taxInvoiceZipCode: {
           identifier : 'tax_invoice_zipcode',
+          optional   : true,
           rules      : [
             {
               type   : 'empty',

--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -45,23 +45,23 @@
       </div>
     </div>
     <div class="field">
-      <label class="required">{{t 'Registered Company'}}</label>
+      <label>{{t 'Registered Company'}}</label>
       {{input type='text' id='tax_invoice_company' value=tax.registeredCompany}}
     </div>
     <div class="field">
-      <label class="required">{{t 'Business Address'}}</label>
+      <label>{{t 'Business Address'}}</label>
       {{textarea rows=3 id='tax_invoice_address' value=tax.address}}
     </div>
     <div class="field">
-      <label class="required">{{t 'City'}}</label>
+      <label>{{t 'City'}}</label>
       {{input type='text' id='tax_invoice_city' value=tax.city}}
     </div>
     <div class="field">
-      <label class="required">{{t 'State'}}</label>
+      <label>{{t 'State'}}</label>
       {{input type='text' id='tax_invoice_state' value=tax.state}}
     </div>
     <div class="field">
-      <label class="required">{{t 'Zipcode'}}</label>
+      <label>{{t 'Zipcode'}}</label>
       {{input type='text' id='tax_invoice_zipcode' value=tax.zip}}
     </div>
     <div class="field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3236 

#### Short description of what this resolves:

- After removing `Company Details Tickbox`, We forgot to make these fields optional

#### ScreenShot :
![image](https://user-images.githubusercontent.com/44091822/60669723-9e4d8000-9e8c-11e9-8298-4dd41197c6b0.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
