### PR TITLE
fix: profile picture link to null when removed

### DIFF
--- a/app/components/widgets/forms/image-upload.js
+++ b/app/components/widgets/forms/image-upload.js
@@ -78,6 +78,8 @@ export default Component.extend({
       if (!this.needsConfirmation) {
         this.set('selectedImage', null);
         this.set('imageUrl', null);
+        this.user.set('avatarUrl', null);
+        this.user.save();
       } else {
         this.set('needsConfirmation', false);
       }

--- a/app/templates/components/forms/user-profile-form.hbs
+++ b/app/templates/components/forms/user-profile-form.hbs
@@ -3,6 +3,7 @@
     <div class="three wide column">
       <div class="ui left floated eight wide column">
         {{widgets/forms/image-upload
+          user=user
           imageUrl=user.avatarUrl
           needsCropper=true
           label=(t 'User Image')


### PR DESCRIPTION

![profile](https://user-images.githubusercontent.com/25197147/62494181-78e7c500-b7f0-11e9-9877-e5dbf5d845ad.gif)
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3360 

#### Short description of what this resolves:
Fixes profile picture removal

#### Changes proposed in this pull request:

- Update avatarUrl to None on the model level when the picture gets deleted.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
