### PR TITLE
fix Tax information pop up in Wizard step 1 showing up towards bottom of screen

### DIFF
--- a/app/components/modals/modal-base.js
+++ b/app/components/modals/modal-base.js
@@ -7,12 +7,18 @@ import { isTesting } from 'open-event-frontend/utils/testing';
 
 export default UiModal.extend({
   tagName           : 'div',
-  classNameBindings : ['isFullScreen:fullscreen', 'isSmall:small', 'isLarge:large'],
+  classNameBindings : ['isFullScreen:fullscreen', 'isSmall:small', 'isLarge:large', 'noCropper'],
 
-  openObserver: observer('isOpen', function() {
+  openObserver: observer('isOpen', 'noCroppper', function() {
     const $element = $(this.element);
     if (this.isOpen) {
-      $element.modal('show');
+      if (this.noCropper) {
+        $element.modal({
+          centered: false
+        }).modal('show');
+      } else {
+        $element.modal('show');
+      } 
     } else {
       $element.modal('hide');
     }

--- a/app/components/modals/tax-info-modal.js
+++ b/app/components/modals/tax-info-modal.js
@@ -7,9 +7,7 @@ import { orderBy } from 'lodash-es';
 
 export default ModalBase.extend(FormMixin, {
   isSmall : false,
-  options : {
-    closable: false
-  },
+  noCropper : true,
 
   autoScrollToErrors   : true,
   isTaxIncludedInPrice : 'include',

--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -76,3 +76,8 @@ body.dimmable.undetached.dimmed {
     }
   }
 }
+
+.no-cropper {
+  margin-left: auto !important;
+  margin-top: 50px !important;
+}

--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -1,3 +1,4 @@
+<i class="red close icon"></i>
 <div class="header">
   {{t 'Add tax information'}}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4505 

#### Short description of what this resolves:
The issue with pop up tax information box is resolved. Now the pop up tax information modal is positioned well. The pop up is fully visible(not hidden by any other area). The session notify modal is placed at suitable placed. I have checked this modal from every scroll position and found result upto mark. Now position of session notify modal is perfect. 
Along with this, this PR also add "close" x icon on its top right of modal.


#### Changes proposed in this pull request:

- The issue with position of tax information modal is resolved.
- Add "close" x icon on its top right of modal.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__screenshots__

_before_
![4505 before](https://user-images.githubusercontent.com/72552281/97034941-4526c580-1583-11eb-8bf9-f03be4fc70e9.png)

_after_
![4505 solved](https://user-images.githubusercontent.com/72552281/97034978-4e179700-1583-11eb-8a00-40f01a903eac.png)

