### PR TITLE
feat: added sorting to list of talks according to average rating

### DIFF
--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -176,13 +176,14 @@ export default Route.extend({
         ]
       });
     }
-    // sorting the sessions according to their average rating
-    sessions.content.sort((a, b) => {
-      return b.__recordData.__data.averageRating - a.__recordData.__data.averageRating;
-    });
+    console.log(sessions);
+    console.log();
+    // sessions.content.sort((a,b)=>{
+    //   return b.__recordData.__data.averageRating - a.__recordData.__data.averageRating;
+    // });
     return {
       event   : eventDetails,
-      session : sessions
+      session : sessions.toArray().sortBy('averageRating').reverse()
     };
   }
 });

--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -177,7 +177,7 @@ export default Route.extend({
       });
     }
     // sorting the sessions according to their average rating
-    sessions.content.sort((a,b)=>{
+    sessions.content.sort((a, b) => {
       return b.__recordData.__data.averageRating - a.__recordData.__data.averageRating;
     });
     return {

--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -176,11 +176,6 @@ export default Route.extend({
         ]
       });
     }
-    console.log(sessions);
-    console.log();
-    // sessions.content.sort((a,b)=>{
-    //   return b.__recordData.__data.averageRating - a.__recordData.__data.averageRating;
-    // });
     return {
       event   : eventDetails,
       session : sessions.toArray().sortBy('averageRating').reverse()

--- a/app/routes/public/sessions/list.js
+++ b/app/routes/public/sessions/list.js
@@ -176,6 +176,10 @@ export default Route.extend({
         ]
       });
     }
+    // sorting the sessions according to their average rating
+    sessions.content.sort((a,b)=>{
+      return b.__recordData.__data.averageRating - a.__recordData.__data.averageRating;
+    });
     return {
       event   : eventDetails,
       session : sessions


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3795 

#### Short description of what this resolves:
Presently the list of talks are not ranked based on the internal rating. Having highest quality talks on the top will attract more audience. This pr solves this issue.

#### Changes proposed in this pull request:
After fetching the sessions we sort the sessions according to their average rating in descending order using Array.sort(). 
-
-
-

Before:
![before](https://user-images.githubusercontent.com/47845897/72466983-013aaf00-3800-11ea-8cee-c9ac79bf5d80.png)

After:
![after](https://user-images.githubusercontent.com/47845897/72467229-81611480-3800-11ea-8b97-56cb31d71d84.png)

The ratings of the sessions are 5, 4, 5, 3, 4 in order according to the before image but they are not mentioned on the page.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
