### PR TITLE
chore: Remove ready event listener

### DIFF
--- a/app/models/event.js
+++ b/app/models/event.js
@@ -178,7 +178,4 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
     return groupBy(this.sessions.toArray(), 'data.state');
   }),
 
-  _ready: on('ready', function() {
-
-  })
 });

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -175,6 +175,6 @@ export default ModelBase.extend(CustomPrimaryKeyMixin, {
 
   sessionsByState: computed('sessions', function() {
     return groupBy(this.sessions.toArray(), 'data.state');
-  }),
+  })
 
 });

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -1,6 +1,5 @@
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { on } from '@ember/object/evented';
 import moment from 'moment';
 import attr from 'ember-data/attr';
 import ModelBase from 'open-event-frontend/models/base';

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,6 +1,5 @@
 import { or } from '@ember/object/computed';
 import { computed } from '@ember/object';
-import { on } from '@ember/object/evented';
 import { inject as service } from '@ember/service';
 import attr from 'ember-data/attr';
 import ModelBase from 'open-event-frontend/models/base';
@@ -98,11 +97,11 @@ export default ModelBase.extend({
   marketerEvents       : hasMany('event'),
   salesAdminEvents     : hasMany('event'),
 
-
-  _didUpdate: on('didUpdate', function(user) {
-    if (toString(user.id) === toString(this.authManager.currentUser.id)) {
-      user = this.store.peekRecord('user', user.id);
+  didUpdate() {
+    this._super(...arguments);
+    if (toString(this.id) === toString(this.authManager.currentUser.id)) {
+      const user = this.store.peekRecord('user', this.id);
       this.authManager.persistCurrentUser(user);
     }
-  })
+  }
 });


### PR DESCRIPTION
Deprecated and spams the logs, and a completely empty callback!

There should be a lint for this