### PR TITLE
fix: organizer-app image size

### DIFF
--- a/app/templates/organizer-app.hbs
+++ b/app/templates/organizer-app.hbs
@@ -35,7 +35,7 @@
     <img class="ui fluid image" src="images/organizer-android.jpg" alt="{{t 'Organizer Android App'}}">
   {{else}}
     <div class="ui grid">
-      <div class="eight wide column">   
+      <div class="eight wide column centered row">   
         <h1 class="weight-900">
           {{t 'Make your event success with Orga App'}}
         </h1>
@@ -84,7 +84,7 @@
         </div>
       </div>
       <div class="eight wide column">
-        <img class="ui large image" src="/images/organizer-android.jpg" alt="Android Pic">
+        <img class="ui medium image" src="/images/organizer-android.jpg" alt="Android Pic">
       </div>
     </div>
   {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3631 

#### Short description of what this resolves:
Image used in the Organizer App Landing is much larger than it should be.

#### Changes proposed in this pull request:

Changed the image size from large to medium.

![Screenshot from 2019-11-17 15-22-27](https://user-images.githubusercontent.com/46647141/69006083-5ec19500-0950-11ea-9131-661085e231c6.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
