### PR TITLE
fix: Use checkbox for adding new proposal in create speaker form

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -542,12 +542,6 @@ export default Component.extend(FormMixin, {
       this.onValid(() => {
         this.sendAction('save');
       });
-    },
-
-
-    toggleNewSessionSelected(value) {
-      this.set('sessionDetails', false);
-      this.set('newSessionSelected', value);
     }
   },
   didInsertElement() {

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -393,13 +393,14 @@
       Or
     </div>
     <div class="field">
-      <UiRadio
+      <UiCheckbox
         @name="sessionDetails"
+        @class="toggle"
+        @checked={{addNewSession}}
         @label={{t "Add a new Proposal"}}
-        @value={{false}}
-        @onChange={{action "toggleNewSessionSelected" true}} />
+        @onChange={{action (mut addNewSession)}}/>
     </div>
-    {{#if this.shouldShowNewSessionDetails}}
+    {{#if addNewSession}}
       {{#each this.allFields.session as |field|}}
         {{#if field.isIncluded}}
           <div class="field">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4027 

#### Short description of what this resolves:
In create speaker form we can't check and uncheck add a new proposal

#### Changes proposed in this pull request:
Use checkbox for add new proposal 
![checkbox-add-proposal](https://user-images.githubusercontent.com/43299408/87766408-be04db80-c836-11ea-8c7e-54ef6ce482bc.gif)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
