### PR TITLE
Pre select public option in call for speakers

### DIFF
--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -167,7 +167,7 @@
       <div class="grouped fields">
         <label for="privacy">{{t 'Privacy'}}</label>
         <div class="field">
-          <div class="ui radio checkbox">
+          <div class="ui radio checkbox active">
             {{widgets/forms/radio-button this.value name='privacy' id='privacy_public' value='public' checked=this.data.speakersCall.privacy}}
             <label for="privacy_public">
               <strong>{{t 'Public'}}:</strong>


### PR DESCRIPTION

Fixes #5272 


#### Changes proposed in this pull request:
public option is pre selected in call for speakers.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
