### PR TITLE
 fix: prevent fastboot to crash for role-invites acceptance

### DIFF
--- a/app/routes/public/role-invites.js
+++ b/app/routes/public/role-invites.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+  redirectionParams: null,
   async beforeModel(transition) {
     const { token } = transition.to.queryParams;
     const originalEventId = transition.resolvedModels.public.originalId;
@@ -20,13 +21,16 @@ export default Route.extend({
       this.set('session.skipRedirectOnInvalidation', true);
       this.session.invalidate();
     }
-
-    this.transitionTo('register', {
+    this.set('redirectionParams',  {
       queryParams: {
         event       : originalEventId,
         inviteToken : token,
         inviteEmail : user.email
       }
     });
+
+  },
+  afterModel() {
+    this.transitionTo('register', this.redirectionParams);
   }
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3348 
Fixes #3347 
Fixes #3306 

#### Short description of what this resolves:

Moves the logic to afterModel, as fastboot doesn't fully support the transition in the beforeModel hook.