### PR TITLE
fix: using include in public speaker query

### DIFF
--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   async model() {
     const eventDetails = this.modelFor('public');
-    let filterOptions = [
+    const filterOptions = [
       {
         or: [
           {

--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -3,34 +3,36 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   async model() {
     const eventDetails = this.modelFor('public');
+    let filterOptions = [
+      {
+        or: [
+          {
+            name : 'sessions',
+            op   : 'any',
+            val  : {
+              name : 'state',
+              op   : 'eq',
+              val  : 'accepted'
+            }
+          },
+          {
+            name : 'sessions',
+            op   : 'any',
+            val  : {
+              name : 'state',
+              op   : 'eq',
+              val  : 'confirmed'
+            }
+          }
+        ]
+      }
+    ];
     return {
       event    : eventDetails,
       speakers : await eventDetails.query('speakers', {
-        filter: [
-          {
-            or: [
-              {
-                name : 'sessions',
-                op   : 'any',
-                val  : {
-                  name : 'state',
-                  op   : 'eq',
-                  val  : 'accepted'
-                }
-              },
-              {
-                name : 'sessions',
-                op   : 'any',
-                val  : {
-                  name : 'state',
-                  op   : 'eq',
-                  val  : 'confirmed'
-                }
-              }
-            ]
-          }
-        ],
-        'page[size]': 0
+        'page[size]' : 0,
+        filter       : filterOptions,
+        include      : 'sessions'
       })
 
     };


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Refers #3650

- Using include to fetch sessions correponding to speakers.
- Using FilterOptions to define filter rather than explicitly defining them in query object
