### PR TITLE
fix: Session state dropdown with/out email removed

### DIFF
--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -14,7 +14,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/events/view/sessions/cell-buttons',
         valuePath       : 'state',
         isSortable      : true,
-        extraValuePaths : ['status'],
+        extraValuePaths : ['id', 'status'],
         options         : {
           sessionStateMap: this.model.sessionStateMap
         },
@@ -158,19 +158,15 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
   }
 
   @action
-  async changeState(session_id, state, sendEmail) {
+  async changeState(session_id, state) {
     const session =  this.store.peekRecord('session', session_id, { backgroundReload: false });
     const oldState = session.state;
-    session.setProperties({
-      sendEmail,
-      state,
-      isMailSent: sendEmail
-    });
+    session.set('state', state);
     this.set('isLoading', true);
 
     try {
       await session.save();
-      const message = `Session has been ${state}` + (sendEmail ? ' and speaker has been notified via email.' : '');
+      const message = `Session has been ${state}`;
       this.notify.success(this.l10n.t(message), {
         id: 'session_state'
       });

--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
@@ -3,15 +3,9 @@
   {{t (capitalize this.extraRecords.status)}}
   <div class="menu">
     {{#each this.states as |state|}}
-      <div class="item">
-          <UiDropdown @class="ui dropdown">
-          <div class="ui {{state.color}} empty circular label"></div>
-          {{t (capitalize state.name)}}
-          <div class="menu">
-            <a href="#" role="button" class="item" {{action this.props.actions.changeState this.record state.name true}}>{{t 'With email'}}</a>
-            <a href="#" role="button" class="item" {{action this.props.actions.changeState this.record state.name false}}>{{t 'Without email'}}</a>
-          </div>
-        </UiDropdown>
+      <div class="item" role="button" {{action this.props.actions.changeState this.extraRecords.id state.name}}>
+        <div class="ui {{state.color}} empty circular label"></div>
+        {{t (capitalize state.name)}}
       </div>
     {{/each}}
   </div>


### PR DESCRIPTION
Broken after changes in #4733

Now, nested dropdown of with/without email is removed