### PR TITLE
[WIP] fix: form submission on enter key press.

### DIFF
--- a/app/components/widgets/forms/location-input.js
+++ b/app/components/widgets/forms/location-input.js
@@ -30,6 +30,12 @@ export default Component.extend({
 
   }),
 
+  keyDown(event) {
+    if (event.keyCode === 13) {
+      event.preventDefault();
+    }
+  },
+
   actions: {
     showAddressView(show = true) {
       this.set('addressViewIsShown', show);
@@ -51,6 +57,13 @@ export default Component.extend({
         lng
       });
     },
+
+    tests(value, event) {
+      if (event.keyCode === 13) {
+        event.preventDefault();
+      }
+    },
+
     placeChanged(place) {
       const addressComponents = place.address_components;
       addressComponents.forEach(component => {

--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -189,18 +189,21 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
   },
 
   actions: {
-    saveDraft() {
+    saveDraft(event) {
+      event.preventDefault();
       this.onValid(() => {
         this.set('data.event.state', 'draft');
         this.sendAction('save');
       });
     },
-    moveForward() {
+    moveForward(event) {
+      event.preventDefault();
       this.onValid(() => {
         this.sendAction('move');
       });
     },
-    publish() {
+    publish(event) {
+      event.preventDefault();
       this.onValid(() => {
         this.set('data.event.state', 'published');
         this.sendAction('save');

--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -189,21 +189,18 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
   },
 
   actions: {
-    saveDraft(event) {
-      event.preventDefault();
+    saveDraft() {
       this.onValid(() => {
         this.set('data.event.state', 'draft');
         this.sendAction('save');
       });
     },
-    moveForward(event) {
-      event.preventDefault();
+    moveForward() {
       this.onValid(() => {
         this.sendAction('move');
       });
     },
-    publish(event) {
-      event.preventDefault();
+    publish() {
       this.onValid(() => {
         this.set('data.event.state', 'published');
         this.sendAction('save');

--- a/app/templates/components/widgets/forms/location-input.hbs
+++ b/app/templates/components/widgets/forms/location-input.hbs
@@ -41,6 +41,7 @@
       name=name
       value=placeName
       placeChangedCallback=(action 'placeChanged')
+      key-down=(action 'tests')
       type='text'
       placeholder=placeholder}}
     <button class="ui left {{unless device.isMobile 'labeled'}} icon button" type="button" {{action 'showAddressView'}}>


### PR DESCRIPTION
Fixes: #2362

#### Short description of what this resolves:
Currently the event creation form gets submitted on enter key press.

#### Changes proposed in this pull request:
The default behaviour for any form input on enter key press is to submit the form. Even though preventDefault is the default behaviour of ember action and it is explicitly specified too, it doesn't seem to work here. I tried bubbles=false too. But that also doesn't seem to fix the issue. At last individually doing the preventDefault worked. This might not be the correct solution and hence I need reviews on it.
- Add event.preventDefault() to avoid form submission.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
