### PR TITLE
feat: use LinkInput for url fields in order-form

### DIFF
--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -76,6 +76,13 @@
                       @value={{mut (get holder field.identifierPath)}}
                       @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}}
                       @readonly="" />
+                  {{else if field.isUrlField}}
+                    <Widgets::Forms::LinkInput
+                      @fixedName={{true}}
+                      @linkName={{field.name}}
+                      @inputId={{if field.isRequired (concat "order_" field.fieldIdentifier "_required") (concat "order_" field.fieldIdentifier)}}
+                      @segmentedLink={{get this.data.speaker field.segmentedLinkName}}
+                      @canRemoveItem={{false}} />
                   {{else}}
                     <Input
                       @type={{field.type}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/4609

#### Short description of what this resolves:


#### Changes proposed in this pull request:

![Screenshot at 2020-09-03 14-59-33](https://user-images.githubusercontent.com/46647141/92098133-7f32e100-edf6-11ea-9d34-061b1717dc87.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
