### PR TITLE
Fixes:Basic Event Details: Enable option Online Events or Mixed Event…

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -154,15 +154,15 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             }
           ]
         },
-        location: {
-          identifier : 'location',
-          rules      : [
-            {
-              type   : 'empty',
-              prompt : this.l10n.t('Location is required to save an event')
-            }
-          ]
-        },
+        // location: {
+        //   identifier : 'location',
+        //   rules      : [
+        //     {
+        //       type   : 'empty',
+        //       prompt : this.l10n.t('Location is required to save an event')
+        //     }
+        //   ]
+        // },
         timezone: {
           identifier : 'timezone',
           rules      : [

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -7,15 +7,27 @@
       @value={{this.data.event.name}} />
   </div>
   <div class="field">
-    <label class="required" for="location">{{t 'Location'}}</label>
+    <div class="inline feild">
+      
+    <label for="location">{{t 'Location'}}</label>
+     <div class="ui checked checkbox">
+      <Input
+      @id="showlocation"
+      @type="checkbox"
+      @checked=pre_checked/>
+      
+      </div>
+      </div>
+  <div id="hiddenDiv">
     <Widgets::Forms::LocationInput
       @inputId="location"
       @lat={{this.data.event.latitude}}
       @lng={{this.data.event.longitude}}
       @placeName={{this.data.event.locationName}}
       @searchableName={{this.data.event.searchableLocationName}}
-      @zoom={{15}}
-      @placeholder={{t "Location is required to make this event live"}}>
+      @zoom={{15}}>
+      {{!--@placeholder={{t "Location is required to make this event live"--}}>
+     
       <div class="inline field">
         <div class="ui slider checkbox">
           <Input
@@ -25,8 +37,58 @@
           <label for="show_map">{{t 'Show map on event page'}}</label>
         </div>
       </div>
-    </Widgets::Forms::LocationInput>
+    </Widgets::Forms::LocationInput></div>
+     <script> 
+      
+      $("#showlocation").on('change', function(){ 
+
+	 $("#hiddenDiv").toggle(); 
+
+      });</script> 
   </div>
+ <div class="field">
+    <div class="inline field">
+      <!--newly added-->
+      <label for="online-events">{{t 'Online Events'}}</label>
+       <div class="ui checked checkbox">
+      <Input
+      @id="showonlineevents"
+      @type="checkbox"/>
+           
+      </div></div>
+    <div id="hiddenDiv2">
+      <label for="Live-Streaming">{{t 'Live Streaming (Optional)'}}</label>
+       <div class="ui labeled right icon input"> 
+        <div class="ui label">
+        https://
+      </div>
+     <Input @type="text" @placeholder="www.livestreaming.com" @selected={{this.protocol}} @onChange={{action (mut this.protocol)}}/>
+    </div> 
+    {{!-- <Widgets::Forms::LinkInput
+        @hasLinkName={{false}}
+        @hasLinkName2={{true}}
+        @linkName={{online-events.name}}
+        @inputId={{online-events.identifier}}
+        @isChild={{false}}
+        @addItem={{false}}
+        @removeItem={{false}}/> --}}
+  
+      <label for="Webinar">{{t 'Webinar (Optional)  '}}</label>
+      <div class="ui labeled right icon input">
+  <div class="ui label">
+    https://
+  </div>
+  <input type="text" placeholder="www.webinar.com">
+  
+</div>   
+ </div></div>
+ <script>
+   $("#hiddenDiv2").hide();
+      $("#showonlineevents").on('change', function(){
+
+	$("#hiddenDiv2").toggle();
+
+});</script>
   <div class="fields">
     <div class="five wide field">
       <label class="required" for="start_date">{{t 'Starts'}}</label>


### PR DESCRIPTION
#4611
**Basic Event Details: Enable option Online Events or Mixed Event** 

#### **Short description of what this resolves:**
Changes in the basic details wizard

#### **Changes proposed in this pull request:**
1.  add a tick box in front of "Location" which is ticked on by default. If the user ticks it off, the fields for "Location" should disappear.
2. add a section "Online Event"
3. add a tick box in front of "Online Event" which is ticked off by default. If the user ticks it on, the fields for "Online Event" should     appear.
        Show a field in section online events for "Live streaming (Optional): https://________________________"
        Show a field in section online event for "Webinar (Optional): https://____________________________"
![image](https://user-images.githubusercontent.com/66299533/89632440-ce512900-d8bf-11ea-8b7c-9fc755c4745e.png)



![image](https://user-images.githubusercontent.com/66299533/89632675-3273ed00-d8c0-11ea-8b0b-949f1ecb89cb.png)
**Additional information**

Please elaborate on this as I couldn't understand this
  1.  disable location and address in the public event page if the location is not enabled
  2.  show the info about live streaming and webinar links on the main page in the central content area if links are provided

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).

- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
