### PR TITLE
fix: use correct URL to download translations

### DIFF
--- a/app/controllers/admin/content/translations.js
+++ b/app/controllers/admin/content/translations.js
@@ -1,28 +1,24 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 
-export default Controller.extend({
-  isLoading: false,
+export default class extends Controller {
+  isLoading = false;
 
-  actions: {
-    translationsDownload() {
-      this.set('isLoading', true);
-      this.loader
-        .downloadFile('/admin/content/translations/all')
-        .then(res => {
-          const anchor = document.createElement('a');
-          anchor.style.display = 'none';
-          anchor.href = URL.createObjectURL(new Blob([res], { type: 'octet/stream' }));
-          anchor.download = 'Translations.zip';
-          anchor.click();
-          this.notify.success(this.l10n.t('Translations Zip generated successfully.'));
-        })
-        .catch(e => {
-          console.warn(e);
-          this.notify.error(this.l10n.t('Unexpected error occurred.'));
-        })
-        .finally(() => {
-          this.set('isLoading', false);
-        });
+  @action
+  async translationsDownload() {
+    this.set('isLoading', true);
+    try {
+      const result = this.loader.downloadFile('/admin/content/translations/all/');
+      const anchor = document.createElement('a');
+      anchor.style.display = 'none';
+      anchor.href = URL.createObjectURL(new Blob([result], { type: 'octet/stream' }));
+      anchor.download = 'Translations.zip';
+      anchor.click();
+      this.notify.success(this.l10n.t('Translations Zip generated successfully.'));
+    } catch (e) {
+      console.warn(e);
+      this.notify.error(this.l10n.t('Unexpected error occurred.'));
     }
+    this.set('isLoading', false);
   }
-});
+}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3355

#### Short description of what this resolves:
Fixes the URL endpoint which is being hit when downloading the translations

#### Changes proposed in this pull request:

- Restructure code according to ES6 style
- Use `/admin/content/translations/all/` to download files

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
