### PR TITLE
fix: Send event startsAt and endsAt time in event timezone

### DIFF
--- a/app/utils/computed-helpers.js
+++ b/app/utils/computed-helpers.js
@@ -47,23 +47,22 @@ export const computedSegmentedLink = function(property) {
 export const computedDateTimeSplit = function(property, segmentFormat, endProperty) {
   return computed(property, {
     get() {
-      if (this.constructor.toString() === 'model:event') {
-        return moment(this.get(property)).tz(this.timezone).format(getFormat(segmentFormat));
-      } else {
-        return moment(this.get(property)).format(getFormat(segmentFormat));
+      let momentDate = moment(this.get(property));
+      if (this.constructor.modelName === 'event') {
+        momentDate = momentDate.tz(this.timezone);
       }
+      return momentDate.format(getFormat(segmentFormat));
     },
     set(key, value) {
       let newDate = moment(value, getFormat(segmentFormat));
-      if (this.constructor.toString() === 'model:event') {
-        newDate = moment(value, getFormat(segmentFormat)).tz(this.timezone, true);
+      if (this.constructor.modelName === 'event') {
+        newDate = newDate.tz(this.timezone, true);
       }
       let oldDate = newDate;
       if (this.get(property)) {
-        if (this.constructor.toString() === 'model:event') {
-          oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT).tz(this.timezone, true);
-        } else {
-          oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT);
+        oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT);
+        if (this.constructor.modelName === 'event') {
+          oldDate = oldDate.tz(this.timezone, true);
         }
       } else {
         oldDate = newDate;

--- a/app/utils/computed-helpers.js
+++ b/app/utils/computed-helpers.js
@@ -47,13 +47,13 @@ export const computedSegmentedLink = function(property) {
 export const computedDateTimeSplit = function(property, segmentFormat, endProperty) {
   return computed(property, {
     get() {
-      return moment(this.get(property)).format(getFormat(segmentFormat));
+      return moment(this.get(property)).tz(this.timezone).format(getFormat(segmentFormat));
     },
     set(key, value) {
-      const newDate = moment(value, getFormat(segmentFormat));
+      const newDate = moment(value, getFormat(segmentFormat)).tz(this.timezone, true);
       let oldDate = newDate;
       if (this.get(property)) {
-        oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT);
+        oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT).tz(this.timezone, true);
       } else {
         oldDate = newDate;
       }

--- a/app/utils/computed-helpers.js
+++ b/app/utils/computed-helpers.js
@@ -47,13 +47,24 @@ export const computedSegmentedLink = function(property) {
 export const computedDateTimeSplit = function(property, segmentFormat, endProperty) {
   return computed(property, {
     get() {
-      return moment(this.get(property)).tz(this.timezone).format(getFormat(segmentFormat));
+      if (this.constructor.toString() === 'model:event') {
+        return moment(this.get(property)).tz(this.timezone).format(getFormat(segmentFormat));
+      } else {
+        return moment(this.get(property)).format(getFormat(segmentFormat));
+      }
     },
     set(key, value) {
-      const newDate = moment(value, getFormat(segmentFormat)).tz(this.timezone, true);
+      let newDate = moment(value, getFormat(segmentFormat));
+      if (this.constructor.toString() === 'model:event') {
+        newDate = moment(value, getFormat(segmentFormat)).tz(this.timezone, true);
+      }
       let oldDate = newDate;
       if (this.get(property)) {
-        oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT).tz(this.timezone, true);
+        if (this.constructor.toString() === 'model:event') {
+          oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT).tz(this.timezone, true);
+        } else {
+          oldDate = moment(this.get(property), segmentFormat === 'date' ? FORM_DATE_FORMAT : FORM_TIME_FORMAT);
+        }
       } else {
         oldDate = newDate;
       }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3632 

#### Short description of what this resolves:
Send event timings in event timezone and render time correctly on event basic details page.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
