### PR TITLE
fix: Speaker Notification: HTML code in message and pop up not entirely visible

### DIFF
--- a/app/components/modals/modal-base.js
+++ b/app/components/modals/modal-base.js
@@ -7,12 +7,18 @@ import { isTesting } from 'open-event-frontend/utils/testing';
 
 export default UiModal.extend({
   tagName           : 'div',
-  classNameBindings : ['isFullScreen:fullscreen', 'isSmall:small', 'isLarge:large'],
+  classNameBindings : ['isFullScreen:fullscreen', 'isSmall:small', 'isLarge:large', 'noCropper'],
 
-  openObserver: observer('isOpen', function() {
+  openObserver: observer('isOpen', 'noCroppper', function() {
     const $element = $(this.element);
     if (this.isOpen) {
-      $element.modal('show');
+      if (this.noCropper) {
+        $element.modal({
+          centered: false
+        }).modal('show');
+      } else {
+        $element.modal('show');
+      }
     } else {
       $element.modal('hide');
     }

--- a/app/components/modals/session-notify-modal.hbs
+++ b/app/components/modals/session-notify-modal.hbs
@@ -21,7 +21,7 @@
         <label>Message</label>
         <Textarea
           name="message"
-          @rows="15"
+          @rows="13"
           @value={{this.message}} />
       </div>
     </form>

--- a/app/components/modals/session-notify-modal.js
+++ b/app/components/modals/session-notify-modal.js
@@ -16,6 +16,7 @@ export default class SessionNotifyModal extends ModalBase {
 
   constructor() {
     super(...arguments);
+    this.noCropper = true;
     this.initialize();
   }
 

--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -76,3 +76,8 @@ body.dimmable.undetached.dimmed {
     }
   }
 }
+
+.no-cropper {
+  margin-left: auto !important;
+  margin-top: 50px !important;
+}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5308 

#### Short description of what this resolves:
The issue with pop up notification box is resolved. Now the pop up notification modal is positioned well.  The pop up is fully visible(not hidden by any other area). 
Along with this, the area provided for message in pop up is reduced to make anchor tag(HTML code) not visible. HTML Anchor <a> tag  can be converted into {app_name_link} via doing some changes to open-event-server repo. Here at open-end-frontend this PR reduce size of message box by which organizer not able to see HTML code on direct vision.

#### Changes proposed in this pull request:

-Solve all issue with session notify modal.
-Reduce message box size

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
 
__Screenshots__

_before_
![4837 before](https://user-images.githubusercontent.com/72552281/97033960-c41afe80-1581-11eb-80a8-1a357bcf9a50.png)
 _after_
![5308](https://user-images.githubusercontent.com/72552281/97034229-31c72a80-1582-11eb-905b-cad0075de438.png)
