### PR TITLE
fix: Automatic scaling feature for speakers photos

### DIFF
--- a/app/styles/components/speaker-list.scss
+++ b/app/styles/components/speaker-list.scss
@@ -13,3 +13,7 @@
 .word-break {
   overflow-wrap: break-word;
 }
+
+#speakerImg {
+	height: 220px;
+}

--- a/app/styles/components/speaker-list.scss
+++ b/app/styles/components/speaker-list.scss
@@ -14,6 +14,7 @@
   overflow-wrap: break-word;
 }
 
-#speakerImg {
+.speakerImg {
 	height: 220px;
+	width: 220px;	
 }

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -1,7 +1,7 @@
 {{#ui-accordion}}
   <div class="title">
     <div class="ui">
-      <img alt="speaker" class="ui medium rounded image" id="speakerImg" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
+      <img alt="speaker" class="ui rounded image speakerImg" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
       <br>
       <h3 class="ui centered header less margin">
         {{speaker.name}}

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -1,7 +1,7 @@
 {{#ui-accordion}}
   <div class="title">
     <div class="ui">
-      <img alt="speaker" class="ui medium rounded image" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
+      <img alt="speaker" class="ui medium rounded image" id="speakerImg" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
       <br>
       <h3 class="ui centered header less margin">
         {{speaker.name}}


### PR DESCRIPTION
Fixes #3794
before making changes:
![Screenshot from 2020-01-15 11-06-59](https://user-images.githubusercontent.com/56407566/72407938-3820ae80-3787-11ea-9f1e-2009eeeb0df6.png)
After making changes:
![Screenshot from 2020-01-15 11-16-02](https://user-images.githubusercontent.com/56407566/72408308-74084380-3788-11ea-835a-335cf7a851fa.png)

![Screenshot from 2020-01-15 11-01-10](https://user-images.githubusercontent.com/56407566/72407949-41118000-3787-11ea-8192-a91efa1c2675.png)
i have checked from the semantic-ui git repo and found definition for ui medium image class . it is -
```
.ui.medium.images .image,
.ui.medium.images img,
.ui.medium.images svg,
.ui.medium.image {
  width: @mediumWidth;
  height: auto;
  font-size: @medium;
}
```
if you want to see ui medium image definition , you can find here :https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/elements/image.less


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
