### PR TITLE
Removed deprecated evented api method

### DIFF
--- a/app/components/tabbed-navigation.js
+++ b/app/components/tabbed-navigation.js
@@ -25,7 +25,7 @@ export default class TabbedNavigation extends Component {
     this.set('item', $('a.active', this.element).text().trim());
   }
 
-  didUpdate() {
+  hasDirtyAttributes() {
     const { isMobile } = this.device;
     if (isMobile) {
       $('a', this.element).addClass('vertical-item');

--- a/app/models/attendee.js
+++ b/app/models/attendee.js
@@ -34,7 +34,7 @@ export default ModelBase.extend({
   gender             : attr('string'),
   ageGroup           : attr('string'),
   birthDate          : attr('moment'),
-  complexFieldValues : attr(),
+  complexFieldValues : attr({ defaultValue: () => {} }),
 
   /**
    * Relationships
@@ -42,11 +42,5 @@ export default ModelBase.extend({
   event  : belongsTo('event'),
   order  : belongsTo('order'),
   ticket : belongsTo('ticket'),
-  user   : belongsTo('user'),
-
-  ready() {
-    if (!this.complexFieldValues) {
-      this.complexFieldValues = {};
-    }
-  }
+  user   : belongsTo('user')
 });

--- a/app/models/custom-form.js
+++ b/app/models/custom-form.js
@@ -51,7 +51,7 @@ export default ModelBase.extend({
   fieldIdentifier : attr('string'),
   form            : attr('string'),
   type            : attr('string', { defaultValue: 'text' }),
-  name            : attr('string'),
+  _name           : attr('string'),
   isRequired      : attr('boolean', { defaultValue: false }),
   isIncluded      : attr('boolean', { defaultValue: false }),
   isFixed         : attr('boolean', { defaultValue: false }),
@@ -92,11 +92,9 @@ export default ModelBase.extend({
     ageGroup        : 'Age Group'
   },
 
-  ready() {
-    if (!this.name) {
-      this.name = this[this.form][this.fieldIdentifier];
-    }
-  },
+  name: computed('_name', function() {
+    return this._name || this[this.form][this.fieldIdentifier];
+  }),
 
   identifierPath: computed('isComplex', function() {
     return !this.isComplex ? this.fieldIdentifier : 'complexFieldValues.' + this.fieldIdentifier;

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -33,7 +33,7 @@ export default class Session extends ModelBase.extend({
   deletedAt          : attr('string'),
   submittedAt        : attr('moment', { defaultValue: () => moment.tz(detectedTimezone) }),
   lastModifiedAt     : attr('string'),
-  complexFieldValues : attr(),
+  complexFieldValues : attr({ defaultValue: () => {} }),
   sessionType        : belongsTo('session-type'),
   microlocation      : belongsTo('microlocation'),
   track              : belongsTo('track'),
@@ -62,12 +62,6 @@ export default class Session extends ModelBase.extend({
   segmentedLinkSlidesUrl : computedSegmentedLink.bind(this)('slidesUrl'),
   segmentedLinkAudioUrl  : computedSegmentedLink.bind(this)('audioUrl'),
   segmentedLinkVideoUrl  : computedSegmentedLink.bind(this)('videoUrl'),
-  segmentedLinkSignUpUrl : computedSegmentedLink.bind(this)('signUpUrl'),
-
-  ready() {
-    if (!this.complexFieldValues) {
-      this.complexFieldValues = {};
-    }
-  }
+  segmentedLinkSignUpUrl : computedSegmentedLink.bind(this)('signUpUrl')
 
 }) {}

--- a/app/models/speaker.js
+++ b/app/models/speaker.js
@@ -34,7 +34,7 @@ export default class Speaker extends ModelBase.extend({
   city               : attr('string'),
   gender             : attr('string'),
   heardFrom          : attr('string'),
-  complexFieldValues : attr(),
+  complexFieldValues : attr({ defaultValue: () => {} }),
 
   segmentedLinkWebsite   : computedSegmentedLink.bind(this)('website'),
   segmentedLinkTwitter   : computedSegmentedLink.bind(this)('twitter'),
@@ -49,12 +49,6 @@ export default class Speaker extends ModelBase.extend({
 
   user     : belongsTo('user'),
   event    : belongsTo('event'),
-  sessions : hasMany('session'),
-
-  ready() {
-    if (!this.complexFieldValues) {
-      this.complexFieldValues = {};
-    }
-  }
+  sessions : hasMany('session')
 
 }) {}

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -97,7 +97,7 @@ export default ModelBase.extend({
   marketerEvents       : hasMany('event'),
   salesAdminEvents     : hasMany('event'),
 
-  didUpdate() {
+  hasDirtyAttributes() {
     this._super(...arguments);
     if (toString(this.id) === toString(this.authManager.currentUser.id)) {
       const user = this.store.peekRecord('user', this.id);

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -5,6 +5,6 @@ window.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember-routing.route-router' },
     { handler: 'silence', matchId: 'ember-views.curly-components.jquery-element' }, // Silencing the jquery warnings until we have moved away from jquery or used native jquery in the app.
-    { handler: 'silence', matchId: 'ember-data.evented-api-usage' } // Silencing the Evented-API warnings until we have solved https://github.com/fossasia/open-event-frontend/issues/4024 .
+    // { handler: 'silence', matchId: 'ember-data.evented-api-usage' } Silencing the Evented-API warnings until we have solved https://github.com/fossasia/open-event-frontend/issues/4024 .
   ]
 };


### PR DESCRIPTION
Fixes #4024 

#### Short description of what this resolves:
Removed `ready()` method under evented API that was going to be deprecated with ember 4.0