### PR TITLE
fix: Number of ticket calculation transpilation

### DIFF
--- a/app/mixins/event-wizard.js
+++ b/app/mixins/event-wizard.js
@@ -70,7 +70,7 @@ export default Mixin.create(MutableArray, CustomFormMixin, {
         data[key] = result.value;
       }
     }
-    const numberOfTickets = data.tickets?.length || 0;
+    const numberOfTickets = data.tickets ? data.tickets.length : 0;
 
     if (event.name && event.startsAtDate && event.endsAtDate && (event.state === 'draft' || (numberOfTickets > 0 && event.deletedTickets?.length !== numberOfTickets))) {
       await destroyDeletedTickets(event.deletedTickets);


### PR DESCRIPTION
Fixes #5117 

For some reason, babel wasn't transpiling `data.tickets?.length || 0` correctly. It transpiled it to 0 statically meaning no matter what the case, number of tickets were evaluated to 0