### PR TITLE
chore: Silence the evented-api-usage warnings

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -2,6 +2,7 @@ window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember-routing.route-router' },
-    { handler: 'silence', matchId: 'ember-views.curly-components.jquery-element' } // Depreciating the jquery warnings until we have moved away from jquery or used native jquery in the app.
+    { handler: 'silence', matchId: 'ember-views.curly-components.jquery-element' }, // Silencing the jquery warnings until we have moved away from jquery or used native jquery in the app.
+    { handler: 'silence', matchId: 'ember-data.evented-api-usage' } // Silencing the Evented-API warnings until we have solved https://github.com/fossasia/open-event-frontend/issues/4024 .
   ]
 };


### PR DESCRIPTION
Logs are extremely hard to read with more than 50k lines.

Fixes issue https://github.com/fossasia/open-event-frontend/issues/4024