### PR TITLE
fix: hiding reset map button and showing map icons

### DIFF
--- a/app/templates/components/widgets/forms/location-input.hbs
+++ b/app/templates/components/widgets/forms/location-input.hbs
@@ -44,9 +44,11 @@
           placeholder={{t "Country"}} />
       </div>
       <div class="ui two column grid">
+        {{!---
         <div class="left floated column">
           <a href="#" {{action 'showAddressView' false}}>{{t 'Reset Map'}}</a>
         </div>
+        ---}}
         <div class="right floated column" style="text-align: right">
           {{yield}}
         </div>

--- a/app/templates/components/widgets/forms/location-input.hbs
+++ b/app/templates/components/widgets/forms/location-input.hbs
@@ -44,16 +44,17 @@
           placeholder={{t "Country"}} />
       </div>
       <div class="ui two column grid">
-        {{!---
+      {{!---
         <div class="left floated column">
           <a href="#" {{action 'showAddressView' false}}>{{t 'Reset Map'}}</a>
         </div>
-        ---}}
+      ---}}
         <div class="right floated column" style="text-align: right">
           {{yield}}
         </div>
       </div>
     </div>
+    {{!---
     <div class="column">
       <GMap
         @lat={{this.lat}}
@@ -64,6 +65,7 @@
         {{g-map-address-marker context address=this.combinedAddress onLocationChange=(action 'onLocationChangeHandler')}}
       </GMap>
     </div>
+    ---}}
   </div>
 {{else}}
   <div class="ui action input">


### PR DESCRIPTION

hiding reset map button, and google map, that often shows that "!" icons in input boxes

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
