### PR TITLE
chore: removing template-inline-precompile

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "ember-cli-head": "^0.4.1",
     "ember-cli-html-minifier": "^1.1.0",
     "ember-cli-htmlbars": "^4.2.2",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-ifa": "^0.7.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mirage": "^0.4.15",


### PR DESCRIPTION
ember-cli-htmlbars-inline-precompile is not needed anymore with dependencies upgrades.