### PR TITLE
fix: Remove divider to resolve UI jumping in session overview card

### DIFF
--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -83,8 +83,7 @@
     {{/if}}
     
     {{#each @session.speakers as |speaker|}}
-      <div class="ui divider"></div>
-      <img alt="speaker" class="ui tiny avatar image" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
+      <img alt="speaker" class="ui tiny avatar image mt-8" src="{{if speaker.thumbnailImageUrl speaker.thumbnailImageUrl (if speaker.photoUrl speaker.photoUrl '/images/placeholders/avatar.png')}}">
       <p>
         <br>
         {{speaker.name}}


### PR DESCRIPTION
Color area "jump difference"  issue resolved #5343

Fixes #5343

#### Short description of what this resolves:
In the public schedules, if the user expands a session the color area "jumps" a bit. The size of the color area before and after the expansion is different. This PR resolves it. Now Area should always be the same.

#### Changes proposed in this pull request:

- Removed Unwanted CSS (Ui divider)
- Added required margin and resolved the jump issue.


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

![after](https://user-images.githubusercontent.com/64387054/96899527-a4ff6c80-14ae-11eb-86b1-73717d5c2f45.gif)

