### PR TITLE
fix: Removed unneccesary line breaks in event title

### DIFF
--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -6,12 +6,12 @@
 {{#if (not-includes this.session.currentRouteName 'events.view.edit')}}
   <div class="ui grid stackable">
     <div class="row">
-      <div class="twelve wide column">
+      <div class="ten wide column">
         <h2 class="ui header">
           {{this.model.name}}
         </h2>
       </div>
-      <div class="four wide column {{unless this.device.isMobile 'right aligned'}}">
+      <div class="six wide column {{unless this.device.isMobile 'right aligned'}}">
         <div class="{{ if this.device.isMobile 'ui icon fluid buttons'}}">
           <Events::View::PublishBar @event={{this.model}} @showOnInvalid={{true}} />
         </div>

--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -6,12 +6,12 @@
 {{#if (not-includes this.session.currentRouteName 'events.view.edit')}}
   <div class="ui grid stackable">
     <div class="row">
-      <div class="four wide column">
+      <div class="twelve wide column">
         <h2 class="ui header">
           {{this.model.name}}
         </h2>
       </div>
-      <div class="twelve wide column {{unless this.device.isMobile 'right aligned'}}">
+      <div class="four wide column {{unless this.device.isMobile 'right aligned'}}">
         <div class="{{ if this.device.isMobile 'ui icon fluid buttons'}}">
           <Events::View::PublishBar @event={{this.model}} @showOnInvalid={{true}} />
         </div>


### PR DESCRIPTION
Fixes #5474 

**Changes proposed in this pull request**
1. Remove unnecessary line breaks.

**Before**
![github](https://user-images.githubusercontent.com/53913514/98072498-2df1ad00-1e8c-11eb-8345-99f4a2adcec2.png)



**After**
![Screenshot 2020-11-04 at 2 19 48 AM](https://user-images.githubusercontent.com/53913514/98072517-3a760580-1e8c-11eb-8cd3-56cc1e879a85.png)


