### PR TITLE
fix: change email verification message on success

### DIFF
--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,6 +1,10 @@
 {{#if this.success}}
   <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-    <p>Your email has been verified successfully! Please login to continue.</p>
+    {{#if this.session.isAuthenticated}}
+      <p>Your email has been verified successfully!</p>
+    {{else}}
+      <p>Your email has been verified successfully! Please login to continue.</p>
+    {{/if}}
   </div>
 {{else}}
   <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">

--- a/app/templates/verify.hbs
+++ b/app/templates/verify.hbs
@@ -1,10 +1,6 @@
 {{#if this.success}}
   <div class="ui {{if this.isLoading 'loading'}} icon info message eight wide column center aligned">
-    {{#if this.session.isAuthenticated}}
-      <p>Your email has been verified successfully!</p>
-    {{else}}
-      <p>Your email has been verified successfully! Please login to continue.</p>
-    {{/if}}
+    <p>Your email has been verified successfully!{{#if (not this.session.isAuthenticated)}} Please login to continue. {{/if}}</p>
   </div>
 {{else}}
   <div class="ui {{if this.isLoading 'loading'}} icon error message eight wide column center aligned">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #
Altering email verification message on successful verification of users #4989

#### Short description of what this resolves:
Showing Email Verification message after checking authentication


#### Changes proposed in this pull request:

- case1 : Authenticated
Message: Your email has been successfully verified!

- case2: Not Authenticated
Message: Your email has been successfully verified! Please login to continue.
