### PR TITLE
fix: ticketing system buttons alignment

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -189,14 +189,14 @@
           </h3>
         {{/if}}
       </div>
-      <button type="button" class="ui blue small button" {{action 'addTicket' 'free' data.event.tickets.length}}>
+      <button type="button" class="ui blue small button {{if device.isMobile 'field fluid'}}" {{action 'addTicket' 'free' data.event.tickets.length}}>
         <i class="large icons basic-details">
           <i class="smile icon"></i>
           <i class="inverted corner add icon"></i>
         </i>
         {{t 'Free Ticket'}}
       </button>
-      <button type="button" class="ui blue small button" {{action 'addTicket' 'paid' data.event.tickets.length}}>
+      <button type="button" class="ui blue small button {{if device.isMobile 'field fluid'}}" {{action 'addTicket' 'paid' data.event.tickets.length}}>
         <i class="large icons basic-details">
           <i class="dollar icon"></i>
           <i class="inverted corner add icon"></i>
@@ -210,7 +210,7 @@
         </div>
       {{/if}} --}}
     
-      <button type="button" class="ui blue small button" {{action 'addTicket' 'donation' data.event.tickets.length}}>
+      <button type="button" class="ui blue small button {{if device.isMobile 'field fluid'}}" {{action 'addTicket' 'donation' data.event.tickets.length}}>
         <i class="large icons basic-details">
           <i class="heart icon"></i>
           <i class="inverted corner add icon"></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3603 

#### Short description of what this resolves:
fixes the weird alignment of The ticketing system buttons(i.e. free ticket, paid ticket ,donation ticket) on the create event page on small screens.

![Screenshot from 2019-11-04 20-56-36](https://user-images.githubusercontent.com/46647141/68530410-de86a880-032d-11ea-862f-f5a32875d4e8.png)

#### Changes proposed in this pull request:

![Screenshot from 2019-11-09 20-07-01](https://user-images.githubusercontent.com/46647141/68530380-b39c5480-032d-11ea-9760-0968eb9e9629.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->

