### PR TITLE
fix: show globe icon for general web links

### DIFF
--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -17,7 +17,13 @@ export default ModelBase.extend({
     // and non-null name is being sent from API, for some reason, for certain events,
     // this throws an error, so we check first if name exists
     // https://github.com/fossasia/open-event-frontend/issues/4777
-    return this.name && this.name.trim().toLowerCase();
+
+    let normalizedName = this.name && this.name.trim().toLowerCase();
+    const socialPlatforms = ['facebook', 'twitter', 'github', 'youtube', 'linkedin', 'google'];
+    if (normalizedName && !socialPlatforms.includes(normalizedName)) {
+      normalizedName = 'globe';
+    }
+    return normalizedName;
   }),
 
   isTwitter: equal('normalizedName', 'twitter'),

--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -20,7 +20,7 @@ export default ModelBase.extend({
 
     const normalizedName = this.name?.trim().toLowerCase();
     const socialPlatforms = ['facebook', 'twitter', 'github', 'youtube', 'linkedin', 'google'];
-    if (normalizedName && !socialPlatforms.includes(normalizedName)) {
+    if (!socialPlatforms.includes(normalizedName)) {
       return 'globe';
     }
     return normalizedName;

--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -18,7 +18,7 @@ export default ModelBase.extend({
     // this throws an error, so we check first if name exists
     // https://github.com/fossasia/open-event-frontend/issues/4777
 
-    let normalizedName = this.name && this.name.trim().toLowerCase();
+    const normalizedName = this.name?.trim().toLowerCase();
     const socialPlatforms = ['facebook', 'twitter', 'github', 'youtube', 'linkedin', 'google'];
     if (normalizedName && !socialPlatforms.includes(normalizedName)) {
       normalizedName = 'globe';

--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -21,7 +21,7 @@ export default ModelBase.extend({
     const normalizedName = this.name?.trim().toLowerCase();
     const socialPlatforms = ['facebook', 'twitter', 'github', 'youtube', 'linkedin', 'google'];
     if (normalizedName && !socialPlatforms.includes(normalizedName)) {
-      normalizedName = 'globe';
+      return 'globe';
     }
     return normalizedName;
   }),


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4802

#### Short description of what this resolves:

Show `globe` icon if the URL is not a standard social media URL.

#### Changes proposed in this pull request:
![Screenshot at 2020-08-19 07-32-22](https://user-images.githubusercontent.com/46647141/90583588-2d7f3980-e1ee-11ea-8041-54ea672fa5e3.png)



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests, and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
