### PR TITLE
fix: Social icons on public event page

### DIFF
--- a/app/styles/partials/colors.scss
+++ b/app/styles/partials/colors.scss
@@ -6,6 +6,14 @@ i.facebook {
   }
 }
 
+i.youtube {
+  &:not(.colored) {
+    &:not(.inverted) {
+      color: #d60303;
+    }
+  }
+}
+
 i.twitter {
   &:not(.colored) {
     &:not(.inverted) {
@@ -48,6 +56,10 @@ i.reddit {
 
 i.facebook.colored.inverted {
   background-color: #3b5998 !important;
+}
+
+i.youtube.colored.inverted {
+  background-color: #d60303 !important;
 }
 
 i.twitter.colored.inverted {

--- a/app/templates/components/public/social-links.hbs
+++ b/app/templates/components/public/social-links.hbs
@@ -9,7 +9,7 @@
   {{/if}}
   {{#each this.socialLinks as |socialLink|}}
     <div class="item">
-      <i class="share square fitted {{socialLink.normalizedName}} disabled icon"></i>
+      <i class="fitted {{socialLink.normalizedName}} disabled icon"></i>
       <div class="content">
         <a href="{{socialLink.link}}" target="_blank" rel="noopener nofollow">{{socialLink.name}}</a>
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4551 

#### Short description of what this resolves:
Social icons not there on public event page

#### Changes proposed in this pull request:
By removing extra classes like `share` and `square`, icons are working fine.
![Social Icons](https://imgur.com/ORprPIZl.png "Social Icons")

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
