### PR TITLE
fix: Add crypto to fastboot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     ]
   },
   "fastbootDependencies": [
+    "crypto",
     "node-fetch",
     "ua-parser-js"
   ]


### PR DESCRIPTION
Fixes #4018 

We aren't using createRecord in fastboot, but it still requires it for some reason. 
https://github.com/emberjs/data/pull/6692