### PR TITLE
fix: Properly format money everywhere

### DIFF
--- a/app/initializers/accounting.js
+++ b/app/initializers/accounting.js
@@ -1,0 +1,8 @@
+import { currency } from 'accounting/settings';
+
+export default {
+  name: 'accounting.js',
+  initialize() {
+    currency.symbol = '';
+  }
+};

--- a/app/templates/admin/sales/discounted-events.hbs
+++ b/app/templates/admin/sales/discounted-events.hbs
@@ -63,19 +63,19 @@
                 {{entry.sales.completed.ticket_count}}
               </td>
               <td class="right aligned">
-                {{currency-symbol this.order.paymentCurrency}} {{format-number entry.sales.completed.sales_total}}
+                {{currency-symbol this.order.paymentCurrency}} {{format-money entry.sales.completed.sales_total}}
               </td>
               <td class="right aligned">
                 {{entry.sales.placed.ticket_count}}
               </td>
               <td class="right aligned">
-                {{currency-symbol this.order.paymentCurrency}} {{format-number entry.sales.places.sales_total}}
+                {{currency-symbol this.order.paymentCurrency}} {{format-money entry.sales.places.sales_total}}
               </td>
               <td class="right aligned">
                 {{entry.sales.pending.ticket_count}}
               </td>
               <td class="right aligned">
-                {{currency-symbol this.order.paymentCurrency}} {{format-number entry.sales.pending.sales_total}}
+                {{currency-symbol this.order.paymentCurrency}} {{format-money entry.sales.pending.sales_total}}
               </td>
             </tr>
           {{/each}}
@@ -91,19 +91,19 @@
               {{totalCompletedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalCompletedSales}}
+              US$ {{format-money totalCompletedSales}}
             </th>
             <th class="right aligned">
               {{totalPlacedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPlacedSales}}
+              US$ {{format-money totalPlacedSales}}
             </th>
             <th class="right aligned">
               {{totalPendingTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPendingSales}}
+              US$ {{format-money totalPendingSales}}
             </th>
           </tr>
         </tfoot> --}}

--- a/app/templates/admin/sales/index.hbs
+++ b/app/templates/admin/sales/index.hbs
@@ -28,11 +28,11 @@
               <td>{{entry.name}}</td>
               <td>{{moment-format entry.startsAt 'ddd, MMM DD \at h:mm A'}}</td>
               <td class="right aligned">{{entry.sales.completed.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-number entry.sales.completed.sales_total}}</td>
+              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-money entry.sales.completed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.placed.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-number entry.sales.placed.sales_total}}</td>
+              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-money entry.sales.placed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.pending.ticket_count}}</td>
-              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-number entry.sales.pending.sales_total}}</td>
+              <td class="right aligned">{{currency-symbol entry.paymentCurrency}} {{format-money entry.sales.pending.sales_total}}</td>
             </tr>
           {{/each}}
         </tbody>
@@ -45,19 +45,19 @@
               {{totalCompletedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalCompletedSales}}
+              US$ {{format-money totalCompletedSales}}
             </th>
             <th class="right aligned">
               {{totalPlacedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPlacedSales}}
+              US$ {{format-money totalPlacedSales}}
             </th>
             <th class="right aligned">
               {{totalPendingTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPendingSales}}
+              US$ {{format-money totalPendingSales}}
             </th>
           </tr>
         </tfoot> --}}

--- a/app/templates/admin/sales/locations.hbs
+++ b/app/templates/admin/sales/locations.hbs
@@ -26,11 +26,11 @@
             <tr>
               <td>{{entry.locationName}}</td>
               <td class="right aligned">{{entry.sales.completed.ticket_count}}</td>
-              <td class="right aligned">US$ {{format-number entry.sales.completed.sales_total}}</td>
+              <td class="right aligned">US$ {{format-money entry.sales.completed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.placed.ticket_count}}</td>
-              <td class="right aligned">US$ {{format-number entry.sales.placed.sales_total}}</td>
+              <td class="right aligned">US$ {{format-money entry.sales.placed.sales_total}}</td>
               <td class="right aligned">{{entry.sales.pending.ticket_count}}</td>
-              <td class="right aligned">US$ {{format-number entry.sales.pending.sales_total}}</td>
+              <td class="right aligned">US$ {{format-money entry.sales.pending.sales_total}}</td>
             </tr>
           {{/each}}
         </tbody>
@@ -38,11 +38,11 @@
           <tr>
             <th><span class="weight-600">{{t 'Total'}}</span></th>
             <th class="right aligned">{{totalCompletedTickets}}</th>
