### PR TITLE
fix: Assign custom form name on init

### DIFF
--- a/app/models/custom-form.js
+++ b/app/models/custom-form.js
@@ -84,6 +84,12 @@ export default ModelBase.extend({
     ageGroup        : 'Age Group'
   },
 
+  ready() {
+    if (!this.name) {
+      this.name = this[this.form][this.fieldIdentifier];
+    }
+  },
+
   identifierPath: computed('isComplex', function() {
     return !this.isComplex ? this.fieldIdentifier : 'complexFieldValues.' + this.fieldIdentifier;
   }),


### PR DESCRIPTION
New field 'name' was added in custom form and it is
populated from backend, so new custom forms in
frontend were initialized without any name because
the previous logic of loading name as custom property
was removed. This is a temporary fix since custom forms
will start to be created on backend instead of frontend

Fixes #4506