### PR TITLE
chore: Bundle nginx in docker for disabled fastboot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,5 +21,8 @@ testem.log
 /kubernetes/images/frontend/deploy-dist/
 /kubernetes/images/frontend/node_Modules/
 .idea
-
+.git
+docs
+kubernetes
+tests
 /yarn-error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /fastboot
 
 COPY --from=builder /app/dist/ dist/
 
-RUN apk add --no-cache ca-certificates && \
+RUN apk add --no-cache ca-certificates nginx && \
     cp dist/package.json . && \
     yarn install && \
     yarn add fastboot-app-server dotenv lodash && \
@@ -36,6 +36,10 @@ RUN apk add --no-cache ca-certificates && \
 COPY scripts/* ./scripts/
 COPY config/environment.js ./config/
 
+RUN rm /etc/nginx/conf.d/default.conf
+COPY config/nginx.conf /etc/nginx/conf.d
+RUN mkdir -p /run/nginx
+
 EXPOSE 4000
 
-CMD ["node", "./scripts/fastboot-server.js"]
+CMD ["sh", "scripts/container_start.sh"]

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,7 +28,7 @@ module.exports = function(environment) {
     },
 
     APP: {
-      apiHost      : process.env.API_HOST || 'https://open-event-api-dev.herokuapp.com',
+      apiHost      : process.env.API_HOST || 'https://api.eventyay.com',
       apiNamespace : process.env.API_NAMESPACE || 'v1'
     },
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,17 @@
+server {
+
+  listen 4000;
+
+  location / {
+    root   /fastboot/dist;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+
+  location = /50x.html {
+    root   /fastboot/dist;
+  }
+
+}

--- a/scripts/container_start.sh
+++ b/scripts/container_start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+node ./scripts/fastboot-server.js
+
+if [ "$FASTBOOT_DISABLED" == "true" ]
+then
+    nginx -g 'daemon off;'
+fi

--- a/scripts/fastboot-server.js
+++ b/scripts/fastboot-server.js
@@ -3,6 +3,16 @@ require('dotenv').config();
 const FastBootAppServer = require('fastboot-app-server');
 const { injectEnvironment } = require('./replace-config');
 
+if (process.env.INJECT_ENV === 'true') {
+  injectEnvironment();
+}
+
+const fastbootDisabled = process.env.FASTBOOT_DISABLED || 'false';
+
+if (fastbootDisabled === 'true') {
+  return;
+}
+
 const enableGzip = process.env.FASTBOOT_GZIP || 'true';
 const fastbootDistPath = process.env.FASTBOOT_DIST_PATH || './dist';
 const enableChunkedResponse = process.env.FASTBOOT_CHUNKED_RESPONSE || 'true';
@@ -10,7 +20,7 @@ const fastbootHost = process.env.FASTBOOT_HOST || '0.0.0.0';
 const fastbootPort = process.env.FASTBOOT_PORT || process.env.PORT || '4000';
 const fastbootWorkers = process.env.FASTBOOT_WORKERS || '1';
 
-let fastbootServer = new FastBootAppServer({
+const fastbootServer = new FastBootAppServer({
   distPath        : fastbootDistPath,
   gzip            : enableGzip === 'true',
   host            : fastbootHost,
@@ -18,9 +28,5 @@ let fastbootServer = new FastBootAppServer({
   chunkedResponse : enableChunkedResponse === 'true',
   workerCount     : parseInt(fastbootWorkers)
 });
-
-if (process.env.INJECT_ENV === 'true') {
-  injectEnvironment();
-}
 
 fastbootServer.start();


### PR DESCRIPTION
Fastboot is consuming too much resources and slowing down user experience (waiting time/performance), and also the behavior of the site differs on fastboot and client render, and makes it difficult to write single code and use features like cookie authentication for long periods of login. Hence, we are disabling fastboot in production as the site is already significantly fast and after some more aggressive caching on frontend and backend, it'll be even more faster