-            <th class="right aligned">US$ {{format-number totalCompletedSales}}</th>
+            <th class="right aligned">US$ {{format-money totalCompletedSales}}</th>
             <th class="right aligned">{{totalPlacedTickets}}</th>
-            <th class="right aligned">US$ {{format-number totalPlacedSales}}</th>
+            <th class="right aligned">US$ {{format-money totalPlacedSales}}</th>
             <th class="right aligned">{{totalPendingTickets}}</th>
-            <th class="right aligned">US$ {{format-number totalPendingSales}}</th>
+            <th class="right aligned">US$ {{format-money totalPendingSales}}</th>
           </tr>
         </tfoot> --}}
       </table>

--- a/app/templates/admin/sales/marketer.hbs
+++ b/app/templates/admin/sales/marketer.hbs
@@ -25,7 +25,7 @@
                 {{entry.sales.completed.ticket_count}}
               </td>
               <td class="right aligned">
-                US$ {{format-number entry.sales.completed.sales_total}}
+                US$ {{format-money entry.sales.completed.sales_total}}
               </td>
             </tr>
           {{/each}}
@@ -38,8 +38,8 @@
               </span>
             </th>
             <th class="right aligned">{{ticketsTotal}}</th>
-            <th class="right aligned">US$ {{format-number salesTotal}}</th>
-            <th class="right aligned">US$ {{format-number discountsTotal}}</th>
+            <th class="right aligned">US$ {{format-money salesTotal}}</th>
+            <th class="right aligned">US$ {{format-money discountsTotal}}</th>
           </tr>
         </tfoot> --}}
       </table>

--- a/app/templates/admin/sales/organizers.hbs
+++ b/app/templates/admin/sales/organizers.hbs
@@ -56,19 +56,19 @@
                 {{entry.sales.completed.ticket_count}}
               </td>
               <td class="right aligned">
-                US$ {{format-number entry.sales.completed.sales_total}}
+                US$ {{format-money entry.sales.completed.sales_total}}
               </td>
               <td class="right aligned">
                 {{entry.sales.placed.ticket_count}}
               </td>
               <td class="right aligned">
-                US$ {{format-number entry.sales.places.sales_total}}
+                US$ {{format-money entry.sales.places.sales_total}}
               </td>
               <td class="right aligned">
                 {{entry.sales.pending.ticket_count}}
               </td>
               <td class="right aligned">
-                US$ {{format-number entry.sales.pending.sales_total}}
+                US$ {{format-money entry.sales.pending.sales_total}}
               </td>
             </tr>
           {{/each}}
@@ -84,19 +84,19 @@
               {{totalCompletedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalCompletedSales}}
+              US$ {{format-money totalCompletedSales}}
             </th>
             <th class="right aligned">
               {{totalPlacedTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPlacedSales}}
+              US$ {{format-money totalPlacedSales}}
             </th>
             <th class="right aligned">
               {{totalPendingTickets}}
             </th>
             <th class="right aligned">
-              US$ {{format-number totalPendingSales}}
+              US$ {{format-money totalPendingSales}}
             </th>
           </tr>
         </tfoot> --}}

--- a/app/templates/admin/sales/revenue.hbs
+++ b/app/templates/admin/sales/revenue.hbs
@@ -44,13 +44,13 @@
                 {{order.ticketCount}}
               </td>
               <td class="right aligned">
-                {{format-number order.feePercentage}}%
+                {{format-money order.feePercentage}}%
                 {{#if order.maximumFee}}
                   <span class="item muted text">[{{t 'Max.'}} {{currency-symbol order.paymentCurrency}} {{order.maximumFee}}]</span>
                 {{/if}}
               </td>
               <td class="right aligned">
-                {{currency-symbol order.paymentCurrency}} {{format-number order.revenue}}
+                {{currency-symbol order.paymentCurrency}} {{format-money order.revenue}}
               </td>
             </tr>
           {{/each}}
@@ -66,7 +66,7 @@
               {{ticketsTotal}}
             </th>
             <th colspan="2" class="right aligned">
-              US$ {{format-number revenueTotal}}
+              US$ {{format-money revenueTotal}}
             </th>
           </tr>
         </tfoot> --}}

--- a/app/templates/components/event-invoice/invoice-summary.hbs
+++ b/app/templates/components/event-invoice/invoice-summary.hbs
@@ -28,7 +28,7 @@
         <td>{{this.event.name}}</td>
         <td>{{moment-format this.data.createdAt 'MM/DD/YYYY'}}</td>
         <td>{{moment-format this.data.completedAt 'MM/DD/YYYY'}}</td>
