### PR TITLE
fix: show language names in original language

### DIFF
--- a/app/services/l10n.js
+++ b/app/services/l10n.js
@@ -13,21 +13,21 @@ export default class L10nService extends L10n {
 
   @computed(function() {
     return {
-      'bn'      : this.t('Bengali/Bangla'),
-      'zh_Hans' : this.t('Chinese (Simplified)'),
-      'zh_Hant' : this.t('Chinese (Traditional)'),
+      'bn'      : this.t('বাংলা'),
+      'zh_Hans' : this.t('中文 (简化版)'),
+      'zh_Hant' : this.t('中文 (傳統的)'),
       'en'      : this.t('English'),
-      'fr'      : this.t('French'),
-      'de'      : this.t('German'),
-      'id'      : this.t('Indonesian'),
-      'ko'      : this.t('Korean'),
-      'pl'      : this.t('Polish'),
-      'es'      : this.t('Spanish'),
-      'th'      : this.t('Thai'),
-      'vi'      : this.t('Vietnamese'),
-      'hi'      : this.t('Hindi'),
-      'ja'      : this.t('Japanese'),
-      'ru'      : this.t('Russian')
+      'fr'      : this.t('français'),
+      'de'      : this.t('Deutsche'),
+      'id'      : this.t('bahasa Indonesia'),
+      'ko'      : this.t('한국어'),
+      'pl'      : this.t('Polskie'),
+      'es'      : this.t('Español'),
+      'th'      : this.t('ไทย'),
+      'vi'      : this.t('Tiếng Việt'),
+      'hi'      : this.t('हिंदी'),
+      'ja'      : this.t('日本語'),
+      'ru'      : this.t('русский')
     };
   })
   availableLocales;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5347

#### Short description of what this resolves:
It changes the the language names to the original languages respectively.


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Before:
![96756660-a8262a00-13d4-11eb-9c94-7035dbff0a06](https://user-images.githubusercontent.com/56963647/96829797-f3355100-1457-11eb-9b5b-1a78f189b4e1.png)

After:
![Screenshot from 2020-10-22 11-04-12](https://user-images.githubusercontent.com/56963647/96829674-bf5a2b80-1457-11eb-8d6a-bb4c3a091b54.png)
