### PR TITLE
fix: Remove awaits in loop

### DIFF
--- a/app/controllers/events/view/edit/attendee.js
+++ b/app/controllers/events/view/edit/attendee.js
@@ -3,9 +3,7 @@ import EventWizardMixin from 'open-event-frontend/mixins/event-wizard';
 
 export default Controller.extend(EventWizardMixin, {
   async saveForms(data) {
-    for (const customForm of data.customForms ? data.customForms.toArray() : []) {
-      await customForm.save();
-    }
+    await Promise.all((data.customForms ? data.customForms.toArray() : []).map(customForm => customForm.save()));
     return data;
   },
   actions: {

--- a/app/controllers/events/view/tickets/add-order.js
+++ b/app/controllers/events/view/tickets/add-order.js
@@ -72,9 +72,7 @@ export default Controller.extend({
       try {
         let order = this.get('model.order');
         let attendees = this.get('model.attendees');
-        for (const attendee of attendees ? attendees.toArray() : []) {
-          await attendee.save();
-        }
+        await Promise.all((attendees ? attendees.toArray() : []).map(attendee => attendee.save()));
         order.set('attendees', attendees.slice());
         await order.save()
           .then(order => {
@@ -82,9 +80,7 @@ export default Controller.extend({
             this.transitionToRoute('orders.new', order.identifier);
           })
           .catch(async() => {
-            for (const attendee of attendees ? attendees.toArray() : []) {
-              await attendee.destroyRecord();
-            }
+            await Promise.all((attendees ? attendees.toArray() : []).map(attendee => attendee.destroyRecord()));
             this.notify.error(this.l10n.t('Oops something went wrong. Please try again'));
           })
           .finally(() => {

--- a/app/controllers/events/view/tickets/order-form.js
+++ b/app/controllers/events/view/tickets/order-form.js
@@ -6,9 +6,7 @@ export default Controller.extend({
    */
   async saveForms(data) {
     await data.event.save();
-    for (const customForm of data.customForms ? data.customForms.toArray() : []) {
-      await customForm.save();
-    }
+    await Promise.all((data.customForms ? data.customForms.toArray() : []).map(customForm => customForm.save()));
     return data;
   },
 

--- a/app/controllers/orders/new.js
+++ b/app/controllers/orders/new.js
@@ -13,9 +13,7 @@ export default Controller.extend({
           await current_user.save();
         }
         let { attendees, paymentMode } = data;
-        for (const attendee of attendees ? attendees.toArray() : []) {
-          await attendee.save();
-        }
+        await Promise.all((attendees ? attendees.toArray() : []).map(attendee => attendee.save()));
         if (paymentMode === 'free') {
           order.set('status', 'completed');
         } else if (paymentMode === 'bank' || paymentMode === 'cheque' || paymentMode === 'onsite') {

--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -125,9 +125,7 @@ export default Controller.extend({
         this.set('isLoading', true);
         let order = this.get('model.order');
         let attendees = this.get('model.attendees');
-        for (const attendee of attendees ? attendees.toArray() : []) {
-          await attendee.save();
-        }
+        await Promise.all((attendees ? attendees.toArray() : []).map(attendee => attendee.save()));
         order.set('attendees', attendees);
         await order.save()
           .then(order => {
@@ -135,9 +133,7 @@ export default Controller.extend({
             this.transitionToRoute('orders.new', order.identifier);
           })
           .catch(async e => {
-            for (const attendee of attendees ? attendees.toArray() : []) {
-              await attendee.destroyRecord();
-            }
+            await Promise.all((attendees ? attendees.toArray() : []).map(attendee => attendee.destroyRecord()));
             this.notify.error(this.l10n.t(e.errors[0].detail));
           })
           .finally(() => {

--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -48,28 +48,31 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
   async saveEventData(propsToSave = []) {
     const event = this.get('model.event');
     const data = {};
-    for (const property of propsToSave) {
+    const results = await Promise.allSettled(propsToSave.map(property => {
       try {
-        data[property] = await event.get(property);
+        return event.get(property);
       } catch (e) {
         if (!(e.errors && e.errors.length && e.errors.length > 0 && e.errors[0].status === 404)) {
           // Lets just ignore any 404s that might occur. And throw the rest for the caller fn to catch
           throw e;
         }
       }
+    }));
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        data[result.value.key] = result.value;
+      }
     }
     const numberOfTickets = data.tickets ? data.tickets.length : 0;
     if (event.name && event.locationName && event.startsAtDate && event.endsAtDate && numberOfTickets > 0) {
       await event.save();
 
-      for (const ticket of data.tickets ? data.tickets.toArray() : []) {
+      await Promise.all((data.tickets ? data.tickets.toArray() : []).map(ticket => {
         ticket.set('maxOrder', Math.min(ticket.get('maxOrder'), ticket.get('quantity')));
-        await ticket.save();
-      }
+        return ticket.save();
+      }));
 
-      for (const socialLink of data.socialLinks ? data.socialLinks.toArray() : []) {
-        await socialLink.save();
-      }
+      await Promise.all((data.socialLinks ? data.socialLinks.toArray() : []).map(socialLink => socialLink.save()));
 
       if (data.copyright && data.copyright.get('licence')) {
         await data.copyright.save();


### PR DESCRIPTION
Fixes #3916 

#### Short description of what this resolves:

If we're performing an operation on each element of an iterable and ```await``` is a part of each operation then the program is not taking full advantage of parallelization benefits of ```async```/```await```. Each successive operation will not start until the previous one has completed.

Using ```Promise.all()``` to ```await``` all the requests that were kicked during the loop to finish will create all the promises at once.

This pull request fixes this issue.



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
