### PR TITLE
fix: Improve RegExp for URLs in Admin settings

### DIFF
--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -20,12 +20,14 @@ export const compulsoryProtocolValidUrlPattern = new RegExp('^(https?:\\/\\/)' /
 
 export const protocolLessValidUrlPattern = new RegExp(
   '^'
+  // localhost inclusion
+  + '(?:(?:localhost)(:\\d{2,5})?|'
   // user:pass authentication
   + '(?:\\S+(?::\\S*)?@)?'
   + '(?:'
   // IP address exclusion
   // private & local networks
-  + '(?!(?:10|127)(?:\\.\\d{1,3}){3})'
+  + '(?!(?:10)(?:\\.\\d{1,3}){3})'
   + '(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})'
   + '(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})'
   // IP address dotted notation octets
@@ -49,7 +51,7 @@ export const protocolLessValidUrlPattern = new RegExp(
   // port number
   + '(?::\\d{2,5})?'
   // resource path
-  + '(?:[/?#]\\S*)?'
+  + '(?:[/?#]\\S*)?)'
   + '$', 'i'
 );
 


### PR DESCRIPTION
Fixes #3528 

#### Short description of what this resolves:
RegExp for URLs improved to allow acceptance of localhost or 127.0.0.1 URLs in Admin settings.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
