### PR TITLE
fix: Add split :// to link in component

### DIFF
--- a/app/components/widgets/forms/link-input.js
+++ b/app/components/widgets/forms/link-input.js
@@ -37,7 +37,7 @@ export default class LinkInput extends Component {
     let proto = this.protocol;
     if (add.includes('http://') || add.includes('https://')) {
       const temp = add.split('://');
-      proto = temp[0];
+      proto = temp[0] + '://';
       add = temp[1];
     }
     if (add.includes('www.')) {


### PR DESCRIPTION
Fixes #5115 

The implementation was correct in https://github.com/fossasia/open-event-frontend/pull/541 (https://github.com/fossasia/open-event-frontend/pull/541/commits/a4b0290fd2ed209d12f18e0313eee6d6ee7bdea7) but for some reason was made wrong in https://github.com/fossasia/open-event-frontend/pull/580 (https://github.com/fossasia/open-event-frontend/pull/580/commits/bbd3851db75a3f810fead46a3453f1c633d588e8)

If a link contains `http(s)://` it split by `://` and made protocol `https` + `://` and address rest of the link
But when it was changed, it made proto `https` and address rest of the link, so if someone pasted `https://hello.com`, the final URL will become `httpshello.com`

Anyway, LinkInput is too complex and big and should be broken down into simpler components