### PR TITLE
Sort events according to date by default on dashboard

### DIFF
--- a/app/components/tables/headers/sort.js
+++ b/app/components/tables/headers/sort.js
@@ -15,6 +15,12 @@ export default class Sort extends Component {
         return 'caret down';
       }
     }
+    else {
+      //default sorting for starts-at column
+      if(kebabCase(this.column.valuePath)=='starts-at'){
+        return 'caret down';
+      }
+    }
     return 'sort';
   }
 
@@ -33,6 +39,13 @@ export default class Sort extends Component {
         this.setProperties({
           sortBy  : null,
           sortDir : null
+        });
+      }
+      else {
+        //default sorting for starts-at
+        this.setProperties({
+          sortBy  : 'starts-at',
+          sortDir : 'DSC'
         });
       }
     }

--- a/app/components/tables/headers/sort.js
+++ b/app/components/tables/headers/sort.js
@@ -14,10 +14,9 @@ export default class Sort extends Component {
       } else {
         return 'caret down';
       }
-    }
-    else {
-      //default sorting for starts-at column
-      if(kebabCase(this.column.valuePath)=='starts-at'){
+    } else {
+      // default sorting for starts-at column
+      if (kebabCase(this.column.valuePath) === 'starts-at') {
         return 'caret down';
       }
     }
@@ -40,9 +39,8 @@ export default class Sort extends Component {
           sortBy  : null,
           sortDir : null
         });
-      }
-      else {
-        //default sorting for starts-at
+      } else {
+        // default sorting for starts-at
         this.setProperties({
           sortBy  : 'starts-at',
           sortDir : 'DSC'


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5175 

#### Short description of what this resolves:

Enchances the dashboard experience by sorting the events according to date by default.

#### Changes proposed in this pull request:

- Added default sorting to the start-date column of events table.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->