### PR TITLE
feat: link event logo and name to event dashboard

### DIFF
--- a/app/templates/components/ui-table/cell/cell-event-general.hbs
+++ b/app/templates/components/ui-table/cell/cell-event-general.hbs
@@ -6,7 +6,7 @@
     {{this.record}}
   </p>
 </LinkTo>
-<div class="ui horizontal large basic buttons">
+<div class="ui horizontal attendees-margin large basic buttons">
   <LinkTo @route="events.view" @model={{this.extraRecords.identifier}}>
     <UiPopup @content={{t "Event Dashboard"}} @class="ui icon button" @position="top center">
       <i class="tasks icon"></i>

--- a/app/templates/components/ui-table/cell/cell-event-general.hbs
+++ b/app/templates/components/ui-table/cell/cell-event-general.hbs
@@ -1,6 +1,11 @@
-<div class="ui header weight-400">
-  <img src="{{if this.extraRecords.logoUrl this.extraRecords.logoUrl '/images/placeholders/Other.jpg'}}" alt="Event Logo" class="ui image"> <br> {{this.record}}
-</div>
+<LinkTo @route="events.view" @model={{this.extraRecords.identifier}}>
+  <div class="ui header">
+    <img src="{{if this.extraRecords.logoUrl this.extraRecords.logoUrl '/images/placeholders/Other.jpg'}}" alt="Event Logo" class="ui image">
+  </div>
+  <p class="ui header weight-400">
+    {{this.record}}
+  </p>
+</LinkTo>
 <div class="ui horizontal large basic buttons">
   <LinkTo @route="events.view" @model={{this.extraRecords.identifier}}>
     <UiPopup @content={{t "Event Dashboard"}} @class="ui icon button" @position="top center">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/4885

#### Short description of what this resolves:

- On the table please link the logo and event name to the specific event dashboard (of the event itself).
- Slightly increase the space between the logo and event name
- Slightly decrease the space between the event name and the below buttons

#### Changes proposed in this pull request:

## Before
![Screenshot at 2020-08-28 19-11-42](https://user-images.githubusercontent.com/46647141/91567194-5cba4700-e962-11ea-8dbe-08888777f9e2.png)

## After
![Screenshot at 2020-08-28 19-10-12](https://user-images.githubusercontent.com/46647141/91567210-65ab1880-e962-11ea-9a30-46789a8e4c5b.png)

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
