### PR TITLE
fix: fix isPaytmActivated attribute save

### DIFF
--- a/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
+++ b/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
@@ -240,9 +240,9 @@
     <label>
       {{t 'Enable PayTM'}}
     </label>
-    {{ui-checkbox class='toggle' checked=isPaytmActivated onChange=(action (mut isPaytmActivated))}}
+    {{ui-checkbox class='toggle' checked=settings.isPaytmActivated onChange=(action (mut settings.isPaytmActivated))}}
   </div>
-  {{#if isPaytmActivated}}
+  {{#if settings.isPaytmActivated}}
     <h3 class="ui header">
       {{t 'PayTM Credentials'}}
       <div class="sub header">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3384 
Blocker: https://github.com/fossasia/open-event-server/pull/6357

#### Short description of what this resolves:
This helps in saving the attribute to the DB. This also requires a server change.