### PR TITLE
feat: only request to fill username for social links in forms

### DIFF
--- a/app/components/widgets/forms/link-input.js
+++ b/app/components/widgets/forms/link-input.js
@@ -11,6 +11,7 @@ import '@ember/object';
   'hasLinkName::labeled',
   'hasLinkName::input:'
 )
+
 export default class LinkInput extends Component {
   hasLinkName = false;
   isChild = false;
@@ -31,14 +32,23 @@ export default class LinkInput extends Component {
   protocolAddressObserver() {
     let add = this.address;
     let proto = this.protocol;
+    const link = this.linkName.toLowerCase();
+    const socialPlatforms = ['twitter', 'facebook', 'instagram', 'linkedin', 'youtube', 'github'];
+
     if (add.includes('http://') || add.includes('https://')) {
       const temp = add.split('://');
       proto = temp[0];
       add = temp[1];
     }
+
     if (add.includes('www.')) {
       add = add.substring(add.indexOf('.') + 1);
     }
+
+    if (socialPlatforms.includes(link)) {
+      proto = `https://${link}.com/`;
+    }
+
     this.set('segmentedLink', {
       protocol : proto,
       address  : add

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -18,6 +18,7 @@
               {{#if field.isUrlField}}
                 <Widgets::Forms::LinkInput
                   @fixedName={{true}}
+                  @linkName={{field.name}}
                   @inputId={{if field.isRequired (concat "session_" field.fieldIdentifier "_required") (concat "session_" field.fieldIdentifier)}}
                   @segmentedLink={{get this.data.session field.segmentedLinkName}}
                   @canRemoveItem={{false}} />
@@ -160,6 +161,7 @@
                 {{#if field.isUrlField}}
                   <Widgets::Forms::LinkInput
                     @fixedName={{true}}
+                    @linkName={{field.name}}
                     @inputId={{if field.isRequired (concat "speaker_" field.fieldIdentifier "_required") (concat "speaker_" field.fieldIdentifier)}}
                     @segmentedLink={{get this.data.speaker field.segmentedLinkName}}
                     @canRemoveItem={{false}} />
@@ -276,6 +278,7 @@
               {{#if field.isUrlField}}
                 <Widgets::Forms::LinkInput
                   @fixedName={{true}}
+                  @linkName={{field.name}}
                   @inputId={{if field.isRequired (concat "speaker_" field.fieldIdentifier "_required") (concat "speaker_" field.fieldIdentifier)}}
                   @segmentedLink={{get this.data.speaker field.segmentedLinkName}}
                   @canRemoveItem={{false}} />

--- a/app/templates/components/widgets/forms/link-input.hbs
+++ b/app/templates/components/widgets/forms/link-input.hbs
@@ -45,9 +45,9 @@
   </div>
 {{else}}
   <div class="ui labeled input">
-          <div class="ui label">
-            {{this.protocol}}
-          </div>
-        <Input @type="text" @value={{this.address}} @name={{name}} @id={{this.inputId}} />
-        </div>
+    <div class="ui label">
+      {{this.protocol}}
+    </div>
+    <Input @type="text" @value={{this.address}} @name={{name}} @id={{this.inputId}} />
+  </div>
 {{/if}}

--- a/app/templates/components/widgets/forms/link-input.hbs
+++ b/app/templates/components/widgets/forms/link-input.hbs
@@ -44,13 +44,10 @@
     </div>
   </div>
 {{else}}
-  <UiDropdown @class="label" @selected={{this.protocol}} @onChange={{action (mut this.protocol)}}>
-    <div class="text">https://</div>
-    <i class="dropdown icon"></i>
-    <div class="menu">
-      <div class="item" data-value="http">http://</div>
-      <div class="item" data-value="https">https://</div>
-    </div>
-  </UiDropdown>
-  <Input @type="text" @value={{this.address}} @name={{name}} @id={{this.inputId}} />
+  <div class="ui labeled input">
+          <div class="ui label">
+            {{this.protocol}}
+          </div>
+        <Input @type="text" @value={{this.address}} @name={{name}} @id={{this.inputId}} />
+        </div>
 {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Refers #4609

#### Short description of what this resolves:
Made social media links on all forms in a way that users only need to add their username or other short forms.

#### Changes proposed in this pull request:
![Screenshot at 2020-09-02 20-30-14](https://user-images.githubusercontent.com/46647141/92001761-b5bc1d80-ed5c-11ea-9702-654db620fea7.png)


#### Additional info
