### PR TITLE
fix: user can't edit session after cfs is closed

### DIFF
--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -13,16 +13,15 @@ export default class extends Controller {
 
     return true;
   }
-  
   @computed('model.event.speakersCall.endsAt')
-  get isCfsOpen(){
+  get isCfsOpen() {
     let cfsEndsAt = this.get('model.event.speakersCall.endsAt');
-    if(cfsEndsAt  < moment()) {
+    if (cfsEndsAt  < moment()) {
       return false;
     }
-    
+
     return true;
-    }
+  }
 
   @action
   openProposalDeleteModal() {

--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -13,6 +13,16 @@ export default class extends Controller {
 
     return true;
   }
+  
+  @computed('model.event.speakersCall.endsAt')
+  get isCfsOpen(){
+    let cfsEndsAt = this.get('model.event.speakersCall.endsAt');
+    if(cfsEndsAt  < moment()) {
+      return false;
+    }
+    
+    return true;
+    }
 
   @action
   openProposalDeleteModal() {

--- a/app/controllers/my-sessions/view.js
+++ b/app/controllers/my-sessions/view.js
@@ -13,15 +13,6 @@ export default class extends Controller {
 
     return true;
   }
-  @computed('model.event.speakersCall.endsAt')
-  get isCfsOpen() {
-    let cfsEndsAt = this.get('model.event.speakersCall.endsAt');
-    if (cfsEndsAt  < moment()) {
-      return false;
-    }
-
-    return true;
-  }
 
   @action
   openProposalDeleteModal() {

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,25 +1,25 @@
 <div class="ui container">
   <div class="ui row">
-    {{#if (not model.isLocked)}}
-      {{#if isCfsOpen}}
-        {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
-          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
-          {{#if device.isMobile}}
-            <div class="ui hidden fitted divider"></div>
-          {{/if}}
-        {{/link-to}}
+    {{#if isCfsOpen}}
+      {{#if (not model.isLocked)}
+          {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
+            <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
+            {{#if device.isMobile}}
+              <div class="ui hidden fitted divider"></div>
+            {{/if}}
+          {{/link-to}}
       {{/if}}
+      {{#each model.speakers as |speaker|}}
+        {{#if (eq speaker.email authManager.currentUser.email)}}
+          {{#link-to 'public.cfs.edit-speaker' model.event.id speaker.id}}
+            <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
+            {{#if device.isMobile}}
+              <div class="ui hidden fitted divider"></div>
+            {{/if}}
+          {{/link-to}}
+        {{/if}}
+      {{/each}}
     {{/if}}
-    {{#each model.speakers as |speaker|}}
-      {{#if (eq speaker.email authManager.currentUser.email)}}
-        {{#link-to 'public.cfs.edit-speaker' model.event.id speaker.id}}
-          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
-          {{#if device.isMobile}}
-            <div class="ui hidden fitted divider"></div>
-          {{/if}}
-        {{/link-to}}
-      {{/if}}
-    {{/each}}
     {{#if isUpcoming}}
       <button class="ui red button {{if device.isMobile 'fluid' 'right floated'}}" {{action 'openProposalDeleteModal'}}>{{t 'Withdraw Proposal'}}</button>
       {{#if device.isMobile}}

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -2,12 +2,12 @@
   <div class="ui row">
     {{#if isCfsOpen}}
       {{#if (not model.isLocked)}}
-          {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
-            <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
-            {{#if device.isMobile}}
-              <div class="ui hidden fitted divider"></div>
-            {{/if}}
-          {{/link-to}}
+        {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
+          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
+          {{#if device.isMobile}}
+            <div class="ui hidden fitted divider"></div>
+          {{/if}}
+        {{/link-to}}
       {{/if}}
       {{#each model.speakers as |speaker|}}
         {{#if (eq speaker.email authManager.currentUser.email)}}

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,6 +1,6 @@
 <div class="ui container">
   <div class="ui row">
-    {{#if isCfsOpen}}
+    {{#if model.event.speakersCall.isOpen}}
       {{#if (not model.isLocked)}}
         {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
           <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,7 +1,7 @@
 <div class="ui container">
   <div class="ui row">
     {{#if isCfsOpen}}
-      {{#if (not model.isLocked)}
+      {{#if (not model.isLocked)}}
           {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
             <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
             {{#if device.isMobile}}

--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,12 +1,14 @@
 <div class="ui container">
   <div class="ui row">
     {{#if (not model.isLocked)}}
-      {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
-        <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
-        {{#if device.isMobile}}
-          <div class="ui hidden fitted divider"></div>
-        {{/if}}
-      {{/link-to}}
+      {{#if isCfsOpen}}
+        {{#link-to 'public.cfs.edit-session' model.event.id model.id}}
+          <button class="ui blue button {{if device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
+          {{#if device.isMobile}}
+            <div class="ui hidden fitted divider"></div>
+          {{/if}}
+        {{/link-to}}
+      {{/if}}
     {{/if}}
     {{#each model.speakers as |speaker|}}
       {{#if (eq speaker.email authManager.currentUser.email)}}


### PR DESCRIPTION
Fixes #3768 
when cfs is closed ,then session detail will look like ,
![Screenshot from 2020-01-06 20-33-47](https://user-images.githubusercontent.com/56407566/71826459-fc6d5100-30c3-11ea-8411-60659c126101.png)
Disappear EditSession button .

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
