### PR TITLE
fix: Separate route for speaker and session edit

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -50,8 +50,8 @@ Router.map(function() {
     this.route('cfs', function() {
       this.route('new-speaker');
       this.route('new-session');
-      this.route('edit-speaker', { path: '/edit/:speaker_id' });
-      this.route('edit-session', { path: '/edit/:session_id' });
+      this.route('edit-speaker', { path: '/edit/speaker/:speaker_id' });
+      this.route('edit-session', { path: '/edit/session/:session_id' });
     });
     this.route('schedule');
     this.route('coc');


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4578 

#### Short description of what this resolves:
The speaker edit route was pointing to the session edit route when the page was reloaded because of conflict in their ids in the route.

#### Changes proposed in this pull request:
Use separate route for editing speaker and session


![separate-speaker-session-edit-route](https://user-images.githubusercontent.com/43299408/87930508-d890bc00-caa5-11ea-9b2b-8214f35bf3ab.gif)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
