### PR TITLE
fix: show speaker name with img in overview mode

### DIFF
--- a/app/templates/components/public/session-item.hbs
+++ b/app/templates/components/public/session-item.hbs
@@ -22,7 +22,8 @@
         <div class="left floated ten wide column">
           <div class="session-speakers">
             {{#each this.session.speakers as |speaker|}}
-              <img alt="speaker" class="ui mini avatar image" src="{{if speaker.iconImageUrl speaker.iconImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
+              <img alt="speaker" class="ui mini middle aligned avatar image" src="{{if speaker.iconImageUrl speaker.iconImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
+              <span class="small text">{{speaker.name}}</span>
             {{/each}}
           </div>
         </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4815

#### Short description of what this resolves:

show speaker name with the avatar in overview mode

#### Changes proposed in this pull request:

![Screenshot at 2020-08-20 20-14-15](https://user-images.githubusercontent.com/46647141/90786894-c498de00-e321-11ea-9c54-fab7d01051c7.png)


![Screenshot at 2020-08-20 20-05-57](https://user-images.githubusercontent.com/46647141/90786783-9e733e00-e321-11ea-95d4-ab9835df3c7b.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)
