### PR TITLE
FIX #2544: Target name gets highlighted

### DIFF
--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -3,11 +3,17 @@ import { computed } from '@ember/object';
 import moment from 'moment';
 
 export default Component.extend({
+  selectedIndex: undefined,
   async didInsertElement() {
     this._super(...arguments);
     let speakersCall = await this.get('event.speakersCall');
     this.set('shouldShowCallforSpeakers',
       speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
+  },
+  actions: {
+    changeSelectedIndex(index) {
+      this.set('selectedIndex', index);
+    }
   },
   isSchedulePublished: computed('event.schedulePublishedOn', function() {
     return this.get('event.schedulePublishedOn') && this.get('event.schedulePublishedOn').toISOString() !== moment(0).toISOString();

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,16 +1,16 @@
 {{#if (and (not-eq session.currentRouteName 'public.cfs.new-session') (not-eq session.currentRouteName 'public.cfs.new-speaker') (not-eq session.currentRouteName 'public.cfs.edit-speaker') (not-eq session.currentRouteName 'public.cfs.edit-session'))}}
   <div class="ui fluid vertical {{unless device.isMobile 'pointing'}} menu">
     {{#if (eq session.currentRouteName 'public.index')}}
-      {{#scroll-to href='#info' class='item active'}}
+      {{#scroll-to click=(action 'changeSelectedIndex' "info") href='#info' class=(if (eq selectedIndex "info") 'active item' 'item')}}
         {{t 'Info'}}
       {{/scroll-to}}
       {{#if event.tickets.length}}
-        {{#scroll-to href='#tickets' class='item'}}
+        {{#scroll-to click=(action 'changeSelectedIndex' "tickets") href='#tickets' class=(if (eq selectedIndex "tickets") 'active item' 'item')}}
           {{t 'Tickets'}}
         {{/scroll-to}}
       {{/if}}
       {{#if event.speakers.length}}
-        {{#link-to 'public.speakers' class='item'}}
+        {{#link-to 'public.speakers' click=(action 'changeSelectedIndex' "speakers") class=(if (eq selectedIndex "speakers") 'active item' 'item')}}
           {{t 'Speakers'}}
         {{/link-to}}
       {{/if}}
@@ -24,29 +24,29 @@
         </a>
       {{/if}}
       {{#if event.speakers.length}}
-        {{#link-to 'public.speakers' class='item'}}
+        {{#link-to 'public.speakers' click=(action 'changeSelectedIndex' "speakers") class=(if (eq selectedIndex "speakers") 'active item' 'item')}}
           {{t 'Speakers'}}
         {{/link-to}}
       {{/if}}
     {{/if}}
     {{#if event.sessions.length}}
-      {{#link-to 'public.sessions' class='item'}}
+      {{#link-to 'public.sessions' click=(action 'changeSelectedIndex' "sessions") class=(if (eq selectedIndex "sessions") 'active item' 'item')}}
         {{t 'Sessions'}}
       {{/link-to}}
     {{/if}}
     {{#if isSchedulePublished}}
-      {{#link-to 'public.schedule' class='item'}}
+      {{#link-to 'public.schedule' click=(action 'changeSelectedIndex' "schedule") class=(if (eq selectedIndex "schedule") 'active item' 'item')}}
         {{t 'Schedule'}}
       {{/link-to}}
     {{/if}}  
     {{#if shouldShowCallforSpeakers }}
-      {{#link-to 'public.cfs' class='item'}}
+      {{#link-to 'public.cfs' click=(action 'changeSelectedIndex' "callForSpeakers") class=(if (eq selectedIndex "callForSpeakers") 'active item' 'item')}}
         {{t 'Call for Speakers'}}
       {{/link-to}}
     {{/if}}
     {{#if event.hasOwnerInfo}}
       {{#if (eq session.currentRouteName 'public.index')}}
-        {{#scroll-to href='#owner' class='item'}}
+        {{#scroll-to click=(action 'changeSelectedIndex' "owner")  href='#owner' class=(if (eq selectedIndex "owner") 'active item' 'item')}}
           {{t 'Owner'}}
         {{/scroll-to}}
       {{else}}
@@ -56,7 +56,7 @@
       {{/if}}
     {{/if}}
     {{#if (eq session.currentRouteName 'public.index')}}
-      {{#scroll-to href='#getting-here' class='item'}}
+      {{#scroll-to click=(action 'changeSelectedIndex' "gettingHere") href='#getting-here' class=(if (eq selectedIndex "gettingHere") 'active item' 'item')}}
         {{t 'Getting here'}}
       {{/scroll-to}}
     {{else}}
@@ -65,7 +65,7 @@
       </a>
     {{/if}}
     {{#if event.codeOfConduct}}
-      {{#link-to 'public.coc' class='item'}}
+      {{#link-to 'public.coc' click=(action 'changeSelectedIndex' "coc") class=(if (eq selectedIndex "coc") 'active item' 'item')}}
         {{t 'Code of Conduct'}}
       {{/link-to}}
     {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2544 

#### Short description of what this resolves:
In the sidebar when the user clicks on scrollable links the correct `{{scroll-to}}` gets highlighted.

#### Video:
![mp4gifgif](https://user-images.githubusercontent.com/35570715/66908631-09c8f100-f029-11e9-93a7-7ff6cc1219af.gif)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
