### PR TITLE
fix: made enter email mandatory for speakers

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -509,7 +509,9 @@ export default Component.extend(FormMixin, {
   shouldShowNewSessionDetails: computed('sessionDetails', 'newSessionSelected', function() {
     return this.newSessionSelected && !this.sessionDetails;
   }),
-
+  isAdmin: computed('authManager.currentUser.isAdmin', function() {
+    return this.get('authManager.currentUser.isSuperAdmin') || this.get('authManager.currentUser.isAdmin');
+  }),
   actions: {
     submit() {
       this.onValid(() => {

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -122,6 +122,10 @@
                 {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                                                  textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
               {{else if (eq field.fieldIdentifier 'email')}}
+                {{#if isAdmin}}
+                  {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
+                                onChange=(action (mut data.speaker.isEmailOverridden))}}
+                {{/if}}
                 {{#if (not data.speaker.isEmailOverridden)}}
                   {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
                           id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
@@ -191,12 +195,14 @@
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
             {{else if (eq field.fieldIdentifier 'email')}}
-              {{!--ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
-                            onChange=(action (mut data.speaker.isEmailOverridden))--}}
-              {{!--#if (not data.speaker.isEmailOverridden)--}}
-              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
+              {{#if isAdmin}}
+                {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
+                              onChange=(action (mut data.speaker.isEmailOverridden))}}
+              {{/if}}
+              {{#if (not data.speaker.isEmailOverridden)}}
+                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
                       id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
-              {{!--/if--}}
+              {{/if}}
             {{else}}
               {{#if field.isUrlField}}
                 {{widgets/forms/link-input

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -122,8 +122,6 @@
                 {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                                                  textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
               {{else if (eq field.fieldIdentifier 'email')}}
-                {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
-                              onChange=(action (mut data.speaker.isEmailOverridden))}}
                 {{#if (not data.speaker.isEmailOverridden)}}
                   {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
                           id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
@@ -193,12 +191,12 @@
               {{widgets/forms/rich-text-editor value=(mut (get data.speaker field.fieldIdentifier))
                 textareaId=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
             {{else if (eq field.fieldIdentifier 'email')}}
-              {{ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
-                            onChange=(action (mut data.speaker.isEmailOverridden))}}
-              {{#if (not data.speaker.isEmailOverridden)}}
-                {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
-                        id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
-              {{/if}}
+              {{!--ui-checkbox label=(t 'Do not require email for this speaker.') checked=data.speaker.isEmailOverridden
+                            onChange=(action (mut data.speaker.isEmailOverridden))--}}
+              {{!--#if (not data.speaker.isEmailOverridden)--}}
+              {{input type=field.type value=(mut (get data.speaker field.fieldIdentifier))
+                      id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier))}}
+              {{!--/if--}}
             {{else}}
               {{#if field.isUrlField}}
                 {{widgets/forms/link-input


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3506 

#### Short description of what this resolves:
This pr makes it mandatory for speakers to enter email.

#### Changes proposed in this pull request:
By removing the checkbox for speakers.

#### Screenshot
![email](https://user-images.githubusercontent.com/45489945/65335523-2d437c00-dbe2-11e9-9410-74cfa8605ef0.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
