### PR TITLE
fix: Editing a Speaker shows Linkedin link

### DIFF
--- a/app/models/speaker.js
+++ b/app/models/speaker.js
@@ -40,7 +40,7 @@ export default ModelBase.extend({
   segmentedLinkTwitter   : computedSegmentedLink.bind(this)('twitter'),
   segmentedLinkGithub    : computedSegmentedLink.bind(this)('github'),
   segmentedLinkFacebook  : computedSegmentedLink.bind(this)('facebook'),
-  segmentedLinkLinkedIn  : computedSegmentedLink.bind(this)('linkedin'),
+  segmentedLinkLinkedin  : computedSegmentedLink.bind(this)('linkedin'),
   segmentedLinkInstagram : computedSegmentedLink.bind(this)('instagram'),
 
   /**


### PR DESCRIPTION

Fixes #3789 
![Screenshot from 2020-01-18 00-16-37](https://user-images.githubusercontent.com/56407566/72637726-ec892300-3987-11ea-8f8e-7892b2ec34ec.png)
Shows the linkedlink in speaker info, which was not showing previously - 
![Screenshot from 2020-01-18 00-17-38](https://user-images.githubusercontent.com/56407566/72637771-062a6a80-3988-11ea-92dd-797f3b10550e.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
