### PR TITLE
fix: url overflow in event export section

### DIFF
--- a/app/templates/components/events/view/export/api-response.hbs
+++ b/app/templates/components/events/view/export/api-response.hbs
@@ -33,7 +33,7 @@
 </div>
 <UiPopup @on="click" @content={{t "Link copied to clipboard"}} @position="bottom right">
   <div class="ui secondary segment url">
-    <CopyButton @clipboardText={{this.displayUrl}} @tagName={{null}}>
+    <CopyButton @clipboardText={{this.displayUrl}} @tagName={{null}} class="x-scrollable">
       <pre>{{this.displayUrl}}</pre>
     </CopyButton>
   </div>
@@ -41,6 +41,6 @@
 <div class="ui secondary header">
   {{t 'Response'}}
 </div>
-<div class="ui {{if this.isLoading 'loading'}} secondary segment response">
+<div class="ui {{if this.isLoading 'loading'}} secondary segment response x-scrollable y-scrollable">
   <pre class="api-response">{{this.json}}</pre>
 </div>

--- a/app/templates/components/events/view/export/download-common.hbs
+++ b/app/templates/components/events/view/export/download-common.hbs
@@ -7,7 +7,7 @@
     ' version of the schedule will be available at:'}}
   </div>
 </h3>
-<div class="ui secondary segment url">
+<div class="ui secondary segment url x-scrollable">
   <pre>{{this.displayUrl}}</pre>
 </div>
 <a class="ui link" href="#" onclick={{action 'startExportTask'}}> {{t 'Alternatively, you can download the'}} {{this.downloadType}} {{t ' here'}}</a>


### PR DESCRIPTION
Fixes #4104

URL segments in the export section of an event page were overflowing, they have now been fixed.

![Screenshot (47)](https://user-images.githubusercontent.com/6567844/82204755-bd6aca00-9905-11ea-9ce7-baf92f543fda.png)
![Screenshot (48)](https://user-images.githubusercontent.com/6567844/82204759-bfcd2400-9905-11ea-8b79-30699110f072.png)
