### PR TITLE
Removed bower

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,7 +3,6 @@ import { computed } from '@ember/object';
 import ENV from 'open-event-frontend/config/environment';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import HasManyQueryAdapterMixin from 'ember-data-has-many-query/mixins/rest-adapter';
-import AdapterFetch from 'ember-fetch/mixins/adapter-fetch';
 import FastbootAdapter from 'ember-data-storefront/mixins/fastboot-adapter';
 
 /**
@@ -20,7 +19,7 @@ export const fixFilterQuery = query  => {
   return query;
 };
 
-export default JSONAPIAdapter.extend(HasManyQueryAdapterMixin, AdapterFetch, FastbootAdapter, {
+export default JSONAPIAdapter.extend(HasManyQueryAdapterMixin, FastbootAdapter, {
   host      : ENV.APP.apiHost,
   namespace : ENV.APP.apiNamespace,
 

--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -29,7 +29,7 @@ export default Route.extend({
     ];
     return this.infinity.model('speakers', {
       filter       : filterOptions,
-      perPage      : 6,
+      perPage      : 12,
       startingPage : 1,
       perPageParam : 'page[size]',
       pageParam    : 'page[number]',

--- a/config/environment.js
+++ b/config/environment.js
@@ -56,10 +56,10 @@ module.exports = function(environment) {
 
     SemanticUI: {
       source: {
-        css        : 'bower_components/open-event-theme/dist',
-        javascript : 'bower_components/open-event-theme/dist',
-        images     : 'bower_components/open-event-theme/dist/themes/default/assets/images',
-        fonts      : 'bower_components/open-event-theme/dist/themes/default/assets/fonts'
+        css        : 'node_modules/@bower_components/open-event-theme/dist',
+        javascript : 'node_modules/@bower_components/open-event-theme/dist',
+        images     : 'node_modules/@bower_components/open-event-theme/dist/themes/default/assets/images',
+        fonts      : 'node_modules/@bower_components/open-event-theme/dist/themes/default/assets/fonts'
       }
     },
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -51,22 +51,22 @@ module.exports = function(defaults) {
     }
   });
 
-  app.import('bower_components/semantic-ui-calendar/dist/calendar.min.css');
-  app.import('bower_components/Croppie/croppie.css');
+  app.import('node_modules/@bower_components/semantic-ui-calendar/dist/calendar.min.css');
+  app.import('node_modules/@bower_components/Croppie/croppie.css');
 
-  app.import('bower_components/semantic-ui-calendar/dist/calendar.min.js', {
+  app.import('node_modules/@bower_components/semantic-ui-calendar/dist/calendar.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
-  app.import('bower_components/wysihtml/dist/wysihtml-toolbar.min.js', {
+  app.import('node_modules/@bower_components/wysihtml/dist/wysihtml-toolbar.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
-  app.import('bower_components/Croppie/croppie.min.js', {
+  app.import('node_modules/@bower_components/Croppie/croppie.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
-  app.import('bower_components/tinyColorPicker/jqColorPicker.min.js', {
+  app.import('node_modules/@bower_components/tinyColorPicker/jqColorPicker.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
-  app.import('bower_components/js-polyfills/xhr.js', {
+  app.import('node_modules/@bower_components/js-polyfills/xhr.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
   app.import('vendor/jquery-ui.min.js', {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "test": "ember test",
     "exam": "ember exam --launch=chrome --random",
     "lint:js": "eslint --fix app ember-cli-build.js testem.js tests",
-    "lint:scss": "sass-lint -c .sass-lint.yml --verbose",
-    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), 'bower_components', 'junction') } catch (e) { }\""
+    "lint:scss": "sass-lint -c .sass-lint.yml --verbose"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "object-to-formdata": "^3.0.3",
     "paypal-checkout": "^4.0.311",
     "query-string": "^6.10.1",
-    "qunit-dom": "^0.9.2",
+    "qunit-dom": "^1.0.0",
     "sanitize-html": "^1.21.1",
     "sass": "^1.25.0",
     "semantic-ui-ember": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,6 +3501,22 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
+broccoli-funnel@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.1.tgz#21b00c2bc1c0b1b4c083e24139e2b321c4cf353f"
+  integrity sha512-G1LdSYpuVU7mxVq8KlOyLztsUv+posrHbe+6n/XymZpPd2bbLmQ4HL0v6YP1wWAnfCVTcTnUTpIkw9oYwy+tTw==
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^4.0.1"
+    debug "^4.1.1"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^2.0.1"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    path-posix "^1.0.0"
+    walk-sync "^2.0.2"
+
 broccoli-kitchen-sink-helpers@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz#77c7c18194b9664163ec4fcee2793444926e0c06"
@@ -3552,6 +3568,14 @@ broccoli-merge-trees@^2.0.0:
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz#f33b451994225522b5c9bcf27d59decfd8ba537d"
   dependencies:
     broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
+broccoli-merge-trees@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-4.1.0.tgz#a30e2e4c5bb0f5eb8981e8af33a8077714c11f1a"
+  integrity sha512-1OXsksKPFiRdiZZOfh1z1mm7ZqKezlMS+DPBpHMDLSb6AhYHvoQfjf0KuMXbY8aoYskj7+Z+EJ5SsS/OC2v5yw==
+  dependencies:
+    broccoli-plugin "^3.1.0"
     merge-trees "^2.0.0"
 
 broccoli-middleware@^2.1.0:
@@ -13126,13 +13150,13 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-dom@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.9.2.tgz#cc7bb777e4f5faa749eca843f54e199755df8473"
-  integrity sha512-BPf7OZjhXo9ekgsViNjQVS9BWkm2yQsPvBoy0juvt5nOFlcBVVwHSYsgpsJOunWkI1IgA3eStAC9mQx3Zw734g==
+qunit-dom@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-1.0.0.tgz#0a2a42f7f0e44ee6ddb5b12bbf296dc2db7ee6dc"
+  integrity sha512-N4lpLP5zs59+01ZWHs73kgbglmUp6Z5TLZRB1GRlq+5H40NStjPU8ZQEVPlKsjYSbsR6xLkn2wlQURJnFArQag==
   dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.1"
+    broccoli-funnel "^3.0.1"
+    broccoli-merge-trees "^4.1.0"
 
 qunit@^2.9.3:
   version "2.9.3"


### PR DESCRIPTION
Fixes #3957 

#### Short description of what this resolves:
As bower is deprecated and not letting us use embroider, replacing ```bower_component``` with ```node_modules@bower_components``` will allow us to use those same packages after installing using yarn.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
