### PR TITLE
fix: change location search placeholder text

### DIFF
--- a/app/templates/components/quick-filter.hbs
+++ b/app/templates/components/quick-filter.hbs
@@ -10,7 +10,7 @@
         @type="text"
         @name = "location"
         @key-up={{action "handleKeyPress"}}
-        placeholder={{t "Search for events"}}
+        placeholder={{t "Search location"}}
         @value={{this.dummyLocation}}
         class="rounded-none" />
     </div>


### PR DESCRIPTION
changes placeholder "search for events" to "search location"
![edit](https://user-images.githubusercontent.com/56203058/95095503-c0494880-0748-11eb-9fd3-331f73d87849.jpg)

fixes #5240 