### PR TITLE
fix: hide cancel button when order state is cancelled

### DIFF
--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -29,7 +29,7 @@
       <i class="check icon"></i>
     {{/ui-popup}}
   {{/if}}
-  {{#if (and (not-eq record.status 'cancelled') (not-eq record.status 'expired') (can-modify-order record))}}
+  {{#if (and (not-eq record.status 'cancelled') (not-eq record.status 'expired') (can-modify-order record) (not-eq extraRecords.status 'cancelled'))}}
     {{#ui-popup content=(t 'Cancel order') click=(action (confirm (t 'Are you sure you would like to cancel this Order?') (action props.actions.cancelOrder record))) class="{{if device.isMobile 'medium' 'huge'}} ui icon button" position='top center'}}
       <i class="delete icon"></i>
     {{/ui-popup}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -29,7 +29,7 @@
       <i class="check icon"></i>
     {{/ui-popup}}
   {{/if}}
-  {{#if (and (not-eq record.status 'cancelled') (not-eq record.status 'expired') (can-modify-order record) (not-eq extraRecords.status 'cancelled'))}}
+  {{#if (and (not-eq extraRecords.status 'cancelled') (not-eq extraRecords.status 'expired') (can-modify-order record))}}
     {{#ui-popup content=(t 'Cancel order') click=(action (confirm (t 'Are you sure you would like to cancel this Order?') (action props.actions.cancelOrder record))) class="{{if device.isMobile 'medium' 'huge'}} ui icon button" position='top center'}}
       <i class="delete icon"></i>
     {{/ui-popup}}


### PR DESCRIPTION

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3719 

#### Short description of what this resolves:
don't show cancel button when order state is cancelled .
![Screenshot from 2019-12-24 23-29-44](https://user-images.githubusercontent.com/56407566/71422113-6ee23800-26a5-11ea-98a9-4c17c96755bf.png)
![Screenshot from 2019-12-24 23-29-50](https://user-images.githubusercontent.com/56407566/71422115-6ee23800-26a5-11ea-95eb-34d45ebf39df.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
