### PR TITLE
feat: Implement a tick box for organizers/admin to override Email

### DIFF
--- a/app/controllers/events/view/sessions/create.js
+++ b/app/controllers/events/view/sessions/create.js
@@ -6,6 +6,9 @@ export default Controller.extend({
       await this.get('model.session').save();
       if (this.addNewSpeaker) {
         let newSpeaker = this.get('model.speaker');
+        if (newSpeaker.isEmailOverridden) {
+          newSpeaker.set('email', this.authManager.currentUser.email);
+        }
         newSpeaker.save()
           .then(() => {
             newSpeaker.sessions.pushObject(_this.get('model.session'));

--- a/app/controllers/events/view/sessions/edit.js
+++ b/app/controllers/events/view/sessions/edit.js
@@ -7,6 +7,9 @@ export default Controller.extend({
       let _this = this;
       if (this.addNewSpeaker) {
         let newSpeaker = this.get('model.speaker');
+        if (newSpeaker.isEmailOverridden) {
+          newSpeaker.set('email', this.authManager.currentUser.email);
+        }
         newSpeaker.save()
           .then(() => {
             newSpeaker.sessions.pushObject(_this.get('model.session'));

--- a/app/controllers/events/view/speakers/create.js
+++ b/app/controllers/events/view/speakers/create.js
@@ -7,7 +7,11 @@ export default Controller.extend({
         if (!sessionDetails) {
           await this.get('model.session').save();
         }
-        await this.get('model.speaker').save();
+        let newSpeaker = this.get('model.speaker');
+        if (newSpeaker.isEmailOverridden) {
+          newSpeaker.set('email', this.authManager.currentUser.email);
+        }
+        await newSpeaker.save();
         if (!sessionDetails) {
           this.get('model.speaker.sessions').pushObject(this.get('model.session'));
           await this.get('model.session').save();

--- a/app/controllers/events/view/speakers/edit.js
+++ b/app/controllers/events/view/speakers/edit.js
@@ -4,7 +4,11 @@ export default Controller.extend({
   actions: {
     save() {
       this.set('isLoading', true);
-      this.get('model.speaker').save()
+      let speaker = this.get('model.speaker');
+      if (speaker.isEmailOverridden) {
+        speaker.set('email', this.authManager.currentUser.email);
+      }
+      speaker.save()
         .then(() => {
           this.notify.success(this.l10n.t('Speaker details have been saved'));
           this.transitionToRoute('events.view.speakers');

--- a/app/models/speaker.js
+++ b/app/models/speaker.js
@@ -27,6 +27,7 @@ export default ModelBase.extend({
   linkedin           : attr('string'),
   organisation       : attr('string'),
   isFeatured         : attr('boolean', { default: false }),
+  isEmailOverridden  : attr('boolean', { default: false }),
   position           : attr('string'),
   country            : attr('string'),
   city               : attr('string'),

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -121,6 +121,13 @@
               {{#if field.isLongText}}
                 {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                                                  textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{else if (eq field.fieldIdentifier 'email')}}
+                {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
+                              onChange=(action (mut data.speaker.isEmailOverridden))}}
+                {{#if (not data.speaker.isEmailOverridden)}}
+                  {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
+                          id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+                {{/if}}
               {{else}}
                 {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier)) id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
               {{/if}}
@@ -185,6 +192,13 @@
             {{#if field.isLongText}}
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+            {{else if (eq field.fieldIdentifier 'email')}}
+              {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
+                            onChange=(action (mut data.speaker.isEmailOverridden))}}
+              {{#if (not data.speaker.isEmailOverridden)}}
+                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
+                        id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{/if}}
             {{else}}
               {{#if field.isUrlField}}
                 {{widgets/forms/link-input


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2953

#### Short description of what this resolves:
When a speaker registers they have to enter an email. It must be possible to override this requirement for organizers/admins

![Screenshot_2019-08-03 Create session Speakers cfs Events Open Event](https://user-images.githubusercontent.com/25428397/62413709-a20d2780-b62f-11e9-9e35-9a21d6cb4c32.png)

![Screenshot_2019-08-03 Create session Sessions cfs Events Open Event](https://user-images.githubusercontent.com/25428397/62413713-a6394500-b62f-11e9-9225-a0e076e530e7.png)



#### Changes proposed in this pull request:
- Adds a checkbox to override email while creating speaker from event dashboard

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
