### PR TITLE
fix: Show Social Links only on Event Pages that are listed on the left side bar

### DIFF
--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -42,7 +42,7 @@
         {{outlet}}
       </div>
       <div class="three wide column">
-        {{#if (not-eq this.session.currentRouteName 'public.cfs.new-speaker')}}
+        {{#if this.displaySideMenu}}
           {{#if (eq this.session.currentRouteName 'public.sessions')}}
             <div class="ui basic segment">
               <h4>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4608 

#### Short description of what this resolves:
Initially the Social Links(twitter) widget display on all the Event Pages including _new-session_ , _edit-session_ , _new-speaker_, _edit-speaker_  pages.  Left side bar not show on these listed pages but right twitter(social links) side bar widget is shown.

This PR solves this issue. Now the right side Social links widgets only visible on those pages which are listed in left side bar. Now the social Links widget not shown on _new-session_ , _edit-session_ , _new-speaker_, _edit-speaker_  pages. 

Controller of event public page contains _displaySideMenu_ function which hide left side bar menu at these four pages. This PR uses this function to hide right side widget at these four pages.

#### Changes proposed in this pull request:

- Social Links widgets only visible on the pages listed in left side bar.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

___screenshots__

__before__

edit-session page
![111](https://user-images.githubusercontent.com/72552281/97973866-be78b080-1dec-11eb-868f-d824f0116fd5.png)

edit-speaker page
![333333](https://user-images.githubusercontent.com/72552281/97973916-d51f0780-1dec-11eb-86c8-f603e912ece6.png)

__after__
new-speaker page
![4444](https://user-images.githubusercontent.com/72552281/97974028-0697d300-1ded-11eb-80c5-e3bd9fa2847d.png)

edit-speaker page
![777777](https://user-images.githubusercontent.com/72552281/97974038-0b5c8700-1ded-11eb-8fe7-8d7696396f6d.png)

edit-session page
![55555](https://user-images.githubusercontent.com/72552281/97974062-13b4c200-1ded-11eb-8451-1e4999b8ed77.png)
