### PR TITLE
fix: update .env.example to run server on heroku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 GOOGLE_API_KEY="Sample Key"
-API_HOST=https://open-event-api-dev.herokuapp.com/
+API_HOST=https://open-event-api-dev.herokuapp.com
 FASTBOOT_DISABLED=true

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 GOOGLE_API_KEY="Sample Key"
-API_HOST=http://127.0.0.1:5000
+API_HOST=https://open-event-api-dev.herokuapp.com/
 FASTBOOT_DISABLED=true


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

Fixes #3530 

#### Short description of what this resolves:
The link to the open-event-server (API_HOST) is updated to connect to the server at heroku.

#### Changes proposed in this pull request:
API_HOST in .env.example updated from http://localhost:5000 --> https://open-event-api-dev.herokuapp.com/

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
