### PR TITLE
fix: Disallow session/speaker edit after cfs closed

### DIFF
--- a/app/templates/my-sessions/view.hbs
+++ b/app/templates/my-sessions/view.hbs
@@ -1,29 +1,31 @@
 <div class="ui container">
   <div class="ui row">
-    {{#if (not this.model.isLocked)}}
-      <LinkTo
-        @route="public.cfs.edit-session"
-        @models={{array this.model.event.id this.model.id}}>
-        <button
-          class="ui blue button {{if this.device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
-        {{#if this.device.isMobile}}
-          <div class="ui hidden fitted divider"></div>
-        {{/if}}
-      </LinkTo>
-    {{/if}}
-    {{#each this.model.speakers as |speaker|}}
-      {{#if (eq speaker.email this.authManager.currentUser.email)}}
+    {{#if this.model.event.speakersCall.isOpen}}
+      {{#if (not this.model.isLocked)}}
         <LinkTo
-          @route="public.cfs.edit-speaker"
-          @models={{array this.model.event.id speaker.id}}>
+          @route="public.cfs.edit-session"
+          @models={{array this.model.event.id this.model.id}}>
           <button
-            class="ui blue button {{if this.device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
+            class="ui blue button {{if this.device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Session Proposal'}}</button>
           {{#if this.device.isMobile}}
             <div class="ui hidden fitted divider"></div>
           {{/if}}
         </LinkTo>
       {{/if}}
-    {{/each}}
+      {{#each this.model.speakers as |speaker|}}
+        {{#if (eq speaker.email this.authManager.currentUser.email)}}
+          <LinkTo
+            @route="public.cfs.edit-speaker"
+            @models={{array this.model.event.id speaker.id}}>
+            <button
+              class="ui blue button {{if this.device.isMobile 'fluid' 'right floated'}}">{{t 'Edit Speaker- '}}{{speaker.name}}</button>
+            {{#if this.device.isMobile}}
+              <div class="ui hidden fitted divider"></div>
+            {{/if}}
+          </LinkTo>
+        {{/if}}
+      {{/each}}
+    {{/if}}
     {{#if this.isUpcoming}}
       <button class="ui red button {{if this.device.isMobile 'fluid' 'right floated'}}"
         {{action 'openProposalDeleteModal'}}>{{t 'Withdraw Proposal'}}</button>

--- a/app/templates/public/cfs/edit-session.hbs
+++ b/app/templates/public/cfs/edit-session.hbs
@@ -4,14 +4,20 @@
       {{t 'Edit Session'}}
     </h2>
     <div class="ui container">
-      <Forms::SessionSpeakerForm
-        @fields={{this.model.forms}}
-        @data={{this.model}}
-        @isLoading={{this.isLoading}}
-        @save={{action "save"}}
-        @isSession={{true}}
-        @includeSession={{true}}
-        @isSessionSpeaker={{true}} />
+      {{#if this.model.event.speakersCall.isOpen}}
+        <Forms::SessionSpeakerForm
+          @fields={{this.model.forms}}
+          @data={{this.model}}
+          @isLoading={{this.isLoading}}
+          @save={{action "save"}}
+          @isSession={{true}}
+          @includeSession={{true}}
+          @isSessionSpeaker={{true}} />
+      {{else}}
+        <h2 class="ui center aligned">
+          {{t 'Speakers Call is closed now'}}
+        </h2>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/templates/public/cfs/edit-speaker.hbs
+++ b/app/templates/public/cfs/edit-speaker.hbs
@@ -4,14 +4,20 @@
       {{t 'Edit Speaker'}}
     </h2>
     <div class="ui container">
-      <Forms::SessionSpeakerForm
-        @fields={{this.model.forms}}
-        @event={{this.model.event}}
-        @data={{this.model}}
-        @isLoading={{this.isLoading}}
-        @save={{action "save"}}
-        @isSpeaker={{true}}
-        @includeSpeaker={{true}} />
+      {{#if this.model.event.speakersCall.isOpen}}
+        <Forms::SessionSpeakerForm
+          @fields={{this.model.forms}}
+          @event={{this.model.event}}
+          @data={{this.model}}
+          @isLoading={{this.isLoading}}
+          @save={{action "save"}}
+          @isSpeaker={{true}}
+          @includeSpeaker={{true}} />
+      {{else}}
+        <h2 class="ui center aligned">
+          {{t 'Speakers Call is closed now'}}
+        </h2>
+      {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3768 

#### Short description of what this resolves:
User can edit his/her session/speaker details even after the cfs has been closed

#### Changes proposed in this pull request:
Disallow session/speaker edit after cfs closed

After CFS has been closed:

![no-edit-session-cfs-closed](https://user-images.githubusercontent.com/43299408/87848763-b6116e00-c900-11ea-88c3-982db790d5b5.png)

No edit option in session details because CFS has been closed

![no-edit-cfs-closed](https://user-images.githubusercontent.com/43299408/87848764-b90c5e80-c900-11ea-8cbc-997861522307.png)

Edit button is visible when CFS is open

![edit-button-visible-cfs-open](https://user-images.githubusercontent.com/43299408/87848939-6469e300-c902-11ea-82c7-24f4a77f8908.png)



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
