### PR TITLE
fix: Changed size of image in Attendee Landing Page (#3529) 

### DIFF
--- a/app/templates/attendee-app.hbs
+++ b/app/templates/attendee-app.hbs
@@ -84,7 +84,7 @@
         </div>
       </div>
       <div class="eight wide column">
-        <img class="ui fluid image" src="/images/android-img.jpg" alt="Android Pic">
+        <img class="ui medium image" src="/images/android-img.jpg" alt="Android Pic">
       </div>
     </div>
   {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3529 

#### Short description of what this resolves:
The image in the attendee landing page is too large, therefore, it needs to be scaled down

#### Changes proposed in this pull request:
- Changed the class of image from `fluid` to `medium`

![Screenshot_20191116_231105](https://user-images.githubusercontent.com/36989112/68996947-e5319480-08c6-11ea-99b2-b501dd3a3f9f.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
