### PR TITLE
fix: Add margin around speaker name and make text selectable

### DIFF
--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -1,7 +1,7 @@
 <UiAccordion>
   <div class="title" {{action 'hideSpeakerImage'}} role="button">
     <div class="ui">
-      <h3 class="ui header">
+      <h3 class="ui header" id="session-id-{{this.session.id}}">
         {{this.session.title}}
         <div class="sub header">
           {{this.session.sessionType.name}}

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -52,7 +52,7 @@
               </strong>
             {{/if}}
           </p>
-          <LinkTo @route='public.sessions.view' @model={{session.id}}>
+          <a href="{{href-to 'public.sessions.list' 'all'}}#session-id-{{session.id}}">
             <div class="ui fluid padded" style={{css color=session.track.fontColor background-color=session.track.color}}>
               <h3 class="item">
                 {{#if (and session.startsAt session.endsAt)}}
@@ -63,7 +63,7 @@
                 <br>
               </h3>
             </div>
-          </LinkTo>
+          </a>
         <br>
         {{/if}}
       {{/each}}

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -54,7 +54,7 @@
           </p>
           <a href="{{href-to 'public.sessions.list' 'all'}}#session-id-{{session.id}}">
             <div class="ui fluid padded" style={{css color=session.track.fontColor background-color=session.track.color}}>
-              <h3 class="item">
+              <h3 class="item" style={{css user-select='text'}}>
                 {{#if (and session.startsAt session.endsAt)}}
                   {{moment-format session.startsAt 'HH:mm'}} - {{moment-format session.endsAt 'hh:mm'}}
                   <br>

--- a/app/templates/components/public/speaker-item.hbs
+++ b/app/templates/components/public/speaker-item.hbs
@@ -4,7 +4,7 @@
       <div class="thumbnail-square">
         <img alt="speaker" class="ui rounded image" src="{{if this.speaker.thumbnailImageUrl this.speaker.thumbnailImageUrl (if this.speaker.photoUrl this.speaker.photoUrl '/images/placeholders/avatar.png')}}">
       </div>
-      <h3 class="ui centered header no margin">
+      <h3 class="ui centered header">
         {{this.speaker.name}}
       </h3>
       <p class="ui small centered disabled header no padding">
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="ui vertical fluid menu content padded">
-    <div class="item">
+    <div class="item" style={{css user-select='text'}}>
       <p class="word-break">
         {{#if this.speaker.shortBiography}}
           {{sanitize this.speaker.shortBiography}}
@@ -52,16 +52,18 @@
               </strong>
             {{/if}}
           </p>
-          <div class="ui fluid padded" style={{css color=session.track.fontColor background-color=session.track.color}}>
-            <h3 class="item">
-              {{#if (and session.startsAt session.endsAt)}}
-                {{moment-format session.startsAt 'HH:mm'}} - {{moment-format session.endsAt 'hh:mm'}}
+          <LinkTo @route='public.sessions.view' @model={{session.id}}>
+            <div class="ui fluid padded" style={{css color=session.track.fontColor background-color=session.track.color}}>
+              <h3 class="item">
+                {{#if (and session.startsAt session.endsAt)}}
+                  {{moment-format session.startsAt 'HH:mm'}} - {{moment-format session.endsAt 'hh:mm'}}
+                  <br>
+                {{/if}}
+                &bull;&nbsp; {{session.title}}
                 <br>
-              {{/if}}
-              &bull;&nbsp; {{session.title}}
-              <br>
-            </h3>
-          </div>
+              </h3>
+            </div>
+          </LinkTo>
         <br>
         {{/if}}
       {{/each}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4000 

#### Short description of what this resolves:
Speaker name was too close to speaker image, there was no link on session and text was not selectable.

#### Changes proposed in this pull request:

- Increase gap between speaker's image and name.
- Make text selectable.
- Link speaker sessions.

##### Before :

![speaker-space-link-selectable-before](https://user-images.githubusercontent.com/43299408/89429617-67b2fa80-d75b-11ea-90f9-a1ce6b37ac83.gif)

##### After :

![speaker-space-link-selectable-after](https://user-images.githubusercontent.com/43299408/89429710-8618f600-d75b-11ea-93ba-75f889c1dd59.gif)

![link-speaker-sessions](https://user-images.githubusercontent.com/43299408/89430160-10615a00-d75c-11ea-8526-40b0e40e1fa5.gif)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
