### PR TITLE
fix: Update GitHub URL Validator

### DIFF
--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -65,7 +65,7 @@ export const validFacebookProfileUrlPattern = new RegExp(
 
 export const validGithubProfileUrlPattern = new RegExp(
   '^(https?:\\/\\/)' // compulsory protocol
-  + '?(?:www.)?github\\.com\\/([a-zA-Z0-9_]+)$'
+  + '?(?:www.)?github\\.com\\/([a-zA-Z0-9_-]+)$'
 );
 
 export const validLinkedinProfileUrlPattern = new RegExp(

--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -65,7 +65,7 @@ export const validFacebookProfileUrlPattern = new RegExp(
 
 export const validGithubProfileUrlPattern = new RegExp(
   '^(https?:\\/\\/)' // compulsory protocol
-  + '?(?:www.)?github\\.com\\/([a-zA-Z0-9_-]+)$'
+  + '?(?:www.)?github\\.com\\/([a-zA-Z0-9_]+)([-]?)([a-zA-Z0-9_]+)$'
 );
 
 export const validLinkedinProfileUrlPattern = new RegExp(


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3324 

#### Short description of what this resolves:

- GitHub Profile allows a single hyphen in the profile.

#### Screenshot :

![image](https://user-images.githubusercontent.com/44091822/62129317-09576e80-b2f4-11e9-971d-2ddc264db62b.png)
