### PR TITLE
fix: Scale down image in Attendee Landing Page (#3529)

### DIFF
--- a/app/templates/attendee-app.hbs
+++ b/app/templates/attendee-app.hbs
@@ -84,7 +84,7 @@
         </div>
       </div>
       <div class="eight wide column">
-        <img class="ui fluid image large" src="/images/android-img.jpg" alt="Android Pic">
+        <img class="ui fluid image medium" src="/images/android-img.jpg" alt="Android Pic">
       </div>
     </div>
   {{/if}}

--- a/app/templates/attendee-app.hbs
+++ b/app/templates/attendee-app.hbs
@@ -84,7 +84,7 @@
         </div>
       </div>
       <div class="eight wide column">
-        <img class="ui fluid image" src="/images/android-img.jpg" alt="Android Pic">
+        <img class="ui fluid image large" src="/images/android-img.jpg" alt="Android Pic">
       </div>
     </div>
   {{/if}}

--- a/app/templates/attendee-app.hbs
+++ b/app/templates/attendee-app.hbs
@@ -84,7 +84,7 @@
         </div>
       </div>
       <div class="eight wide column">
-        <img class="ui fluid image medium" src="/images/android-img.jpg" alt="Android Pic">
+        <img class="ui medium image" src="/images/android-img.jpg" alt="Android Pic">
       </div>
     </div>
   {{/if}}


### PR DESCRIPTION

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3529 

#### Short description of what this resolves:
The image in the attendee landing page is too large, therefore, it needs to be scaled down

#### Changes proposed in this pull request:
Fixes the size of the image in attendee landing page by changing it's class to medium. This was done by adding the class medium to the image.

![medium](https://user-images.githubusercontent.com/23402988/66388370-a27ac380-e9ce-11e9-9997-e406a4a6328b.jpg)


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
