### PR TITLE
fix: Ticket maxorder should not be less than minOrder value

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -132,6 +132,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
       return (endDatetime.diff(startDatetime, 'minutes') > 0);
     };
 
+    window.$.fn.form.settings.rules.checkMaxMin = () => {
+      return this.get('data.ticket.minOrder') <= this.get('data.ticket.maxOrder');
+    };
+
     let validationRules = {
       inline : true,
       delay  : false,
@@ -276,6 +280,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'number',
               prompt : this.l10n.t('Invalid number')
+            },
+            {
+              type   : 'integer[1..]',
+              prompt : this.l10n.t('Minimum Order should be greater than 0')
             }
           ]
         },
@@ -291,8 +299,8 @@ export default Component.extend(FormMixin, EventWizardMixin, {
               prompt : this.l10n.t('Invalid number')
             },
             {
-              type   : 'integer[1..]',
-              prompt : this.l10n.t('Maximum tickets per order should be greater than 0')
+              type   : 'checkMaxMin',
+              prompt : this.l10n.t('Maximum tickets per order should be greater than minimum order')
             }
           ]
         },

--- a/app/templates/components/widgets/forms/ticket-input.hbs
+++ b/app/templates/components/widgets/forms/ticket-input.hbs
@@ -126,11 +126,11 @@
         <div class="fields">
           <div class="three wide field">
             <label class="required text muted" for="ticket_min_order">{{t 'Minimum Order'}}</label>
-            {{input type='number' value=ticket.minOrder name='ticket_min_order'}}
+            {{input type='number' value=ticket.minOrder name='ticket_min_order' min='1'}}
           </div>
           <div class="three wide field">
             <label class="required text muted" for="ticket_max_order">{{t 'Maximum Order'}}</label>
-            {{input type='number' value=ticket.maxOrder name='ticket_max_order'}}
+            {{input type='number' value=ticket.maxOrder name='ticket_max_order' min='1'}}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3521 

#### Short description of what this resolves:
Added client side check for the ticket value of minorder,maxorder should not be less than 0 and ticket maxOrder value should always be greater than or equal to minOrder

#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
