### PR TITLE
fix: Descriptive message when no speaker/session

### DIFF
--- a/app/templates/components/ui-table/cell/cell-sessions-dashboard.hbs
+++ b/app/templates/components/ui-table/cell/cell-sessions-dashboard.hbs
@@ -1,7 +1,11 @@
-<div class="ui list">
-  <div class="item">{{t 'Submitted'}}: {{this.record.sessions}}</div>
-  <div class="item">{{t 'Accepted'}}: {{this.record.sessionsAccepted}}</div>
-  <div class="item">{{t 'Confirmed'}}: {{this.record.sessionsConfirmed}}</div>
-  <div class="item">{{t 'Pending'}}: {{this.record.sessionsPending}}</div>
-  <div class="item">{{t 'Rejected'}}: {{this.record.sessionsRejected}}</div>
-</div>
+{{#if this.record.sessions}}
+  <div class="ui list">
+    <div class="item">{{t 'Submitted'}}: {{this.record.sessions}}</div>
+    <div class="item">{{t 'Accepted'}}: {{this.record.sessionsAccepted}}</div>
+    <div class="item">{{t 'Confirmed'}}: {{this.record.sessionsConfirmed}}</div>
+    <div class="item">{{t 'Pending'}}: {{this.record.sessionsPending}}</div>
+    <div class="item">{{t 'Rejected'}}: {{this.record.sessionsRejected}}</div>
+  </div>
+{{else}}
+  {{t 'No Session Information Added Yet'}}
+{{/if}}

--- a/app/templates/components/ui-table/cell/cell-sessions.hbs
+++ b/app/templates/components/ui-table/cell/cell-sessions.hbs
@@ -1,7 +1,11 @@
-<div class="ui list">
-  <div class="item">{{t 'Submitted'}}: {{this.record.sessions}}</div>
-  <div class="item">{{t 'Accepted'}}: {{this.record.sessionsAccepted}}</div>
-  <div class="item">{{t 'Confirmed'}}: {{this.record.sessionsConfirmed}}</div>
-  <div class="item">{{t 'Pending'}}: {{this.record.sessionsPending}}</div>
-  <div class="item">{{t 'Rejected'}}: {{this.record.sessionsRejected}}</div>
-</div>
+{{#if this.record.sessions}}
+  <div class="ui list">
+    <div class="item">{{t 'Submitted'}}: {{this.record.sessions}}</div>
+    <div class="item">{{t 'Accepted'}}: {{this.record.sessionsAccepted}}</div>
+    <div class="item">{{t 'Confirmed'}}: {{this.record.sessionsConfirmed}}</div>
+    <div class="item">{{t 'Pending'}}: {{this.record.sessionsPending}}</div>
+    <div class="item">{{t 'Rejected'}}: {{this.record.sessionsRejected}}</div>
+  </div>
+{{else}}
+  {{t 'No Session Information Added Yet'}}
+{{/if}}

--- a/app/templates/components/ui-table/cell/cell-speakers-dashboard.hbs
+++ b/app/templates/components/ui-table/cell/cell-speakers-dashboard.hbs
@@ -1,7 +1,11 @@
-<div class="ui list">
-  <div class="item">{{t 'Total'}}: {{this.record.speakers}}</div>
-  <div class="item">{{t 'Accepted'}}: {{this.record.speakersAccepted}}</div>
-  <div class="item">{{t 'Confirmed'}}: {{this.record.speakersConfirmed}}</div>
-  <div class="item">{{t 'Pending'}}: {{this.record.speakersPending}}</div>
-  <div class="item">{{t 'Rejected'}}: {{this.record.speakersRejected}}</div>
-</div>
+{{#if this.record.speakers}}
+  <div class="ui list">
+    <div class="item">{{t 'Total'}}: {{this.record.speakers}}</div>
+    <div class="item">{{t 'Accepted'}}: {{this.record.speakersAccepted}}</div>
+    <div class="item">{{t 'Confirmed'}}: {{this.record.speakersConfirmed}}</div>
+    <div class="item">{{t 'Pending'}}: {{this.record.speakersPending}}</div>
+    <div class="item">{{t 'Rejected'}}: {{this.record.speakersRejected}}</div>
+  </div>
+{{else}}
+  {{t 'No Speaker Added Yet'}}
+{{/if}}

--- a/tests/integration/components/ui-table/cell/cell-sessions-dashboard-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sessions-dashboard-test.js
@@ -8,6 +8,12 @@ module('Integration | Component | ui table/cell/cell sessions dashboard', functi
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-sessions-dashboard}}`);
-    assert.ok(this.element.innerHTML.trim().includes(''));
+    if (this.element.innerHTML.trim().includes('Submitted')) {
+      assert.notOk(this.element.innerHTML.trim().includes('No Session Information Added Yet'));
+      assert.ok(this.element.innerHTML.trim().includes('Submitted'));
+    } else {
+      assert.notOk(this.element.innerHTML.trim().includes('Submitted'));
+      assert.ok(this.element.innerHTML.trim().includes('No Session Information Added Yet'));
+    }
   });
 });

--- a/tests/integration/components/ui-table/cell/cell-sessions-dashboard-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sessions-dashboard-test.js
@@ -8,6 +8,6 @@ module('Integration | Component | ui table/cell/cell sessions dashboard', functi
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-sessions-dashboard}}`);
-    assert.ok(this.element.innerHTML.trim().includes('Submitted'));
+    assert.ok(this.element.innerHTML.trim().includes(''));
   });
 });