-        <td>{{currency-symbol this.eventCurrency}} {{format-number this.data.amount}}</td>
+        <td>{{currency-symbol this.eventCurrency}} {{format-money this.data.amount}}</td>
       </tr>
     </tbody>
   </table>

--- a/app/templates/components/events/view/overview/event-tickets.hbs
+++ b/app/templates/components/events/view/overview/event-tickets.hbs
@@ -15,7 +15,7 @@
       </tr>
       <tr>
         <td>{{t 'Sales (amount)'}}</td>
-        <td>{{currency-symbol this.data.event.paymentCurrency}} {{format-number this.sales}}</td>
+        <td>{{currency-symbol this.data.event.paymentCurrency}} {{format-money this.sales}}</td>
       </tr>
     </tbody>
   </table>

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -75,10 +75,10 @@
                 </div>
               </td>
               {{#if this.data.discountCode}}
-                <td>{{currency-symbol this.eventCurrency}} {{format-number ticket.price}}</td>
-                <td>{{currency-symbol this.eventCurrency}} {{format-number ticket.discount}}</td>
+                <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.price}}</td>
+                <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.discount}}</td>
                 <td>
-                  {{currency-symbol this.eventCurrency}} {{format-number (mult (sub ticket.price ticket.discount) (ticket-attendees this.data.attendees ticket.attendees))}}
+                  {{currency-symbol this.eventCurrency}} {{format-money (mult (sub ticket.price ticket.discount) (ticket-attendees this.data.attendees ticket.attendees))}}
                 </td>
               {{/if}}
               <td>{{ticket-attendees this.data.attendees ticket.attendees}}</td>
@@ -88,9 +88,9 @@
                   {{ticket.name}}
                 </div>
               </td>
