### PR TITLE
fix: make event delete & transfer confirmation modal case sensitive

### DIFF
--- a/app/components/modals/event-delete-modal.js
+++ b/app/components/modals/event-delete-modal.js
@@ -5,6 +5,6 @@ export default ModalBase.extend({
   isSmall         : true,
   confirmName     : '',
   isNameDifferent : computed('confirmName', function() {
-    return this.eventName ? this.confirmName.toLowerCase() !== this.eventName.toLowerCase() : true;
+    return this.eventName ? this.confirmName !== this.eventName : true;
   })
 });

--- a/app/components/modals/event-transfer-modal.js
+++ b/app/components/modals/event-transfer-modal.js
@@ -5,6 +5,6 @@ export default ModalBase.extend({
   isSmall          : true,
   confirmEventName : '',
   isNameDifferent  : computed('confirmEventName', 'eventName', function() {
-    return this.eventName ? this.confirmEventName.toLowerCase() !== this.eventName.toLowerCase() : true;
+    return this.eventName ? this.confirmEventName !== this.eventName : true;
   })
 });


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4084 

#### Short description of what this resolves:

made event delete & tansfer confirmation case sensitive.
