### PR TITLE
fix: event invoice table 'all' filter displays invoices

### DIFF
--- a/app/controllers/account/billing/invoices/list.js
+++ b/app/controllers/account/billing/invoices/list.js
@@ -10,10 +10,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       columns = [
         {
           name      : 'Invoice ID',
-          valuePath : 'id'
+          valuePath : 'identifier'
         },
         {
-          name          : 'Name',
+          name          : 'Event Name',
           valuePath     : 'event',
           cellComponent : 'ui-table/cell/events/cell-event-invoice'
         },
@@ -22,8 +22,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
           valuePath : 'createdAt'
         },
         {
-          name      : 'Outstanding Amount',
-          valuePath : 'amount'
+          name            : 'Outstanding Amount',
+          valuePath       : 'amount',
+          extraValuePaths : ['event'],
+          cellComponent   : 'ui-table/cell/events/cell-amount'
         },
         {
           name      : 'View Invoice',
@@ -34,10 +36,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       columns = [
         {
           name      : 'Invoice ID',
-          valuePath : 'id'
+          valuePath : 'identifier'
         },
         {
-          name          : 'Name',
+          name          : 'Event Name',
           valuePath     : 'event',
           cellComponent : 'ui-table/cell/events/cell-event-invoice'
         },
@@ -46,8 +48,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
           valuePath : 'createdAt'
         },
         {
-          name      : 'Amount',
-          valuePath : 'amount'
+          name            : 'Amount',
+          valuePath       : 'amount',
+          extraValuePaths : ['event'],
+          cellComponent   : 'ui-table/cell/events/cell-amount'
         },
         {
           name      : 'Date Paid',
@@ -63,10 +67,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       columns =   [
         {
           name      : 'Invoice ID',
-          valuePath : 'id'
+          valuePath : 'identifier'
         },
         {
-          name          : 'Name',
+          name          : 'Event Name',
           valuePath     : 'event',
           cellComponent : 'ui-table/cell/events/cell-event-invoice'
 
@@ -76,8 +80,10 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
           valuePath : 'createdAt'
         },
         {
-          name      : 'Amount Due',
-          valuePath : 'amount'
+          name            : 'Amount Due',
+          valuePath       : 'amount',
+          extraValuePaths : ['event'],
+          cellComponent   : 'ui-table/cell/events/cell-amount'
         },
         {
           name      : 'View Invoice',
@@ -85,20 +91,22 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         }
 
       ];
-    } else if (this.model.params.invoice_status === 'due') {
+    } else if (this.model.params.invoice_status === 'all') {
       columns = [
         {
           name      : 'Invoice ID',
-          valuePath : 'id'
+          valuePath : 'identifier'
         },
         {
-          name          : 'Name',
+          name          : 'Event Name',
           valuePath     : 'event',
           cellComponent : 'ui-table/cell/events/cell-event-invoice'
         },
         {
-          name      : 'Amount',
-          valuePath : 'amount'
+          name            : 'Amount',
+          valuePath       : 'amount',
+          extraValuePaths : ['event'],
+          cellComponent   : 'ui-table/cell/events/cell-amount'
         },
         {
           name      : 'Status',

--- a/app/routes/account/billing/invoices/index.js
+++ b/app/routes/account/billing/invoices/index.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  beforeModel() {
+    this._super(...arguments);
+    this.transitionTo('account.billing.invoices.list', 'all');
+  }
+});

--- a/app/templates/components/ui-table/cell/events/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/events/cell-amount.hbs
@@ -1,0 +1,1 @@
+{{currency-symbol extraRecords.event.paymentCurrency}} {{format-number record}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3393 

#### Short description of what this resolves:
Event invoices aren't visible for `all` filter and there are few places to refactor

#### Changes proposed in this pull request:
- fix column fetch for `all` filter
- changed `id` to `identifier` and `Name` to `Event Name`
- display amount alongwith currency

![Screenshot_2019-08-13 All Invoices Billing Info Account Open Event](https://user-images.githubusercontent.com/25428397/62958066-98e03f80-be13-11e9-9338-5df3dc9d5191.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