-              <td>{{currency-symbol this.eventCurrency}} {{format-number ticket.price}}</td>
+              <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.price}}</td>
               {{#if this.data.discountCode}}
-                <td>{{currency-symbol this.eventCurrency}} {{format-number ticket.discount}}</td>
+                <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.discount}}</td>
               {{/if}}
               <td>{{ticket-attendees this.data.attendees ticket.attendees}}</td>
               {{#if this.event.tax}}
@@ -107,7 +107,7 @@
                 </td>
               {{/if}}
               <td>
-                {{currency-symbol this.eventCurrency}} {{format-number (mult (sub ticket.price ticket.discount) (ticket-attendees this.data.attendees ticket.attendees))}}
+                {{currency-symbol this.eventCurrency}} {{format-money (mult (sub ticket.price ticket.discount) (ticket-attendees this.data.attendees ticket.attendees))}}
               </td>
             {{/if}}
               
@@ -136,7 +136,7 @@
               </div>
             </th>
             <th colspan="4">
-              {{currency-symbol this.eventCurrency}} {{format-number this.data.amount}}
+              {{currency-symbol this.eventCurrency}} {{format-money this.data.amount}}
             </th>
           </tr>
         </tfoot>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -32,19 +32,19 @@
             {{#if ticket.discount}}
               <td>
                 <div id="{{ticket.id}}_price" class="strike text">
-                  {{this.eventCurrency}} {{format-number ticket.price}}
+                  {{this.eventCurrency}} {{format-money ticket.price}}
                 </div>
                 <div id="{{ticket.id}}_discount">
-                  {{this.eventCurrency}} {{format-number (sub ticket.price ticket.discount)}}
+                  {{this.eventCurrency}} {{format-money (sub ticket.price ticket.discount)}}
                   {{#if this.taxInfo}}
                     {{#if this.showTaxIncludedMessage}}
                       <small class="ui gray-text small">
-                        {{t 'includes'}} {{this.eventCurrency}} {{format-number ticket.includedTaxAmount}}
+                        {{t 'includes'}} {{this.eventCurrency}} {{format-money ticket.includedTaxAmount}}
                       </small>
                     {{else}}
                       <small class="ui gray-text small">
                         + {{this.eventCurrency}}
-                        {{format-number (add (sub ticket.ticketPriceWithTax ticket.price) ticket.discount)}}
+                        {{format-money (add (sub ticket.ticketPriceWithTax ticket.price) ticket.discount)}}
                       </small>
                     {{/if}}
                     <div>
@@ -65,16 +65,16 @@
                       @value={{ticket.price}} /><br>
                   </div>
                 {{else}}
-                  {{this.eventCurrency}} {{format-number ticket.price}}
+                  {{this.eventCurrency}} {{format-money ticket.price}}
                 {{/if}}
                 {{#if (and this.taxInfo (not-eq ticket.type 'free'))}}
                   {{#if this.showTaxIncludedMessage}}
                     <small class="ui gray-text small">
-                      {{t 'includes'}} {{this.eventCurrency}} {{format-number ticket.includedTaxAmount}}
+                      {{t 'includes'}} {{this.eventCurrency}} {{format-money ticket.includedTaxAmount}}
                     </small>
                   {{else}}
                     <small class="ui gray-text small">
-                      + {{this.eventCurrency}} {{format-number (sub ticket.ticketPriceWithTax ticket.price)}}
+                      + {{this.eventCurrency}} {{format-money (sub ticket.ticketPriceWithTax ticket.price)}}
                     </small>
                   {{/if}}
                   <div>
@@ -107,9 +107,9 @@
             <td id='{{ticket.id}}_subtotal' class="ui right aligned">
               {{#if this.taxInfo}}
                 {{this.eventCurrency}}
-                {{format-number (mult (sub ticket.ticketPriceWithTax ticket.discount) ticket.orderQuantity)}}
+                {{format-money (mult (sub ticket.ticketPriceWithTax ticket.discount) ticket.orderQuantity)}}
               {{else}}
-                {{this.eventCurrency}} {{format-number (mult (sub ticket.price ticket.discount) ticket.orderQuantity)}}
+                {{this.eventCurrency}} {{format-money (mult (sub ticket.price ticket.discount) ticket.orderQuantity)}}
               {{/if}}
             </td>
           </tr>
@@ -124,7 +124,7 @@
         <th></th>
         <th colspan="4">
           <div class="ui right aligned small primary icon">
-            {{t 'Total'}}: {{this.eventCurrency}} {{format-number this.total}}
+            {{t 'Total'}}: {{this.eventCurrency}} {{format-money this.total}}
           </div>
         </th>
       </tr>

--- a/app/templates/components/ui-table/cell/admin/sales/status/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/admin/sales/status/cell-amount.hbs
@@ -1,3 +1,3 @@
 <span>
-  US$ {{format-number this.record}}
+  US$ {{format-money this.record}}
 </span>

--- a/app/templates/components/ui-table/cell/events/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/events/cell-amount.hbs
@@ -1,1 +1,1 @@
-{{currency-symbol this.extraRecords.event.paymentCurrency}} {{format-number this.record}}
+{{currency-symbol this.extraRecords.event.paymentCurrency}} {{format-money this.record}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-price.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-price.hbs
@@ -1,5 +1,5 @@
 <div class="weight-400">
-  {{currency-symbol this.extraRecords.event.paymentCurrency}}  {{format-number this.record}}
+  {{currency-symbol this.extraRecords.event.paymentCurrency}}  {{format-money this.record}}
 </div>
 {{#if this.extraRecords.discountCode.code}}
   <div class="ui mini yellow label">

--- a/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-price.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-price.hbs
@@ -1,1 +1,1 @@
-{{currency-symbol this.paymentCurrency}} {{format-number this.record.price}}
+{{currency-symbol this.paymentCurrency}} {{format-money this.record.price}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/cell-add-order-total.hbs
@@ -1,1 +1,1 @@
-{{currency-symbol this.paymentCurrency}} {{format-number (mult this.record.orderQuantity this.record.price)}}
+{{currency-symbol this.paymentCurrency}} {{format-money (mult this.record.orderQuantity this.record.price)}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
@@ -1,5 +1,5 @@
 <div class="weight-400">
-  {{currency-symbol this.extraRecords.event.paymentCurrency}}  {{format-number this.record}}
+  {{currency-symbol this.extraRecords.event.paymentCurrency}}  {{format-money this.record}}
 </div>
 {{#if this.extraRecords.discountCode.code}}
   <div class="ui mini yellow label">

--- a/app/templates/event-invoice/review.hbs
+++ b/app/templates/event-invoice/review.hbs
@@ -65,7 +65,7 @@
                 <strong>{{t 'Date Issued'}}:</strong> {{moment-format this.model.createdAt 'MM/DD/YYYY'}} 
               </div>
               <div class="item">
-                <strong>{{t 'Total Invoice Amount'}}:</strong> {{currency-symbol this.model.event.paymentCurrency}} {{format-number this.model.amount}}
+                <strong>{{t 'Total Invoice Amount'}}:</strong> {{currency-symbol this.model.event.paymentCurrency}} {{format-money this.model.amount}}
               </div>
             </div>
           </div>


### PR DESCRIPTION
For some reason, `format-number` was used to represent money in the app which removed any decimal part and rounded it off to integer

Before:
![image](https://user-images.githubusercontent.com/3874064/83363247-796fce80-a3b5-11ea-8df8-d42eca248904.png)

After:
![image](https://user-images.githubusercontent.com/3874064/83363212-39105080-a3b5-11ea-9bc4-284615b5c5f7.png)
