### PR TITLE
fix: Change default pre-selected fields in wizard step 4

### DIFF
--- a/app/mixins/custom-form.js
+++ b/app/mixins/custom-form.js
@@ -50,9 +50,9 @@ export default Mixin.create(MutableArray, {
         fieldIdentifier : 'track',
         form            : 'session',
         type            : 'select',
-        isRequired      : true,
-        isIncluded      : true,
-        isFixed         : true,
+        isRequired      : false,
+        isIncluded      : false,
+        isFixed         : false,
         event           : parent
       }),
       this.store.createRecord('custom-form', {
@@ -60,7 +60,7 @@ export default Mixin.create(MutableArray, {
         form            : 'session',
         type            : 'select',
         isRequired      : false,
-        isIncluded      : true,
+        isIncluded      : false,
         event           : parent
       }),
       this.store.createRecord('custom-form', {
@@ -84,7 +84,7 @@ export default Mixin.create(MutableArray, {
         form            : 'session',
         type            : 'file',
         isRequired      : false,
-        isIncluded      : true,
+        isIncluded      : false,
         event           : parent
       }),
       this.store.createRecord('custom-form', {
@@ -158,7 +158,7 @@ export default Mixin.create(MutableArray, {
         form            : 'speaker',
         type            : 'select',
         isRequired      : false,
-        isIncluded      : true,
+        isIncluded      : false,
         event           : parent
       }),
       this.store.createRecord('custom-form', {
@@ -246,7 +246,7 @@ export default Mixin.create(MutableArray, {
         form            : 'speaker',
         type            : 'text',
         isRequired      : false,
-        isIncluded      : true,
+        isIncluded      : false,
         event           : parent
       }),
       this.store.createRecord('custom-form', {

--- a/app/mixins/custom-form.js
+++ b/app/mixins/custom-form.js
@@ -50,9 +50,9 @@ export default Mixin.create(MutableArray, {
         fieldIdentifier : 'track',
         form            : 'session',
         type            : 'select',
-        isRequired      : false,
-        isIncluded      : false,
-        isFixed         : false,
+        isRequired      : true,
+        isIncluded      : true,
+        isFixed         : true,
         event           : parent
       }),
       this.store.createRecord('custom-form', {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4586 

#### Short description of what this resolves:
Session and speaker custom forms have few fields pre-selected for new events in wizard step 4.

#### Changes proposed in this pull request:
Change default pre-selected fields

![default-pre-selected-fields](https://user-images.githubusercontent.com/43299408/88175308-53dba480-cc43-11ea-8006-53b139875272.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
