### PR TITLE
fix: Prevent mutating data in sponsors event wizard page

### DIFF
--- a/app/routes/events/view/edit/sponsors.js
+++ b/app/routes/events/view/edit/sponsors.js
@@ -9,8 +9,11 @@ export default class SponsorsRoute extends Route.extend(EventWizardMixin) {
   }
 
   async model() {
-    let data = this.modelFor('events.view.edit');
-    data.sponsors = await data.event.get('sponsors');
-    return data;
+    const data = this.modelFor('events.view.edit');
+    const sponsors = await data.event.get('sponsors');
+    return {
+      sponsors,
+      ...data
+    };
   }
 }


### PR DESCRIPTION
Due to mutation, it was throwing an error
if switched to more than once

Fixes #4501 