### PR TITLE
[WIP] fix: Add support for newline in event description.

### DIFF
--- a/app/components/widgets/forms/rich-text-editor.js
+++ b/app/components/widgets/forms/rich-text-editor.js
@@ -11,6 +11,7 @@ export default Component.extend({
   // Ensure any changes to the parser rules are set in the sanitizer @ services/sanitizer.js
   standardParserRules: {
     tags: {
+      'br'     : 1,
       'p'      : 1,
       'b'      : { 'rename_tag': 'strong' },
       'strong' : 1,

--- a/app/services/sanitizer.js
+++ b/app/services/sanitizer.js
@@ -7,7 +7,7 @@ export default Service.extend({
 
   // Ensure any changes to the sanitizer rules are set in the rich text editor @ components/widgets/forms/rich-text-editor.js
   options: {
-    allowedTags       : ['b', 'strong', 'i', 'em', 'u', 'ol', 'ul', 'li', 'a', 'p'],
+    allowedTags       : ['br', 'b', 'strong', 'i', 'em', 'u', 'ol', 'ul', 'li', 'a', 'p'],
     allowedAttributes : {
       'a': ['href', 'rel', 'target']
     },


### PR DESCRIPTION
Fixes #3419

#### Short description of what this resolves:
Currently new lines are not shown in event description.

#### Changes proposed in this pull request:

- Add `br` in parser rules.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
