### PR TITLE
fix: change email verification success msg

### DIFF
--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,24 +1,13 @@
-{{#if this.session.isAuthenticated}}
-
   {{#if this.success}}
     <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-      <p>Your email has been verified successfully!</p>
+      {{#if this.session.isAuthenticated}}
+        <p>Your email has been verified successfully!</p>
+      {{else}}
+        <p>Your email has been verified successfully! Please Login to continue</p>
+      {{/if}}
     </div>
   {{else}}
     <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
       <p>Error: {{t this.error}}</p>
     </div>
   {{/if}}
-
-  {{else}}
-    {{#if this.success}}
-      <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-        <p>Your email has been verified successfully! Please login to continue</p>
-      </div>
-    {{else}}
-      <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
-        <p>Error: {{t this.error}}</p>
-      </div>
-    {{/if}}
-
-{{/if}}

--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,6 +1,6 @@
 {{#if this.success}}
   <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-    <p>Your email has been verified successfully! Please login to continue.</p>
+    <p>Your email has been verified successfully!</p>
   </div>
 {{else}}
   <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">

--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,9 +1,23 @@
-{{#if this.success}}
-  <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-    <p>Your email has been verified successfully!</p>
-  </div>
-{{else}}
-  <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
-    <p>Error: {{t this.error}}</p>
-  </div>
+{{#if this.session.isAuthenticated}}
+  {{#if this.success}}
+    <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
+      <p>Your email has been verified successfully!</p>
+    </div>
+  {{else}}
+    <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
+      <p>Error: {{t this.error}}</p>
+    </div>
+  {{/if}}
 {{/if}}
+
+{{#unless this.session.isAuthenticated}}
+  {{#if this.success}}
+    <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
+      <p>Your email has been verified successfully! Please login to continue</p>
+    </div>
+  {{else}}
+    <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
+      <p>Error: {{t this.error}}</p>
+    </div>
+  {{/if}}
+{{/unless}}

--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,4 +1,5 @@
 {{#if this.session.isAuthenticated}}
+
   {{#if this.success}}
     <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
       <p>Your email has been verified successfully!</p>
@@ -8,16 +9,16 @@
       <p>Error: {{t this.error}}</p>
     </div>
   {{/if}}
-{{/if}}
 
-{{#unless this.session.isAuthenticated}}
-  {{#if this.success}}
-    <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-      <p>Your email has been verified successfully! Please login to continue</p>
-    </div>
   {{else}}
-    <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
-      <p>Error: {{t this.error}}</p>
-    </div>
-  {{/if}}
-{{/unless}}
+    {{#if this.success}}
+      <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
+        <p>Your email has been verified successfully! Please login to continue</p>
+      </div>
+    {{else}}
+      <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">
+        <p>Error: {{t this.error}}</p>
+      </div>
+    {{/if}}
+
+{{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


Fixes #
Email verification message on successful verification of users #4989 

Showing Email Verification message after checking authentication

case1 : Authenticated
Message: Your email has been successfully verified!

case2: Not Authenticated
Message: Your email has been successfully verified! Please login to continue.

#### Short description of what this resolves:
Altered success message on email verification.
