### PR TITLE
fixed Capitalization in heading and alignment of footer columns

### DIFF
--- a/app/styles/partials/footer.scss
+++ b/app/styles/partials/footer.scss
@@ -27,6 +27,10 @@ footer {
   }
 }
 
+.ui.inverted.link.list {
+  text-align: left;
+}
+
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) { // sass-lint:disable-line no-vendor-prefixes
   .main-container {
     margin: $page-top-margin 0;

--- a/app/styles/partials/footer.scss
+++ b/app/styles/partials/footer.scss
@@ -27,10 +27,6 @@ footer {
   }
 }
 
-.ui.inverted.link.list {
-  text-align: left;
-}
-
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) { // sass-lint:disable-line no-vendor-prefixes
   .main-container {
     margin: $page-top-margin 0;

--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -1,7 +1,7 @@
 <div class="ui center aligned container">
   <div class="ui stackable inverted divided grid">
     <div class="four wide column">
-      <div class="ui inverted link list">
+      <div class="ui left aligned container inverted link list">
         <strong class="item">{{t 'Use'}} {{this.settings.appName}}</strong>
         <a class="item" href="https://support.eventyay.com" target="_blank" rel="noopener noreferrer">{{t 'How it Works'}}</a>
         <a class="item" href="https://support.eventyay.com/pricing" rel="noopener noreferrer">{{t 'Pricing'}}</a>
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="four wide column">
-      <div class="ui inverted link list">
+      <div class="ui left aligned container inverted link list">
         <strong class="item">{{t 'Plan Events'}}</strong>
         <a class="item" href="https://support.eventyay.com/online-registration" target="_blank" rel="noopener noreferrer">
           {{t 'Online Registration'}}
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="four wide column">
-      <div class="ui inverted link list">
+      <div class="ui left aligned container inverted link list">
         <strong class="item">{{t 'Find Events'}}</strong>
         <a class="item" href="{{href-to 'explore'}}" target="_blank" rel="noopener noreferrer">
           {{t 'Browse Local Events'}}
@@ -38,7 +38,7 @@
     </div>
 
     <div class="four wide column">
-      <div class="ui inverted link list">
+      <div class="ui left aligned container inverted link list">
         <strong class="item">{{t 'Connect With Us'}}</strong>
         {{#if this.socialLinks.supportUrl}}
           <a class="item" href="{{this.socialLinks.supportUrl}}" target="_blank" rel="noopener noreferrer">

--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -39,7 +39,7 @@
 
     <div class="four wide column">
       <div class="ui inverted link list">
-        <strong class="item">{{t 'Connect with us'}}</strong>
+        <strong class="item">{{t 'Connect With Us'}}</strong>
         {{#if this.socialLinks.supportUrl}}
           <a class="item" href="{{this.socialLinks.supportUrl}}" target="_blank" rel="noopener noreferrer">
             <i class="info icon"></i> {{t 'Blog'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4612 - author @mariobehling 

#### Short description of what this resolves:
Capitalized  'W' and 'U' in the heading "Connect with us" in footer and aligned the columns to left.

#### Changes proposed in this pull request:

-Left align columns
-Heading "Connect With Us" -> capital W in with, capital U in us
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
![open event footer](https://user-images.githubusercontent.com/65273718/89027153-a4d85080-d347-11ea-8a82-16c4ccdc3baf.png)

