### PR TITLE
transform event-card scale on hover

### DIFF
--- a/app/styles/partials/event-card.scss
+++ b/app/styles/partials/event-card.scss
@@ -1,5 +1,7 @@
 .event.card {
+  border-radius: 5px;
   height: 355px;
+  transition: transform .3s;
 
   .header {
     height: 50px;
@@ -14,6 +16,11 @@
   img {
     height: 179px !important;
     object-fit: cover;
+  }
+
+  :hover > & {
+    box-shadow: 5px 5px 5px #808080;
+    transform: scale(1.1);
   }
 }
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### Short description of what this resolves:
It resolves issue #3569 



#### Changes proposed in this pull request:

- Now the event-card will transform to a 1.1 scale on hover
- Has a 5px shadow on right and bottom on hover
![OpenEvent-MozillaFirefox2019-10](https://user-images.githubusercontent.com/43860289/67417533-a28ddc80-f5e6-11e9-8d3b-2074a07f8d42.gif)

**_The preview is kind of slow and the transforming is smooth_**


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
