### PR TITLE
chore: change event blog url

### DIFF
--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -5,7 +5,7 @@
         <strong class="item">{{t 'Use'}} {{this.settings.appName}}</strong>
         <a class="item" href="https://support.eventyay.com" target="_blank" rel="noopener noreferrer">{{t 'How it Works'}}</a>
         <a class="item" href="{{href-to 'pricing'}}"> {{t 'Pricing'}} </a>
-        <a class="item" href="https://blog.fossasia.org/tags/open-event" rel="noopener noreferrer">{{t 'Event Blog'}}</a>
+        <a class="item" href="https://blog.eventyay.com/" rel="noopener noreferrer">{{t 'Blog'}}</a>
       </div>
     </div>
     <div class="four wide column">


### PR DESCRIPTION

Fixes #4995 

Short description of what this resolves:
Changed the URL and the section name from "Event Blog" to "Blog" in footer.