### PR TITLE
fix: show social-links only on pages having side-menu

### DIFF
--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -40,7 +40,10 @@
         {{outlet}}
       </div>
       <div class="three wide column">
-        {{#if (not-eq this.session.currentRouteName 'public.cfs.new-speaker')}}
+        {{#if (and (not-eq this.session.currentRouteName 'public.cfs.new-session') 
+              (not-eq this.session.currentRouteName 'public.cfs.new-speaker') 
+              (not-eq this.session.currentRouteName 'public.cfs.edit-speaker') 
+              (not-eq this.session.currentRouteName 'public.cfs.edit-session'))}}
           <Public::SocialLinks @externalUrl={{this.model.externalEventUrl}} @socialLinks={{this.model.socialLinks}} />
         {{/if}}
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


#### Short description of what this resolves:

Fixes #4608

#### Changes proposed in this pull request:

show social-links only on pages having side-menu

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
