### PR TITLE
fix: Change default API based on environment

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -28,7 +28,7 @@ module.exports = function(environment) {
     },
 
     APP: {
-      apiHost      : process.env.API_HOST || 'https://api.eventyay.com',
+      apiHost      : process.env.API_HOST || (environment === 'production' ? 'https://api.eventyay.com' : 'https://open-event-api-dev.herokuapp.com'),
       apiNamespace : process.env.API_NAMESPACE || 'v1'
     },
 


### PR DESCRIPTION
In #5244, we changed the default API to production, but tests started failing because a user account was not present on production, so now we choose the API based on environment