### PR TITLE
Fixing the button alignment issue in complete order page.

### DIFF
--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -24,12 +24,12 @@
     </div>
   </div>
   <div class="row">
-    <div class="column right aligned">
-      <button class="ui labeled icon {{if isLoadingTickets 'loading'}} button" {{action downloadTickets model.event.name model.order.identifier}}>
+    <div class="column right {{if device.isMobile 'center'}} aligned">
+      <button class="ui labeled icon {{if isLoadingTickets 'loading '}}button" {{action downloadTickets model.event.name model.order.identifier}}>
         <i class="ticket alternate icon"></i>
         {{t 'Download Tickets'}}
       </button>
-      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button">
+      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}}button">
         <i class="download icon"></i>
         {{t 'Download Invoice'}}
       </button>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -25,11 +25,11 @@
   </div>
   <div class="row">
     <div class="column right {{if device.isMobile 'center'}} aligned">
-      <button class="ui labeled icon {{if isLoadingTickets 'loading '}}button" {{action downloadTickets model.event.name model.order.identifier}}>
+      <button class="ui labeled icon {{if isLoadingTickets 'loading '}} button" {{action downloadTickets model.event.name model.order.identifier}}>
         <i class="ticket alternate icon"></i>
         {{t 'Download Tickets'}}
       </button>
-      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}}button">
+      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button">
         <i class="download icon"></i>
         {{t 'Download Invoice'}}
       </button>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -25,7 +25,7 @@
   </div>
   <div class="row">
     <div class="column right {{if device.isMobile 'center'}} aligned">
-      <button class="ui labeled icon {{if isLoadingTickets 'loading '}} button" {{action downloadTickets model.event.name model.order.identifier}}>
+      <button class="ui labeled icon {{if isLoadingTickets 'loading'}} button" {{action downloadTickets model.event.name model.order.identifier}}>
         <i class="ticket alternate icon"></i>
         {{t 'Download Tickets'}}
       </button>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -24,12 +24,12 @@
     </div>
   </div>
   <div class="row">
-    <div class="column right {{if device.isMobile 'center'}} aligned">
-      <button class="ui labeled icon {{if isLoadingTickets 'loading'}} button" {{action downloadTickets model.event.name model.order.identifier}}>
+    <div class="column right aligned">
+      <button class="ui labeled icon {{if isLoadingTickets 'loading'}} button {{if device.isMobile 'fluid' 'right aligned'}}" {{action downloadTickets model.event.name model.order.identifier}}>
         <i class="ticket alternate icon"></i>
         {{t 'Download Tickets'}}
       </button>
-      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button">
+      <button {{action 'downloadInvoice' model.event.name model.order.identifier }} class="ui labeled icon blue {{if isLoadingInvoice 'loading'}} button {{if device.isMobile 'fluid' 'right aligned'}}">
         <i class="download icon"></i>
         {{t 'Download Invoice'}}
       </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4052 

#### Short description of what this resolves:
Fixes the button alignment issue in `complete order` page in Mobile View.

#### Changes proposed in this pull request:

- in file `view.hbs`

#### Screenshot :

**Before**
![Screenshot 2020-02-11 00:57:21](https://user-images.githubusercontent.com/35539313/74185582-ed536300-4c6e-11ea-8bed-58c140c286f0.png)

**After**
![Screenshot 2020-02-11 01:02:01](https://user-images.githubusercontent.com/35539313/74185600-f6dccb00-4c6e-11ea-9d55-97b8a8774a1c.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
