### PR TITLE
fix: Add location required error message in wizard step 1

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -154,6 +154,15 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             }
           ]
         },
+        location: {
+          identifier : 'location',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Location is required to save an event')
+            }
+          ]
+        },
         timezone: {
           identifier : 'timezone',
           rules      : [

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -7,7 +7,7 @@
       @value={{this.data.event.name}} />
   </div>
   <div class="field">
-    <label for="location">{{t 'Location'}}</label>
+    <label class="required" for="location">{{t 'Location'}}</label>
     <Widgets::Forms::LocationInput
       @inputId="location"
       @lat={{this.data.event.latitude}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4585 

#### Short description of what this resolves:
No error message was shown to the user regarding required event location in event create wizard step 1.

#### Changes proposed in this pull request:
Show error message if the user tries to save an event without entering event location.

![location-required](https://user-images.githubusercontent.com/43299408/88160341-22a3aa00-cc2c-11ea-82fc-99936fac4309.gif "Location required error message")


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
