### PR TITLE
fix: Include track and session type in org sessions view

### DIFF
--- a/app/routes/events/view/sessions/list.js
+++ b/app/routes/events/view/sessions/list.js
@@ -64,7 +64,7 @@ export default class extends Route.extend(EmberTableRouteMixin) {
 
     filterOptions = this.applySearchFilters(filterOptions, params, searchField);
     let queryString = {
-      include        : 'speakers,feedbacks',
+      include        : 'speakers,feedbacks,session-type,track',
       filter         : filterOptions,
       'page[size]'   : params.per_page || 10,
       'page[number]' : params.page || 1


### PR DESCRIPTION
Now, all required items are requested in a single request
instead of sending a thousand requests per page