### PR TITLE
fix: Show online or mixed location in event page header

### DIFF
--- a/app/controllers/public.js
+++ b/app/controllers/public.js
@@ -32,7 +32,7 @@ export default class PublicController extends Controller {
       return 'Location to be announced';
     }
   }
-  
+
   @action
   toggleMenu() {
     this.toggleProperty('isMenuOpen');

--- a/app/controllers/public.js
+++ b/app/controllers/public.js
@@ -20,7 +20,7 @@ export default class PublicController extends Controller {
     return this.session.currentRouteName && this.session.currentRouteName !== 'public.cfs.new-session' && this.session.currentRouteName !== 'public.cfs.new-speaker' && this.session.currentRouteName !== 'public.cfs.edit-speaker' && this.session.currentRouteName !== 'public.cfs.edit-session';
   }
 
-  @computed('locationName', 'online')
+  @computed('model.locationName', 'model.online')
   get headerLocation() {
     if (this.model.locationName && this.model.online) {
       return `In-Person Event and Online Event ${this.model.locationName}`;

--- a/app/controllers/public.js
+++ b/app/controllers/public.js
@@ -20,6 +20,19 @@ export default class PublicController extends Controller {
     return this.session.currentRouteName && this.session.currentRouteName !== 'public.cfs.new-session' && this.session.currentRouteName !== 'public.cfs.new-speaker' && this.session.currentRouteName !== 'public.cfs.edit-speaker' && this.session.currentRouteName !== 'public.cfs.edit-session';
   }
 
+  @computed('locationName', 'online')
+  get headerLocation() {
+    if (this.model.locationName && this.model.online) {
+      return `In-Person Event and Online Event ${this.model.locationName}`;
+    } else if (this.model.online) {
+      return 'Online Event';
+    } else if (this.model.locationName) {
+      return this.model.locationName;
+    } else {
+      return 'Location to be announced';
+    }
+  }
+  
   @action
   toggleMenu() {
     this.toggleProperty('isMenuOpen');

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -14,7 +14,7 @@
               <h5 class="event time ends">{{t 'To'}} {{header-date this.model.endsAt this.model.timezone}}</h5>
             {{/if}}
             <h1 class="event name">{{this.model.name}}</h1>
-            <h4 class="event location"><i class="icon map marker alternate"></i>{{this.model.locationName}}</h4>
+            <h4 class="event location"><i class="icon map marker alternate"></i>{{this.model.headerLocation}}</h4>
           </div>
         </div>
       </div>

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -14,7 +14,7 @@
               <h5 class="event time ends">{{t 'To'}} {{header-date this.model.endsAt this.model.timezone}}</h5>
             {{/if}}
             <h1 class="event name">{{this.model.name}}</h1>
-            <h4 class="event location"><i class="icon map marker alternate"></i>{{this.model.headerLocation}}</h4>
+            <h4 class="event location"><i class="icon map marker alternate"></i>{{this.headerLocation}}</h4>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5161 

#### Short description of what this resolves:
Fixed the issue of empty location line in the header of the public event page.

#### Changes proposed in this pull request:
- Fixed by creating a computed property as suggested by @iamareebjamal

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->