### PR TITLE
fix: page scroll with URL hash redirection.

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -442,6 +442,8 @@ export default Component.extend(FormMixin, EventWizardMixin, {
         event,
         type,
         position,
+        quantity      : 100,
+        maxPrice      : type === 'donation' ? 10000 : null,
         salesStartsAt : salesStartDateTime,
         salesEndsAt   : salesEndDateTime
       }));

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -26,7 +26,7 @@ export default class SideMenu extends Component {
     super.didInsertElement(...arguments);
     const speakersCall = await this.event.speakersCall;
     this.set('shouldShowCallforSpeakers',
-      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));    
+      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
     this.checkSpeakers();
     this.checkSessions();
   }
@@ -72,7 +72,7 @@ export default class SideMenu extends Component {
         document.querySelector(this.getAttribute('href')).scrollIntoView({
           behavior: 'smooth', block: 'start'
         });
-        
+
         document.querySelectorAll('.scroll').forEach(node => {
           node.classList.remove('active');
         });

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -56,10 +56,9 @@ export default class SideMenu extends Component {
   @action
   scrollToTarget(e) {
 
-    if(history.pushState) {
+    if (history.pushState) {
       history.pushState(null, null, e);
-    }
-    else {
+    } else {
       location.hash = e;
     }
     document.querySelector(e).scrollIntoView({

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -26,8 +26,7 @@ export default class SideMenu extends Component {
     super.didInsertElement(...arguments);
     const speakersCall = await this.event.speakersCall;
     this.set('shouldShowCallforSpeakers',
-      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
-      
+      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));     
     this.checkSpeakers();
     this.checkSessions();
   }

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -26,7 +26,7 @@ export default class SideMenu extends Component {
     super.didInsertElement(...arguments);
     const speakersCall = await this.event.speakersCall;
     this.set('shouldShowCallforSpeakers',
-      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));     
+      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
     this.checkSpeakers();
     this.checkSessions();
   }

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import moment from 'moment';
 import { SPEAKERS_FILTER } from 'open-event-frontend/routes/public/speakers';
 import { tracked } from '@glimmer/tracking';
+import $ from 'jquery';
 
 @classic
 export default class SideMenu extends Component {
@@ -13,12 +14,20 @@ export default class SideMenu extends Component {
   @tracked
   showSessions = false;
 
+  async didRender() {
+    super.didRender();
+    const anchor_tag = window.location.hash;
+    $('html, body').animate({
+      scrollTop: $(anchor_tag).offset().top
+    }, 20);
+  }
+
   async didInsertElement() {
     super.didInsertElement(...arguments);
     const speakersCall = await this.event.speakersCall;
     this.set('shouldShowCallforSpeakers',
       speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
-
+      
     this.checkSpeakers();
     this.checkSessions();
   }
@@ -46,12 +55,15 @@ export default class SideMenu extends Component {
   }
 
   @action
-  scrollToTarget() {
+  scrollToTarget(e) {
+    document.querySelector(e).scrollIntoView({
+      behavior: 'smooth', block: 'start'
+    });
     document.querySelectorAll('.scroll').forEach(anchor => {
       anchor.addEventListener('click', function(e) {
         e.preventDefault();
         document.querySelector(this.getAttribute('href')).scrollIntoView({
-          behavior: 'smooth'
+          behavior: 'smooth', block: 'start'
         });
 
         document.querySelectorAll('.scroll').forEach(node => {

--- a/app/components/public/side-menu.js
+++ b/app/components/public/side-menu.js
@@ -26,7 +26,7 @@ export default class SideMenu extends Component {
     super.didInsertElement(...arguments);
     const speakersCall = await this.event.speakersCall;
     this.set('shouldShowCallforSpeakers',
-      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));
+      speakersCall && speakersCall.announcement && (speakersCall.privacy === 'public'));    
     this.checkSpeakers();
     this.checkSessions();
   }
@@ -55,16 +55,24 @@ export default class SideMenu extends Component {
 
   @action
   scrollToTarget(e) {
+
+    if(history.pushState) {
+      history.pushState(null, null, e);
+    }
+    else {
+      location.hash = e;
+    }
     document.querySelector(e).scrollIntoView({
       behavior: 'smooth', block: 'start'
     });
+
     document.querySelectorAll('.scroll').forEach(anchor => {
       anchor.addEventListener('click', function(e) {
         e.preventDefault();
         document.querySelector(this.getAttribute('href')).scrollIntoView({
           behavior: 'smooth', block: 'start'
         });
-
+        
         document.querySelectorAll('.scroll').forEach(node => {
           node.classList.remove('active');
         });

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,11 +1,11 @@
 {{#if (and (not-eq this.session.currentRouteName 'public.cfs.new-session') (not-eq this.session.currentRouteName 'public.cfs.new-speaker') (not-eq this.session.currentRouteName 'public.cfs.edit-speaker') (not-eq this.session.currentRouteName 'public.cfs.edit-session'))}}
   <div class="ui fluid vertical {{unless this.device.isMobile 'pointing'}} menu">
     {{#if (eq this.session.currentRouteName 'public.index')}}
-      <a href='#info' {{action "scrollToTarget"}} class='item active scroll'>
+      <a href='#info' {{action "scrollToTarget" '#info'}} class='item active scroll'>
         {{t 'Info'}}
       </a>
       {{#if this.event.tickets.length}}
-        <a href='#tickets' {{action "scrollToTarget"}} class='item scroll'>
+        <a href='#tickets' {{action scrollToTarget '#tickets'}} class='item scroll'>
           {{t 'Tickets'}}
         </a>
       {{/if}}
@@ -46,17 +46,17 @@
     {{/if}}
     {{#if this.event.hasOwnerInfo}}
       {{#if (eq this.session.currentRouteName 'public.index')}}
-        <a href='#owner' {{action "scrollToTarget"}} class='item scroll'>
+        <a href='#organizer' {{action scrollToTarget '#organizer'}} class='item scroll'>
           {{t 'Organizer'}}
         </a>
       {{else}}
-        <a class="item" href="{{href-to 'public.index'}}#owner">
+        <a class="item" href="{{href-to 'public.index'}}#organizer">
           {{t 'Organizer'}}
         </a>
       {{/if}}
     {{/if}}
     {{#if (eq this.session.currentRouteName 'public.index')}}
-      <a href='#getting-here' class='item scroll'>
+      <a href='#getting-here' {{action scrollToTarget '#getting-here'}} class='item scroll'>
         {{t 'Getting here'}}
       </a>
     {{else}}

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -55,7 +55,7 @@
     <div class="ui hidden divider"></div>
   {{/if}}
   {{#if this.model.event.hasOwnerInfo}}
-    <h2 class="ui header" id="owner">
+    <h2 class="ui header" id="organizer">
       {{t 'Organized  by'}} {{this.model.event.ownerName}}
     </h2>
     {{sanitize this.model.event.ownerDescription}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4849 

#### Short description of what this resolves:

- Fixed the redirection based on URL hash and anchor tags. Now the anchored div relative to the URL hash shows up at the top of the screen on page load.
- Earlier it required two clicks initially on page load to jump to a particular section of the event page using the side-menu. This was so because the first click was required to bind the anchor scroll action with the click event. It did not trigger the scroll action on the first click. Added scroll action to the first click.

#### Demo Links:
- https://open-event-frontend-d12ttsngk.vercel.app/e/41bb1094#info
- https://open-event-frontend-d12ttsngk.vercel.app/e/41bb1094#tickets
- https://open-event-frontend-d12ttsngk.vercel.app/e/41bb1094#organizer
- https://open-event-frontend-d12ttsngk.vercel.app/e/41bb1094#getting-here

These links direct to the respective sections of the event page in the demo.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->

