### PR TITLE
fix: show "more call for speaker" button when appropriate

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,11 +27,13 @@
       {{/each}}
     </div>
     <div class="ui hidden divider"></div>
-    <div class="ui centered grid">
-      <div class="row">
-        {{#link-to "explore" (query-params cfs='open') class='ui blue button'}}{{t 'Show more calls for speakers'}}{{/link-to}}
+    {{#if (gt callForSpeakersEvents 3)}}
+      <div class="ui centered grid">
+        <div class="row">
+          {{#link-to "explore" (query-params cfs='open') class='ui blue button'}}{{t 'Show more calls for speakers'}}{{/link-to}}
+        </div>
       </div>
-    </div>
+    {{/if}}
   {{/if}}
 
   {{modals/event-share-modal isOpen=isShareModalOpen event=eventToShare}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,7 +27,7 @@
       {{/each}}
     </div>
     <div class="ui hidden divider"></div>
-    {{#if (gt callForSpeakersEvents 3)}}
+    {{#if (gt callForSpeakersEvents.length 3)}}
       <div class="ui centered grid">
         <div class="row">
           {{#link-to "explore" (query-params cfs='open') class='ui blue button'}}{{t 'Show more calls for speakers'}}{{/link-to}}


### PR DESCRIPTION
Fixes #3309 
**changes it propose**
when there are less than or equal to three the "show more call for speaker " button will not be visible . 
![Screenshot from 2019-11-08 09-44-02](https://user-images.githubusercontent.com/56407566/68449313-9f146b00-020c-11ea-9ee9-1ec4a1edd147.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
