### PR TITLE
fix: increase page size to 21 for speakers

### DIFF
--- a/app/routes/public/speakers.js
+++ b/app/routes/public/speakers.js
@@ -47,7 +47,7 @@ export default class SpeakersRoute extends Route {
       event    : eventDetails,
       speakers : await this.infinity.model('speakers', {
         filter       : SPEAKERS_FILTER,
-        perPage      : 12,
+        perPage      : 21,
         startingPage : 1,
         perPageParam : 'page[size]',
         pageParam    : 'page[number]',


### PR DESCRIPTION

Fixes #4866
Making page size to 21 is giving better performance than 12 in terms of breaks while scrolling on a pageSize of 12 and total time also. And Also loads fast. So this is kind of trade of between total time and loading time I guess. So I found pageSize 21 as a best option.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
