### PR TITLE
fix: save wizard as draft on each step

### DIFF
--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -164,9 +164,21 @@ export default Component.extend(EventWizardMixin, FormMixin, {
   },
 
   actions: {
+    saveDraft() {
+      this.onValid(() => {
+        this.set('data.event.state', 'draft');
+        this.sendAction('save');
+      });
+    },
     move(direction) {
       this.onValid(() => {
         this.sendAction('move', direction);
+      });
+    },
+    publish() {
+      this.onValid(() => {
+        this.set('data.event.state', 'published');
+        this.sendAction('save');
       });
     },
     addItem(type) {

--- a/app/components/forms/wizard/sponsors-step.js
+++ b/app/components/forms/wizard/sponsors-step.js
@@ -54,19 +54,8 @@ export default Component.extend(FormMixin, {
     },
     saveDraft() {
       this.onValid(() => {
-        let { sponsors } = this.data;
-        let incorrect_sponsors = sponsors.filter(function(sponsor) {
-          return (!sponsor.get('name'));
-        });
-        if (incorrect_sponsors.length > 0) {
-          this.notify.error(this.l10n.t('Please fill the required fields.'), {
-            id: 'req_field_spon'
-          });
-          this.set('isLoading', false);
-        } else {
-          this.set('data.event.state', 'draft');
-          this.sendAction('save');
-        }
+        this.set('data.event.state', 'draft');
+        this.sendAction('save');
       });
     },
     move(direction) {


### PR DESCRIPTION

Fixes #4712 

#### Short description of what this resolves:
Wizard Step 3 and Step 4: Not possible to save draft

#### Changes proposed in this pull request:

Allow saving as draft on each step..
![ezgif com-optimize](https://user-images.githubusercontent.com/56407566/89625485-8fb67100-d8b5-11ea-933f-5e07b7bff02b.gif)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
