### PR TITLE
feat: add instagram social link

### DIFF
--- a/app/components/forms/admin/content/social-links-form.js
+++ b/app/components/forms/admin/content/social-links-form.js
@@ -51,6 +51,21 @@ export default Component.extend(FormMixin, {
             }
           ]
         },
+        instagram: {
+          identifier : 'instagram',
+          optional   : true,
+          rules      : [
+            {
+              type   : 'containsExactly[instagram.com]',
+              prompt : this.l10n.t('Please enter a valid instagram url')
+            },
+            {
+              type   : 'regExp',
+              value  : protocolLessValidUrlPattern,
+              prompt : this.l10n.t('Please enter a valid url')
+            }
+          ]
+        },
         googleGroup: {
           identifier : 'google_group',
           optional   : true,

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -72,6 +72,7 @@ export default ModelBase.extend({
   twitterUrl                 : attr('string'),
   supportUrl                 : attr('string'),
   facebookUrl                : attr('string'),
+  instagramUrl               : attr('string'),
   youtubeUrl                 : attr('string'),
   androidAppUrl              : attr('string'),
   frontendUrl                : attr('string'),
@@ -102,6 +103,7 @@ export default ModelBase.extend({
 
   segmentedSupportUrl    : computedSegmentedLink.bind(this)('supportUrl'),
   segmentedFacebookUrl   : computedSegmentedLink.bind(this)('facebookUrl'),
+  segmentedInstagramUrl  : computedSegmentedLink.bind(this)('instagramUrl'),
   segmentedTwitterUrl    : computedSegmentedLink.bind(this)('twitterUrl'),
   segmentedGoogleUrl     : computedSegmentedLink.bind(this)('googleUrl'),
   segmentedYoutubeUrl    : computedSegmentedLink.bind(this)('youtubeUrl'),

--- a/app/routes/create.js
+++ b/app/routes/create.js
@@ -17,7 +17,7 @@ export default class CreateRoute extends Route.extend(AuthenticatedRouteMixin, E
         copyright           : this.store.createRecord('event-copyright'),
         stripeAuthorization : this.store.createRecord('stripe-authorization')
       }),
-      types  : await this.store.query('event-type', {
+      types: await this.store.query('event-type', {
         sort: 'name'
       }),
       topics: await this.store.query('event-topic', {

--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -46,6 +46,11 @@
             <i class="facebook f icon"></i> {{t 'Facebook'}}
           </a>
         {{/if}}
+        {{#if this.socialLinks.instagramUrl}}
+          <a class="item" href="{{this.socialLinks.instagramUrl}}" target="_blank" rel="noopener noreferrer">
+            <i class="instagram icon"></i> {{t 'Instagram'}}
+          </a>
+        {{/if}}
         {{#if this.socialLinks.twitterUrl}}
           <a class="item" href="{{this.socialLinks.twitterUrl}}" target="_blank" rel="noopener noreferrer">
             <i class="twitter icon"></i> {{t 'Twitter'}}
@@ -63,7 +68,7 @@
         {{/if}}
         {{#if this.socialLinks.googleUrl}}
           <a class="item" href="{{this.socialLinks.googleUrl}}" target="_blank" rel="noopener noreferrer">
-            <i class="google plus icon"></i> {{t 'Google +'}}
+            <i class="google groups icon"></i> {{t 'Google Groups'}}
           </a>
         {{/if}}
       </div>

--- a/app/templates/components/forms/admin/content/social-links-form.hbs
+++ b/app/templates/components/forms/admin/content/social-links-form.hbs
@@ -18,6 +18,12 @@
       @inputId="facebook" />
   </div>
   <div class="field">
+    <label>{{t 'Instagram'}}</label>
+    <Widgets::Forms::LinkInput
+      @segmentedLink={{this.socials.segmentedInstagramUrl}}
+      @inputId="instagram" />
+  </div>
+  <div class="field">
     <label>{{t 'Google Group'}}</label>
     <Widgets::Forms::LinkInput
       @segmentedLink={{this.socials.segmentedGoogleUrl}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:

Fixes #4617

Requires https://github.com/fossasia/open-event-server/pull/7163

#### Changes proposed in this pull request:

- Added field for the Instagram social link.
- rename google + to google group in URL.

![Screenshot at 2020-07-26 08-45-54](https://user-images.githubusercontent.com/46647141/88470633-7eb44a00-cf1c-11ea-8075-c6cdffba849e.png)

Unfortunately, Semantic UI doesn't have an icon for google-groups. I'm finding a suitable icon and will update.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
