### PR TITLE
fixed url overflow in event export section

### DIFF
--- a/app/styles/components/events/view/export.scss
+++ b/app/styles/components/events/view/export.scss
@@ -32,3 +32,7 @@
 .url {
   padding: 0 1em !important;
 }
+
+.segment pre {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
Fixes #4104 

URL segment in the export section of an event page was overflowing, it has now been fixed.

![image](https://user-images.githubusercontent.com/6567844/81711289-cd049180-9473-11ea-9975-ee4aaa64c5a6.png)


Have a nice day :")