### PR TITLE
fix: Allow newline in sanitized HTML

### DIFF
--- a/app/services/sanitizer.js
+++ b/app/services/sanitizer.js
@@ -26,7 +26,7 @@ export default Service.extend({
 
   // Ensure any changes to the sanitizer rules are set in the rich text editor @ components/widgets/forms/rich-text-editor.js
   options: {
-    allowedTags       : ['b', 'strong', 'i', 'em', 'u', 'ol', 'ul', 'li', 'a', 'p'],
+    allowedTags       : ['b', 'strong', 'i', 'em', 'u', 'ol', 'ul', 'li', 'a', 'p', 'br'],
     allowedAttributes : ['href', 'rel', 'target']
   },
 


### PR DESCRIPTION
Fixes #4542 
Fixes #5178 

Example Event with line breaks and links https://open-event-frontend-czssukq39.vercel.app/e/295ce8c5