### PR TITLE
fix: add default text for country field in session-speaker-form

### DIFF
--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -162,7 +162,9 @@
                                fullTextSearch=true}}
                   {{input type='hidden' id='speaker_country' value=data.speaker.country}}
                   <i class="dropdown icon"></i>
-                  <div class="default text">{{get data 'selectedCountry'}}</div>
+                  <div class="default text">
+                    {{t 'Select Country'}}
+                  </div>
                   <div class="menu">
                     {{#each countries as |country|}}
                       <div class="item" data-value="{{country.name}}">
@@ -260,7 +262,9 @@
                          fullTextSearch=true}}
                 {{input type='hidden' id=(if field.isRequired (concat 'speaker_' field.fieldIdentifier '_required') (concat 'speaker_' field.fieldIdentifier)) value=data.speaker.country}}
                 <i class="dropdown icon"></i>
-                <div class="default text">{{get data 'selectedCountry'}}</div>
+                <div class="default text">
+                  {{t 'Select Country'}}
+                </div>
                 <div class="menu">
                   {{#each countries as |country|}}
                     <div class="item" data-value="{{country.name}}">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4086 

#### Short description of what this resolves:
 Added default text for country field in session speaker form.

![Screenshot from 2020-02-15 07-16-25](https://user-images.githubusercontent.com/46647141/74579858-ef495900-4fc3-11ea-815a-a1494fb0c56b.png)

![Screenshot from 2020-02-15 07-20-41](https://user-images.githubusercontent.com/46647141/74579860-f2444980-4fc3-11ea-874c-edc4e8135fcd.png)
