### PR TITLE
fix: Don't expand ticket input when editing existing event

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -192,7 +192,7 @@
           {{#each this.tickets as |ticket index|}}
             <Widgets::Forms::TicketInput
               @ticket={{ticket}}
-              @isExpanded="true"
+              @isExpanded={{if this.data.event.id false true}}
               @timezone={{this.data.event.timezone}}
               @canMoveUp={{not-eq index 0}}
               @canMoveDown={{not-eq ticket.position (dec this.data.event.tickets.length)}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4672 

#### Short description of what this resolves:
When editing existing events ticket input is in expanded state which is not needed.

#### Changes proposed in this pull request:
Don't expand ticket input when editing existing event. If event id already exists then there's no need to show expanded ticket input settings.

![no-expand-when-edit](https://user-images.githubusercontent.com/43299408/88975768-6b1c3100-d2d8-11ea-963e-159c38d14728.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
