### PR TITLE
enh: add stripe test keys to admin payment-gateway-form

### DIFF
--- a/app/components/forms/admin/settings/payment-gateway-form.js
+++ b/app/components/forms/admin/settings/payment-gateway-form.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import FormMixin from 'open-event-frontend/mixins/form';
+import ENV from 'open-event-frontend/config/environment';
 
 export default Component.extend(FormMixin, {
   getValidationRules() {
@@ -35,6 +36,25 @@ export default Component.extend(FormMixin, {
             {
               type   : 'empty',
               prompt : this.l10n.t('Please enter the publishable key')
+            }
+          ]
+        },
+        stripeTestSecretKey: {
+          identifier : 'stripe_test_secret_key',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter the secret test key')
+            }
+          ]
+        },
+
+        stripeTestPublishableKey: {
+          identifier : 'stripe_test_publishable_key',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter the publishable test key')
             }
           ]
         },
@@ -143,6 +163,10 @@ export default Component.extend(FormMixin, {
 
   isCheckedStripe: computed(function() {
     return this.get('settings.stripeClientId');
+  }),
+
+  stripeMode: computed(function() {
+    return ENV.environment === 'development' || ENV.environment === 'test' ? 'debug' : 'production';
   }),
 
   isCheckedPaypal: computed(function() {

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -43,6 +43,8 @@ export default ModelBase.extend({
   stripeClientId             : attr('string'),
   stripeSecretKey            : attr('string'),
   stripePublishableKey       : attr('string'),
+  stripeTestSecretKey        : attr('string'),
+  stripeTestPublishableKey   : attr('string'),
   isAliPayActivated          : attr('boolean'),
   isPaypalActivated          : attr('boolean'),
   isStripeActivated          : attr('boolean'),

--- a/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
+++ b/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
@@ -22,18 +22,52 @@
       </label>
       {{input type='text' name='stripe_client_id' value=settings.stripeClientId}}
     </div>
+    <h5 class="ui header">
+      {{t 'Stripe Integration Mode'}}
+    </h5>
     <div class="field">
-      <label>
-        {{t 'Secret Key'}}
-      </label>
-      {{input type='text' name='stripe_secret_key' value=settings.stripeSecretKey}}
+      {{ui-radio label=(t 'Test mode - Used during development and testing')
+                 name='stripe_integration_mode'
+                 value='debug'
+                 current=stripeMode
+                 onChange=(action (mut stripeMode))}}
     </div>
+    {{#if (eq stripeMode 'debug')}}
+      <div class="field">
+        <label>
+          {{t 'Secret Test Key'}}
+        </label>
+        {{input type='text' name='stripe_test_secret_key' value=settings.stripeTestSecretKey}}
+      </div>
+      <div class="field">
+        <label>
+          {{t 'Publishable Test Key'}}
+        </label>
+        {{input type='text' name='stripe_test_publishable_key' value=settings.stripeTestPublishableKey}}
+      </div>
+    {{/if}}
+    <div class="ui hidden divider"></div>
     <div class="field">
-      <label>
-        {{t 'Publishable Key'}}
-      </label>
-      {{input type='text' name='stripe_publishable_key' value=settings.stripePublishableKey}}
+      {{ui-radio label=(t 'Live mode - Used during production')
+                 name='stripe_integration_mode'
+                 value='production'
+                 current=stripeMode
+                 onChange=(action (mut stripeMode))}}
     </div>
+    {{#if (eq stripeMode 'production')}}
+      <div class="field">
+        <label>
+          {{t 'Secret Key'}}
+        </label>
+        {{input type='text' name='stripe_secret_key' value=settings.stripeSecretKey}}
+      </div>
+      <div class="field">
+        <label>
+          {{t 'Publishable Key'}}
+        </label>
+        {{input type='text' name='stripe_publishable_key' value=settings.stripePublishableKey}}
+      </div>
+    {{/if}}
     <div class="ui hidden divider"></div>
   {{/if}}
   <div class="inline field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3364

#### Changes proposed in this pull request:

- Adds stripe test keys to the payment-gateway-form

_Test Keys_
![Screenshot_2019-08-08 Payment Gateway Settings Administration Open Event](https://user-images.githubusercontent.com/25428397/62651672-2c7ac180-b977-11e9-92b1-0b6a13f7639a.png)

_Live Keys_
![Screenshot_2019-08-08 Payment Gateway Settings Administration Open Event(1)](https://user-images.githubusercontent.com/25428397/62651676-2f75b200-b977-11e9-8c17-214f901c483f.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
