### PR TITLE
Updated timezone format from +hhmm to +hh:mm UTC

### DIFF
--- a/app/helpers/header-date.js
+++ b/app/helpers/header-date.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export function headerDate(params) {
   let timezone = params[1] ? params[1] : moment.tz.guess();
-  return `${moment(params[0]).tz(timezone).format('dddd, MMMM Do YYYY, h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
+  return `${moment(params[0]).tz(timezone).format('dddd, MMMM Do YYYY, hh:mm')} (${moment.tz(params[0], timezone).format('Z')} UTC)`;
 }
 
 export default Helper.helper(headerDate);


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3559 

#### Short description of what this resolves:
Adds the suffix UTC and also add : to distinguish between hours and minutes.

#### Changes proposed in this pull request:

- Changed from `zoneAbbr` to `format`


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
