### PR TITLE
feat: parallelize event overview api requests

### DIFF
--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
+import { allSettled } from 'rsvp';
 import EmberTableRouteMixin from 'open-event-frontend/mixins/ember-table-route';
 
 export default class extends Route.extend(EmberTableRouteMixin) {
@@ -25,7 +25,7 @@ export default class extends Route.extend(EmberTableRouteMixin) {
     const rolesPromise = this.store.findAll('role');
 
     const [sponsors, roleInvites, sessionTypes, socialLinks,
-      statistics, orderStat, tickets, roles] = await RSVP.allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
+      statistics, orderStat, tickets, roles] = await allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
       statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise]);
 
 

--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -25,8 +25,8 @@ export default class extends Route.extend(EmberTableRouteMixin) {
     const rolesPromise = this.store.findAll('role');
 
     const [sponsors, roleInvites, sessionTypes, socialLinks,
-      statistics, orderStat, tickets, roles] = await allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
-      statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise]).map(result => result.value);
+      statistics, orderStat, tickets, roles] = (await allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
+      statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise])).map(result => result.value);
 
 
     return {

--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -26,7 +26,7 @@ export default class extends Route.extend(EmberTableRouteMixin) {
 
     const [sponsors, roleInvites, sessionTypes, socialLinks,
       statistics, orderStat, tickets, roles] = await allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
-      statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise]);
+      statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise]).map(result => result.value);
 
 
     return {

--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 import EmberTableRouteMixin from 'open-event-frontend/mixins/ember-table-route';
 
 export default class extends Route.extend(EmberTableRouteMixin) {
@@ -14,18 +15,30 @@ export default class extends Route.extend(EmberTableRouteMixin) {
       'page[number]' : params.per_page || 1
     };
     queryString = this.applySortFilters(queryString, params);
+    const sponsorsPromise = this.asArray(eventDetails.query('sponsors', {}, queryString));
+    const roleInvitesPromise = eventDetails.query('roleInvites', {});
+    const sessionTypesPromise = eventDetails.query('sessionTypes', {});
+    const socialLinksPromise = eventDetails.query('socialLinks', {});
+    const statisticsPromise = eventDetails.query('generalStatistics', {});
+    const orderStatPromise = eventDetails.query('orderStatistics', {});
+    const ticketsPromise = eventDetails.query('tickets', {});
+    const rolesPromise = this.store.findAll('role');
+
+    const [sponsors, roleInvites, sessionTypes, socialLinks,
+      statistics, orderStat, tickets, roles] = await RSVP.allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, socialLinksPromise,
+      statisticsPromise, orderStatPromise, ticketsPromise, rolesPromise]);
 
 
     return {
-      event        : await eventDetails,
-      sponsors     : await this.asArray(eventDetails.query('sponsors', {}, queryString)),
-      roleInvites  : await eventDetails.query('roleInvites', {}),
-      sessionTypes : await eventDetails.query('sessionTypes', {}),
-      socialLinks  : await eventDetails.query('socialLinks', {}),
-      statistics   : await eventDetails.query('generalStatistics', {}),
-      orderStat    : await eventDetails.query('orderStatistics', {}),
-      tickets      : await eventDetails.query('tickets', {}),
-      roles        : await this.store.findAll('role')
+      event: eventDetails,
+      sponsors,
+      roleInvites,
+      sessionTypes,
+      socialLinks,
+      statistics,
+      orderStat,
+      tickets,
+      roles
     };
   }
 }


### PR DESCRIPTION
Reduces event overview page load time significantly, removes redundant promise for event details, as ember resolves models hierarchically, it's already resolved before the hook is called.

Fix for #4099