### PR TITLE
fix: Sort using State not working in admin session.

### DIFF
--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -18,7 +18,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       },
       {
         name            : 'State',
-        valuePath       : 'status',
+        valuePath       : 'state',
         cellComponent   : 'ui-table/cell/events/view/sessions/cell-session-state',
         isSortable      : true,
         headerComponent : 'tables/headers/sort'


### PR DESCRIPTION
Fixes #3460 

#### Short description of what this resolves:
Currently the sort by state wasn't working in admin sessions.

#### Changes proposed in this pull request:

- Fix the value being sent in params for the sort query of the state.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
