### PR TITLE
feat: Parallelize event page fetch

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -123,23 +123,23 @@ export default Component.extend(FormMixin, {
         this.set('invalidPromotionalCode', true);
       }
       try {
-        let discountCode = await this.store.queryRecord('discount-code', { eventIdentifier: this.event.id, code: this.promotionalCode });
-        let discountCodeEvent = await discountCode.get('event');
+        const discountCode = await this.store.queryRecord('discount-code', { eventIdentifier: this.event.id, code: this.promotionalCode, include: 'event,tickets' });
+        const discountCodeEvent = await discountCode.event;
         if (this.currentEventIdentifier === discountCodeEvent.identifier) {
-          let discountType = discountCode.get('type');
-          let discountValue = discountCode.get('value');
+          const discountType = discountCode.type;
+          const discountValue = discountCode.value;
           this.order.set('discountCode', discountCode);
-          let tickets = await discountCode.get('tickets');
+          const tickets = await discountCode.tickets;
           tickets.forEach(ticket => {
-            let ticketPrice = ticket.get('price');
-            let taxRate = ticket.get('event.tax.rate');
-            let discount = discountType === 'amount' ? Math.min(ticketPrice, discountValue) : ticketPrice * (discountValue / 100);
+            const ticketPrice = ticket.price;
+            const taxRate = ticket.get('event.tax.rate');
+            const discount = discountType === 'amount' ? Math.min(ticketPrice, discountValue) : ticketPrice * (discountValue / 100);
             ticket.set('discount', discount);
             if (taxRate && !this.showTaxIncludedMessage) {
-              let ticketPriceWithTax = (ticketPrice - ticket.discount) * (1 + taxRate / 100);
+              const ticketPriceWithTax = (ticketPrice - ticket.discount) * (1 + taxRate / 100);
               ticket.set('ticketPriceWithTax', ticketPriceWithTax);
             } else if (taxRate && this.showTaxIncludedMessage) {
-              let includedTaxAmount = (taxRate * (ticketPrice - discount)) / (100 + taxRate);
+              const includedTaxAmount = (taxRate * (ticketPrice - discount)) / (100 + taxRate);
               ticket.set('includedTaxAmount', includedTaxAmount);
             }
             this.discountedTickets.addObject(ticket);

--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -4,6 +4,7 @@ import Route from '@ember/routing/route';
 import moment from 'moment';
 import { set } from '@ember/object';
 import ENV from 'open-event-frontend/config/environment';
+import { allSettled } from 'rsvp';
 
 @classic
 export default class IndexRoute extends Route {
@@ -13,8 +14,6 @@ export default class IndexRoute extends Route {
   async model() {
     const event = this.modelFor('public');
     const ticketsPromise = event.query('tickets', {
-      reload: true,
-
       filter: [
         {
           and: [
@@ -45,7 +44,8 @@ export default class IndexRoute extends Route {
     const sponsorsPromise = event.get('sponsors');
     const taxPromise = event.get('tax');
 
-    const [tickets, featuredSpeakers, sponsors, tax] = await Promise.all([ticketsPromise, featuredSpeakersPromise, sponsorsPromise, taxPromise]);
+    const [tickets, featuredSpeakers, sponsors, tax] = (await allSettled([ticketsPromise, featuredSpeakersPromise, sponsorsPromise, taxPromise]))
+      .map(result => result.value);
 
     return {
       event,


### PR DESCRIPTION
Fetch infos about tickets, speakers, sessions, etc parallely.
Should be ideally done in their own components but OK for now
Also include event and tickets in discount code query