### PR TITLE
fix: Filter attendee form from all custom forms

### DIFF
--- a/app/routes/events/view/edit/attendee.js
+++ b/app/routes/events/view/edit/attendee.js
@@ -18,11 +18,11 @@ export default class AttendeeRoute extends Route.extend(CustomFormMixin) {
     const event = this.modelFor('events.view');
     const data = {
       event,
-      customForms: await event.query('customForms', {
+      customForms: (await event.query('customForms', {
         filter       : filterOptions,
         sort         : 'id',
         'page[size]' : 50
-      }),
+      })).toArray().filter(field => field.form === 'attendee'),
       newFormField: {
         name : '',
         type : 'text'


### PR DESCRIPTION
Fixes #4597

Ember Data strikes again. There is a custom function `query` used everywhere throughout the project which filters out the items from server. But ember data returns all the items from local in memory DB because how cool it is, and this custom query method does not take it into account. Hence, once all custom form fields are loaded in memory, it returns all the items rather than just the attendee custom form