### PR TITLE
fix: uses refreshModel to refresh session table after an action

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-session-title.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-session-title.hbs
@@ -1,15 +1,15 @@
 {{record}}
 <div class="hidden ui divider"></div>
 <div class="ui horizontal compact basic buttons">
-  {{#ui-popup content=(t 'View Session') class="{{if device.isMobile 'medium' 'huge'}} ui icon button"  click=(action props.actions.viewSession record) position='left center'}}
+  {{#ui-popup content=(t 'View Session') class="{{if device.isMobile 'medium' 'huge'}} ui icon button"  click=(action props.actions.viewSession extraRecords.id) position='left center'}}
     <i class="unhide icon"></i>		
   {{/ui-popup}}
   {{#if (not extraRecords.isLocked)}}
-    {{#ui-popup content=(t 'Edit Session') class="{{if device.isMobile 'medium' 'huge'}} ui icon button" click=(action props.actions.editSession record extraRecords.event.id) position='left center'}}
+    {{#ui-popup content=(t 'Edit Session') class="{{if device.isMobile 'medium' 'huge'}} ui icon button" click=(action props.actions.editSession extraRecords.id extraRecords.event.id) position='left center'}}
       <i class="edit icon"></i>
     {{/ui-popup}}
   {{/if}}
-  {{#ui-popup content=(t 'Delete Session') click=(action (confirm (t 'Are you sure you would like to delete this Session?') (action props.actions.deleteSession record))) class="{{if device.isMobile 'medium' 'huge'}} ui icon button" position='left center'}}
+  {{#ui-popup content=(t 'Delete Session') click=(action (confirm (t 'Are you sure you would like to delete this Session?') (action props.actions.deleteSession extraRecords.id))) class="{{if device.isMobile 'medium' 'huge'}} ui icon button" position='left center'}}
     <i class="trash outline icon"></i>
   {{/ui-popup}}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3449  

#### Short description of what this resolves:
Sometimes, while viewing/editing/deleting a session, unexpected entries are passed as params. Fix it using extraRecords

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
