### PR TITLE
fix: Ticket dashboard  table css overflow on small screens

### DIFF
--- a/app/templates/components/tables/utilities/search-box.hbs
+++ b/app/templates/components/tables/utilities/search-box.hbs
@@ -1,4 +1,4 @@
-<div class="ui small icon input">
+<div class="ui small icon input search-box">
   {{input type="text" value=searchQuery placeholder="Search ..." }}
   <i class="search icon"></i>
 </div>

--- a/app/templates/events/view/tickets/index.hbs
+++ b/app/templates/events/view/tickets/index.hbs
@@ -10,7 +10,7 @@
   </div>
 </div>
 <br>
-<div class="row">
+<div class="row x-scrollable">
   <div class="ui header">
     {{t 'Order Summary'}}
     <span class="sub header">
@@ -121,7 +121,7 @@
 </div>
 <br>
 
-<div class="row">
+<div class="row x-scrollable">
   <table class="ui stackable celled unstackable table">
     <thead>
       <tr>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3589 #3605 

#### Short description of what this resolves:
fixes the ticket dashboard Table CSS Overflow on Small Device Screens.
<img width="549" alt="issuebug" src="https://user-images.githubusercontent.com/46647141/68089135-d9d47700-fe8b-11e9-964e-ae9291d58b54.png">

Also fixes the manage events dashboard search-box overflow on small screen devices :
![Screenshot from 2019-11-05 20-11-08](https://user-images.githubusercontent.com/46647141/68404556-bfa8da80-01a4-11ea-9de6-ed41390167b2.png)


#### Changes proposed in this pull request:
I have fixed it by setting the css overflow property to scroll.

![Screenshot from 2019-11-03 22-07-53](https://user-images.githubusercontent.com/46647141/68089190-523b3800-fe8c-11e9-90d0-2682c19c2bb4.png)

![Screenshot from 2019-11-03 22-07-59](https://user-images.githubusercontent.com/46647141/68089196-57988280-fe8c-11e9-98b2-050cae7a1b19.png)

![Screenshot from 2019-11-07 21-23-37](https://user-images.githubusercontent.com/46647141/68404705-f3840000-01a4-11ea-998d-79b8ed70c595.png)




#### Checklist

- [x]  I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
