### PR TITLE
fix: remove location check from event-wizard mixin

### DIFF
--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -117,9 +117,6 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
       if (event.name === undefined || event.name === '') {
         errorObject.errors.push({ 'detail': 'Event name has not been provided' });
       }
-      if (event.locationName === undefined || event.locationName === '') {
-        errorObject.errors.push({ 'detail': 'Location has not been provided' });
-      }
       if (event.startsAtDate === undefined || event.endsAtDate === undefined) {
         errorObject.errors.push({ 'detail': 'Dates have not been provided' });
       }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4058 

Now Events can be saved as draft without filling the location field.