### PR TITLE
fix: footer copyright credits

### DIFF
--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -73,7 +73,7 @@
   <div class="ui stackable grid">
     <div class="thirteen wide computer twelve wide tablet column left aligned">
       <div class="ui horizontal inverted small divided link list less top margin">
-        <span class="item">{{t 'Copyright'}} &copy; {{moment-format (now) 'YYYY'}}  {{config.appName}} </span>
+        <span class="item">{{t 'Copyright'}} &copy; {{moment-format (now) 'YYYY'}}  {{settings.appName}} </span>
         {{#each footerPages as |page|}}
           {{#link-to 'pages' page.url class='item'}}
             {{page.name}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3697 

#### Short description of what this resolves:
copyright © 2019 Eventyay Should be there instead of Open event.


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)
