### PR TITLE
fix : Renaming google+ entry to google groups in admin/content social link page 

### DIFF
--- a/app/components/forms/admin/content/social-links-form.js
+++ b/app/components/forms/admin/content/social-links-form.js
@@ -56,8 +56,8 @@ export default Component.extend(FormMixin, {
           optional   : true,
           rules      : [
             {
-              type   : 'containsExactly[plus.google.com]',
-              prompt : this.l10n.t('Please enter a valid google plus url')
+              type   : 'containsExactly[groups.google.com]',
+              prompt : this.l10n.t('Please enter a valid google groups url')
             },
             {
               type   : 'regExp',

--- a/app/templates/components/forms/admin/content/social-links-form.hbs
+++ b/app/templates/components/forms/admin/content/social-links-form.hbs
@@ -21,7 +21,7 @@
     }}
   </div>
   <div class="field">
-    <label>{{t 'Google +'}}</label>
+    <label>{{t 'Google groups'}}</label>
     {{widgets/forms/link-input
       segmentedLink=socials.segmentedGoogleUrl
       inputId='google_plus'


### PR DESCRIPTION
Fixes #3584 
#### Short description of what this resolves:
It changes the google plus entry to google groups in admin/content page .Also fixes the required regex expression for google goups url (https://groups.google.com/forum/#!forum/open-event).Also updated the warning messages shows in box after filling wrong url from "enter a valid google plus url" to "enter a valid google groups url"

#### Changes proposed in this pull request:
-changed google plus entry in (https://eventyay.com/admin/content) to google groups entry.
![Screenshot from 2019-10-31 18-00-54](https://user-images.githubusercontent.com/56407566/68010689-480e1380-fcab-11e9-91cf-9669be9f395f.png)
on entering the wrong url -
![Screenshot from 2019-10-31 18-19-13](https://user-images.githubusercontent.com/56407566/68010706-565c2f80-fcab-11e9-9fc0-79f8366ead12.png)
on entering the right url -
![Screenshot from 2019-10-31 18-19-53](https://user-images.githubusercontent.com/56407566/68010718-61af5b00-fcab-11e9-84fa-4d94884ad556.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
