### PR TITLE
feat: Show complex custom form values for attendee info

### DIFF
--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -25,6 +25,9 @@
                 {{else if (eq field.type 'select')}}
                   <span>{{get holder field.fieldIdentifier}}</span>
                 {{/if}}
+                {{#if field.isComplex}}
+                  <span>{{get holder.complexFieldValues field.fieldIdentifier}}</span>
+                {{/if}}
               </div>
             {{/if}}
           {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4519 

#### Short description of what this resolves:
Complex custom form values was not visible in attendee information.

#### Changes proposed in this pull request:
Make complex custom form values visible by checking if that particular field is complex or not.
![complex-field-value-visible](https://user-images.githubusercontent.com/43299408/87242645-43aa1500-c44c-11ea-9e1d-08bfa694e256.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