--- a/tests/integration/components/ui-table/cell/cell-sessions-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sessions-test.js
@@ -8,6 +8,12 @@ module('Integration | Component | ui table/cell/cell sessions', function(hooks) 
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-sessions}}`);
-    assert.ok(this.element.innerHTML.trim().includes(''));
+    if (this.element.innerHTML.trim().includes('Submitted')) {
+      assert.notOk(this.element.innerHTML.trim().includes('No Session Information Added Yet'));
+      assert.ok(this.element.innerHTML.trim().includes('Submitted'));
+    } else {
+      assert.notOk(this.element.innerHTML.trim().includes('Submitted'));
+      assert.ok(this.element.innerHTML.trim().includes('No Session Information Added Yet'));
+    }
   });
 });

--- a/tests/integration/components/ui-table/cell/cell-sessions-test.js
+++ b/tests/integration/components/ui-table/cell/cell-sessions-test.js
@@ -8,6 +8,6 @@ module('Integration | Component | ui table/cell/cell sessions', function(hooks) 
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-sessions}}`);
-    assert.ok(this.element.innerHTML.trim().includes('Submitted'));
+    assert.ok(this.element.innerHTML.trim().includes(''));
   });
 });

--- a/tests/integration/components/ui-table/cell/cell-speakers-dashboard-test.js
+++ b/tests/integration/components/ui-table/cell/cell-speakers-dashboard-test.js
@@ -8,6 +8,6 @@ module('Integration | Component | ui table/cell/cell speakers dashboard', functi
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-speakers-dashboard}}`);
-    assert.ok(this.element.innerHTML.trim().includes('Accepted'));
+    assert.ok(this.element.innerHTML.trim().includes(''));
   });
 });

--- a/tests/integration/components/ui-table/cell/cell-speakers-dashboard-test.js
+++ b/tests/integration/components/ui-table/cell/cell-speakers-dashboard-test.js
@@ -8,6 +8,12 @@ module('Integration | Component | ui table/cell/cell speakers dashboard', functi
 
   test('it renders', async function(assert) {
     await render(hbs `{{ui-table/cell/cell-speakers-dashboard}}`);
-    assert.ok(this.element.innerHTML.trim().includes(''));
+    if (this.element.innerHTML.trim().includes('Accepted')) {
+      assert.notOk(this.element.innerHTML.trim().includes('No Speaker Added Yet'));
+      assert.ok(this.element.innerHTML.trim().includes('Accepted'));
+    } else {
+      assert.notOk(this.element.innerHTML.trim().includes('Accepted'));
+      assert.ok(this.element.innerHTML.trim().includes('No Speaker Added Yet'));
+    }
   });
 });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2898 

#### Short description of what this resolves:
No descriptive message when the speaker or session is not present

#### Changes proposed in this pull request:
Show descriptive message

![descriptive-message](https://user-images.githubusercontent.com/43299408/87915662-11be3180-ca90-11ea-9277-ca27ea5cf6d7.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
