### PR TITLE
chore: Move tinyColorPicker from bower to npm

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -76,7 +76,7 @@ module.exports = function(defaults) {
   app.import('bower_components/wysihtml/dist/wysihtml-toolbar.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
-  app.import('bower_components/tinyColorPicker/jqColorPicker.min.js', {
+  app.import('node_modules/tinyColorPicker/jqColorPicker.min.js', {
     using: [{ transformation: 'fastbootShim' }]
   });
   app.import('bower_components/js-polyfills/xhr.js', {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "semantic-ui-ember": "3.0.3",
     "string_decoder": "^1.3.0",
     "style-loader": "^1.1.3",
+    "tinyColorPicker": "https://github.com/PitPik/tinyColorPicker#1.1.1",
     "torii": "^0.10.1",
     "typescript": "^3.7.5",
     "url-parse": "^1.4.7",
@@ -152,7 +153,6 @@
     "@bower_components/open-event-theme": "fossasia/open-event-theme#^0.0.6",
     "@bower_components/pace": "HubSpot/pace#^1.0.2",
     "@bower_components/semantic-ui-calendar": "mdehoog/semantic-ui-calendar#^0.0.8",
-    "@bower_components/tinyColorPicker": "PitPik/tinyColorPicker#^1.1.1",
     "@bower_components/wysihtml": "Voog/wysihtml#^0.5.5",
     "ua-parser-js": "^0.7.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,10 +863,6 @@
   version "0.0.8"
   resolved "https://codeload.github.com/mdehoog/semantic-ui-calendar/tar.gz/930d05ce0150c1fb04757dac82c0758a66419aca"
 
-"@bower_components/tinyColorPicker@PitPik/tinyColorPicker#^1.1.1":
-  version "1.1.1"
-  resolved "https://codeload.github.com/PitPik/tinyColorPicker/tar.gz/44ffe523b62975d400cc088736d17451e1d8cd7e"
-
 "@bower_components/wysihtml@Voog/wysihtml#^0.5.5":
   version "0.5.5"
   resolved "https://codeload.github.com/Voog/wysihtml/tar.gz/2578cede1de168a3c46ac9c0e7faa49ae533d3e9"
@@ -3305,7 +3301,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-body-parser@1.19.0, body-parser@^1.17.0, body-parser@^1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -15822,6 +15818,10 @@ tiny-lr@^1.1.1:
     livereload-js "^2.3.0"
     object-assign "^4.1.0"
     qs "^6.4.0"
+
+"tinyColorPicker@https://github.com/PitPik/tinyColorPicker#1.1.1":
+  version "1.1.1"
+  resolved "https://github.com/PitPik/tinyColorPicker#44ffe523b62975d400cc088736d17451e1d8cd7e"
 
 tmp@0.0.28:
   version "0.0.28"


### PR DESCRIPTION
Fix for #3957