### PR TITLE
feat: Implement event publish-unpublish confirm pop-up

### DIFF
--- a/app/components/modals/publish-unpublish-modal.js
+++ b/app/components/modals/publish-unpublish-modal.js
@@ -1,0 +1,11 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+@classic
+export default class PublishUnpublishModal extends ModalBase {
+  @action
+  toggleView() {
+    this.set('isOpen', false);
+  }
+}

--- a/app/controllers/events/view.js
+++ b/app/controllers/events/view.js
@@ -4,7 +4,13 @@ import { action } from '@ember/object';
 
 export default class extends Controller {
   @action
+  openConfirmModal() {
+    this.set('isPublishUnpublishModalOpen', true);
+  }
+
+  @action
   togglePublishState() {
+    this.set('isPublishUnpublishModalOpen', false);
     if (isEmpty(this.model.locationName)) {
       this.notify.error(this.l10n.t('Your event must have a location before it can be published.'),
         {

--- a/app/templates/components/modals/publish-unpublish-modal.hbs
+++ b/app/templates/components/modals/publish-unpublish-modal.hbs
@@ -1,0 +1,28 @@
+<i class="black close icon"></i>
+<div class="header">
+  {{t 'Are you sure?'}}
+</div>
+<div class="content">
+  {{#if (eq this.state 'published')}}
+    <p>{{t 'This will unpublish your event. It will not be accessible to the public on the Internet anymore if you continue. The data of the event will still be available on your dashboard, but tickets, call for speakers or any other features will no longer be available online. Do you want to unpublish your event now?'}}</p>
+  {{else}}
+    <p>{{t 'This will publish the event and the event will be visible on the Internet. Please confirm you want to publish your event.'}}</p>
+  {{/if}}
+</div>
+<div class="actions">
+	{{#if (eq this.state 'published')}}
+		<button type="button" class="ui red button" {{action this.togglePublishState}}>
+			{{t 'Yes, Unpublish it'}}
+		</button>
+		<button type="button" class="ui button" {{action 'toggleView'}}>
+			{{t 'Cancel'}}
+		</button>
+	{{else}}
+		<button type="button" class="ui green button" {{action this.togglePublishState}}>
+			{{t 'Yes'}}
+		</button>
+		<button type="button" class="ui button" {{action 'toggleView'}}>
+			{{t 'Cancel, Do Not Publish it Now'}}
+		</button>
+	{{/if}}
+</div>

--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -34,7 +34,7 @@
             {{/if}}
           </a>
           
-            <button class="ui button labeled icon small" {{action 'togglePublishState'}}>
+            <button class="ui button labeled icon small" {{action 'openConfirmModal'}}>
               {{#if (eq this.model.state 'published')}}
                 <i class="ban icon"></i>
                 {{t 'Unpublish'}}
@@ -90,3 +90,4 @@
   {{!-- the edit page will be rendered without any of the above tabs --}}
   {{outlet}}
 {{/if}}
+<Modals::PublishUnpublishModal @isOpen={{this.isPublishUnpublishModalOpen}} @state={{this.model.state}} @togglePublishState={{action 'togglePublishState'}} />


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4621 

#### Short description of what this resolves:
There was no confirmation when user publish or unpublish his/her event.

#### Changes proposed in this pull request:
Show confirmation pop-up whenever user tries to publish or unpublish his/her event.

![publish-unpublish-confirm](https://user-images.githubusercontent.com/43299408/88717005-80108d00-d13d-11ea-9efa-a7a93d85bb5e.gif)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
