### PR TITLE
chore: Change to angle bracket syntax for sort_by

### DIFF
--- a/app/templates/account/billing/invoices/list.hbs
+++ b/app/templates/account/billing/invoices/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen wide column">
-  {{tables/default columns=columns
-                  rows=model.eventInvoices.data
-                  currentPage=page
-                  pageSize=per_page
-                  searchQuery=search
-                  sortBy=sort_by
-                  sortDir=sort_dir
-                  metaData=model.eventInvoices.meta
-                  filterOptions=filterOptions
-                  widthConstraint="eq-container"
-                  resizeMode="fluid"
-                  fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.eventInvoices.data}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.eventInvoices.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/import.hbs
+++ b/app/templates/events/import.hbs
@@ -1,3 +1,3 @@
 <Events::EventImportSection @uploadFile={{action "uploadFile"}} @importStatus={{importStatus}} @importError={{importError}} @isImporting={{isImporting}} @file={{file}} />
 <div class="ui hidden divider"></div>
-<Events::ImportsHistorySection @data={{model.importJobs}} @columns={{columns}} @page={{page}} @per_page={{per_page}} @search={{search}} @sort_by={{sort_by}} @sort_dir={{sort_dir}} @filterOptions={{filterOptions}} />
+<Events::ImportsHistorySection @data={{this.model.importJobs}} @columns={{this.columns}} @page={{this.page}} @per_page={{this.per_page}} @search={{this.search}} @sort_by={{this.sort_by}} @sort_dir={{this.sort_dir}} @filterOptions={{this.filterOptions}} />

--- a/app/templates/events/list.hbs
+++ b/app/templates/events/list.hbs
@@ -1,13 +1,13 @@
-{{tables/default  columns=columns
-                  rows=model.data
-                  currentPage=page
-                  pageSize=per_page
-                  searchQuery=search
-                  sortBy=sort_by
-                  sortDir=sort_dir
-                  metaData=model.meta
-                  filterOptions=filterOptions
-                  widthConstraint="eq-container"
-                  resizeMode="fluid"
-                  fillMode="equal-column"
-}}
+<Tables::Default
+  @columns={{this.columns}}
+  @rows={{this.model.data}}
+  @currentPage={{this.page}}
+  @pageSize={{this.per_page}}
+  @searchQuery={{this.search}}
+  @sortBy={{this.sort_by}}
+  @sortDir={{this.sort_dir}}
+  @metaData={{this.model.meta}}
+  @filterOptions={{this.filterOptions}}
+  @widthConstraint="eq-container"
+  @resizeMode="fluid"
+  @fillMode="equal-column" />

--- a/app/templates/events/view/index.hbs
+++ b/app/templates/events/view/index.hbs
@@ -1,20 +1,20 @@
 <div class="ui grid stackable">
   <div class="eight wide column">
-    <Events::View::Overview::EventSetupChecklist @data={{model}} />
+    <Events::View::Overview::EventSetupChecklist @data={{this.model}} />
   </div>
   <div class="eight wide column">
-    <Events::View::Overview::GeneralInfo @data={{model}} />
+    <Events::View::Overview::GeneralInfo @data={{this.model}} />
   </div>
   <div class="eight wide column">
-    <Events::View::Overview::ManageRoles @data={{model}} />
+    <Events::View::Overview::ManageRoles @data={{this.model}} />
   </div>
   <div class="eight wide column">
-    <Events::View::Overview::EventSponsors @data={{model.sponsors}} @columns={{columns}} @page={{page}} @per_page={{per_page}} @search={{search}} @sort_by={{sort_by}} @sort_dir={{sort_dir}} @filterOptions={{filterOptions}} />
+    <Events::View::Overview::EventSponsors @data={{this.model.sponsors}} @columns={{this.columns}} @page={{this.page}} @per_page={{this.per_page}} @search={{this.search}} @sort_by={{this.sort_by}} @sort_dir={{this.sort_dir}} @filterOptions={{this.filterOptions}} />
   </div>
   <div class="eight wide column">
     <Events::View::Overview::EventApps />
   </div>
   <div class="eight wide column">
-    <Events::View::Overview::EventTickets @data={{model}} />
+    <Events::View::Overview::EventTickets @data={{this.model}} />
   </div>
 </div>

--- a/app/templates/events/view/sessions/list.hbs
+++ b/app/templates/events/view/sessions/list.hbs
@@ -1,16 +1,16 @@
 <div class="sixteen wide column">
-  {{tables/default  columns=columns
-                    rows=model.sessions.data
-                    feedbacks=model.feedbacks
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.sessions.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.sessions.data}}
+    @feedbacks={{this.model.feedbacks}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.sessions.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/view/speakers/list.hbs
+++ b/app/templates/events/view/speakers/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen wide column">
-  {{tables/default  columns=columns
-                    rows=model.data
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.data}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/view/tickets/access-codes/list.hbs
+++ b/app/templates/events/view/tickets/access-codes/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen wide column">
-  {{tables/default  columns=columns
-                    rows=model.data
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.data}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/view/tickets/attendees/list.hbs
+++ b/app/templates/events/view/tickets/attendees/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen column wide">
-  {{tables/default  columns=columns
-                    rows=model.data
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.data}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/view/tickets/discount-codes/list.hbs
+++ b/app/templates/events/view/tickets/discount-codes/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen wide column">
-  {{tables/default  columns=columns
-                    rows=model.data
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.model.data}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>

--- a/app/templates/events/view/tickets/orders/list.hbs
+++ b/app/templates/events/view/tickets/orders/list.hbs
@@ -1,15 +1,15 @@
 <div class="sixteen column wide">
-  {{tables/default  columns=columns
-                    rows=rows
-                    currentPage=page
-                    pageSize=per_page
-                    searchQuery=search
-                    sortBy=sort_by
-                    sortDir=sort_dir
-                    metaData=model.meta
-                    filterOptions=filterOptions
-                    widthConstraint="eq-container"
-                    resizeMode="fluid"
-                    fillMode="equal-column"
-  }}
+  <Tables::Default
+    @columns={{this.columns}}
+    @rows={{this.rows}}
+    @currentPage={{this.page}}
+    @pageSize={{this.per_page}}
+    @searchQuery={{this.search}}
+    @sortBy={{this.sort_by}}
+    @sortDir={{this.sort_dir}}
+    @metaData={{this.model.meta}}
+    @filterOptions={{this.filterOptions}}
+    @widthConstraint="eq-container"
+    @resizeMode="fluid"
+    @fillMode="equal-column" />
 </div>


### PR DESCRIPTION
{{sort_by}} was being treated as a composable helper
and thus all builds like #4301 and mainly #4298 were breaking
Some changes were reverted in #4322, but changing to
{{this.sort_by}} makes it unambiguous and also octane
compatible