### PR TITLE
Revert "chore(deps-dev): bump ember-source from 3.16.1 to 3.16.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ember-router-scroll": "^2.0.0",
     "ember-simple-auth": "^3.0.0",
     "ember-simple-auth-token": "^4.0.7",
-    "ember-source": "~3.16.2",
+    "ember-source": "~3.16.1",
     "ember-table": "^2.2.3",
     "ember-truth-helpers": "^2.1.0",
     "ember-uuid": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,10 +7008,10 @@ ember-source-channel-url@^2.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.16.2:
-  version "3.16.2"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.16.2.tgz#bdb342445804d20b46796b98919a924e5a8eb61e"
-  integrity sha512-aRF90V88rJ6h47ootUw8oGcV7O4ulwLYNVqnokTr9RTeWjEimwMtzLLazUfDR1LZMkdMTLVLGcQkJCJVvUAg5A==
+ember-source@~3.16.1:
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.16.1.tgz#997f51c2b74620906d2a8111089b6e894b6165e6"
+  integrity sha512-4cYfQ+DsqeSTqG0RztuTsh8d8p0XdeIaPWe9Ol229GhQjM1JgpjQNTXGJDTIB8FfbAxycPlCwIk2qXygA+pFsA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/plugin-transform-block-scoping" "^7.6.2"


### PR DESCRIPTION
Reverts fossasia/open-event-frontend#4049

Fixes #4062 
- This broke the every request the infinityLoader was sending to the server, hence neither the speaker nor session page was working.