### PR TITLE
Standardized Date and Time

### DIFF
--- a/app/components/public/add-to-calender.hbs
+++ b/app/components/public/add-to-calender.hbs
@@ -3,9 +3,9 @@
     <i class="clock alternate outline icon pt-1"></i>
     <div class="content">
       {{#if this.isSingleDay}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "ddd, DD MMMM, YYYY"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
       {{else}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "ddd, DD MMMM, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "ddd, DD MMMM, YYYY h:mm A"}} 
       {{/if}}
       ({{this.timezone}})
       <br>

--- a/app/templates/components/order-card.hbs
+++ b/app/templates/components/order-card.hbs
@@ -27,7 +27,7 @@
       </SmartOverflow>
       <div class="meta">
         <span class="date">
-          {{moment-format this.order.event.startsAt 'ddd, DD MMMM YYYY, h:mm A'}}
+          {{moment-format this.order.event.startsAt 'ddd, DD MMMM, YYYY hh:mm A'}}
         </span>
       </div>
       <SmartOverflow @class="description">
@@ -46,7 +46,7 @@
         </span>
         <span>#{{this.order.identifier}}</span>
         {{#if this.order.completedAt}}
-          <span>{{t 'on'}} {{moment-format this.order.completedAt 'MMMM DD, YYYY h:mm A'}}</span>
+          <span>{{t 'on'}} {{moment-format this.order.completedAt 'DD MMMM, YYYY hh:mm A'}}</span>
         {{/if}}
       </span>
     </div>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -28,7 +28,7 @@
                 <small class="ui gray-text tiny">{{ticket.description}}</small>
               {{/if}}
               <div>
-                <small class="ui gray-text small">Sale ends on {{moment-format ticket.salesEndsAt 'ddd, DD MMMM YY, h:mm A'}}</small>
+                <small class="ui gray-text small">Sale ends on {{moment-format ticket.salesEndsAt 'ddd, DD MMMM, YYYY hh:mm A'}}</small>
               </div>
             </td>
             <td></td>

--- a/app/templates/components/ui-table/cell/cell-simple-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-date.hbs
@@ -4,6 +4,6 @@
   </span>
 {{else if this.record}}
   <span>
-    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat 'MMMM DD, YYYY - HH:mm A')}}
+    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat 'DD MMMM, YYYY - hh:mm A')}}
   </span>
 {{/if}}

--- a/app/templates/components/ui-table/cell/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/cell-validity.hbs
@@ -1,5 +1,5 @@
 <span>
-  {{moment-format this.record 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.record 'DD MMMM, YYYY - hh:mm A'}}
   <br>To<br>
-  {{moment-format this.extraRecords.validTill 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.extraRecords.validTill 'DD MMMM, YYYY - hh:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
@@ -14,10 +14,10 @@
       </span>
     {{/if}}
     {{#if (eq this.record.status 'completed')}}
-      {{moment-format this.record.completedAt 'MMMM Do YYYY, h:mm A -'}}
+      {{moment-format this.record.completedAt 'DD MMMM, YYYY hh:mm A -'}}
       {{moment-from-now this.record.completedAt}}
     {{else}}
-      {{moment-format this.record.createdAt 'MMMM Do YYYY, h:mm A -'}}
+      {{moment-format this.record.createdAt 'DD MMMM, YYYY hh:mm A -'}}
       {{moment-from-now this.record.createdAt}}
     {{/if}}
   </div>

--- a/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
@@ -1,3 +1,3 @@
 <span>
-  {{moment-format this.record 'MMMM Do YYYY, h:mm a'}}
+  {{moment-format this.record 'DD MMMM, YYYY hh:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
@@ -1,9 +1,9 @@
 {{#if this.record}}
   <div>
-    {{moment-format this.record 'MMMM DD, YYYY - hh:mm A'}}
+    {{moment-format this.record 'DD MMMM, YYYY - hh:mm A'}}
   </div>
 {{else}}
   <div>
-    {{moment-format this.extraRecords.createdAt 'MMMM DD, YYYY - hh:mm A'}}
+    {{moment-format this.extraRecords.createdAt 'DD MMMM, YYYY - hh:mm A'}}
   </div>
 {{/if}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -16,9 +16,9 @@
     {{/if}}
     <span class="muted text">
       {{#if this.extraRecords.completedAt}}
-        {{moment-format this.extraRecords.completedAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.completedAt}}
+        {{moment-format this.extraRecords.completedAt 'DD MMMM, YYYY hh:mm A -'}} {{moment-from-now this.extraRecords.completedAt}}
       {{else}}
-        {{moment-format this.extraRecords.createdAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.createdAt}}
+        {{moment-format this.extraRecords.createdAt 'DD MMMM, YYYY hh:mm A -'}} {{moment-from-now this.extraRecords.createdAt}}
       {{/if}}
     </span>
   </div>

--- a/app/templates/event-invoice/review.hbs
+++ b/app/templates/event-invoice/review.hbs
@@ -15,10 +15,10 @@
                 <strong>{{t 'Event Name'}}:</strong> {{this.model.event.name}}
               </div>
               <div class="item">
-                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'DD MMMM, YYYY'}} 
               </div>
               <div class="item">
-                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'DD MMMM, YYYY'}} 
               </div>
               <div class="item">
                 <strong>{{t 'Total Invoice Amount'}}:</strong> {{currency-symbol this.model.event.paymentCurrency}} {{format-money this.model.amount}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5490

#### Short description of what this resolves:

All dates and time converted to single format

#### Changes proposed in this pull request:
1. Weekly days are set to "ddd"   
 i.e Mon, Tue ...
2. Dates are set to DD MMMM, YYYY  
 eg. 30 November 2020
3. Time has been set to hh:mm A   
eg. 09:00 PM

Also use of commas are set to same all over

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
