### PR TITLE
fix: minOrder-maxOrder & minPrice-maxPrice validation in basic-details-step

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -12,6 +12,7 @@ import { inject as service } from '@ember/service';
 import EventWizardMixin from 'open-event-frontend/mixins/event-wizard';
 import { protocolLessValidUrlPattern } from 'open-event-frontend/utils/validators';
 import ENV from 'open-event-frontend/config/environment';
+import $ from 'jquery';
 
 export default Component.extend(FormMixin, EventWizardMixin, {
 
@@ -128,6 +129,12 @@ export default Component.extend(FormMixin, EventWizardMixin, {
 
   // TODO: Removing the Event Time Validations due to the weird and buggy behaviour. Will be restored once a perfect solution is found. Please check issue: https://github.com/fossasia/open-event-frontend/issues/3667
   getValidationRules() {
+    $.fn.form.settings.rules.checkMaxMinPrice = () => {
+      return $('.ui.form').form('get value', 'min_price') <= $('.ui.form').form('get value', 'max_price');
+    };
+    $.fn.form.settings.rules.checkMaxMinOrder = () => {
+      return $('.ui.form').form('get value', 'ticket_min_order') <= $('.ui.form').form('get value', 'ticket_max_order');
+    };
 
     let validationRules = {
       inline : true,
@@ -257,6 +264,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'number',
               prompt : this.l10n.t('Invalid number')
+            },
+            {
+              type   : 'checkMaxMinOrder',
+              prompt : this.l10n.t('Minimum order should not be greater than maximum')
             }
           ]
         },
@@ -274,6 +285,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'integer[1..]',
               prompt : this.l10n.t('Maximum tickets per order should be greater than 0')
+            },
+            {
+              type   : 'checkMaxMinOrder',
+              prompt : this.l10n.t('Maximum order should not be less than minimum')
             }
           ]
         },
@@ -287,6 +302,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'integer[1..]',
               prompt : this.l10n.t('Minimum price needs to be greater than zero')
+            },
+            {
+              type   : 'checkMaxMinPrice',
+              prompt : this.l10n.t('Minimum price should not be greater than maximum')
             }
           ]
         },
@@ -300,6 +319,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'integer[1..]',
               prompt : this.l10n.t('Maximum price needs to be greater than zero')
+            },
+            {
+              type   : 'checkMaxMinPrice',
+              prompt : this.l10n.t('Maximum price should not be less than minimum')
             }
           ]
         },


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3521 

#### Short description of what this resolves:

Added minOrder-maxOrder & minPrice-maxPrice validation in ticket-input.
**(Server checks are already present.)**

#### Changes proposed in this pull request:
![Screenshot from 2020-01-25 22-36-23](https://user-images.githubusercontent.com/46647141/73124711-7195bd00-3fc4-11ea-93b4-d2152ac7eb11.png)


![Screenshot from 2020-01-25 22-37-11](https://user-images.githubusercontent.com/46647141/73124719-7f4b4280-3fc4-11ea-8fdc-fe3265b916aa.png)
