### PR TITLE
Standardized Date and Time 

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -465,7 +465,7 @@ export default Component.extend(FormMixin, EventWizardMixin, {
       eventStartDate = moment(new Date(eventStartDate));
       this.data.event.tickets.forEach(ticket => {
         if (moment(eventStartDate).isBefore(ticket.get('salesEndsAt'))) {
-          ticket.set('salesEndsAt', moment(eventStartDate, 'MM/DD/YYYY').toDate());
+          ticket.set('salesEndsAt', moment(eventStartDate, 'D MMM, YYYY').toDate());
         }
       });
     },

--- a/app/components/public/add-to-calender.hbs
+++ b/app/components/public/add-to-calender.hbs
@@ -3,9 +3,9 @@
     <i class="clock alternate outline icon pt-1"></i>
     <div class="content">
       {{#if this.isSingleDay}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "dddd, D MMMM, YYYY h:mm A"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
       {{else}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "dddd, D MMMM, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "dddd, D MMMM, YYYY h:mm A"}} 
       {{/if}}
       ({{this.timezone}})
       <br>

--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -41,7 +41,7 @@
         <div class="right floated four wide column">
           {{#if @session.startsAt}}
             <div class=""><i class="icon map marker alternate"></i>{{@session.microlocation.name}}</div>
-            <div class="small text"><i class="wait icon"></i>{{general-date @session.startsAt @timezone 'hh:mm a / DD-MM-YYYY (z)'}}</div>
+            <div class="small text"><i class="wait icon"></i>{{general-date @session.startsAt @timezone 'D MMM, YYYY h:mm A'}}</div>
           {{/if}}
         </div>
       {{/if}}

--- a/app/controllers/account/billing/invoices/list.js
+++ b/app/controllers/account/billing/invoices/list.js
@@ -28,7 +28,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/cell-date',
         options         : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {
@@ -37,7 +37,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent : 'ui-table/cell/cell-date',
         options       : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {

--- a/app/controllers/admin/messages/list.js
+++ b/app/controllers/admin/messages/list.js
@@ -54,7 +54,7 @@ get columns() {
       isSortable      : true,
       cellComponent   : 'ui-table/cell/cell-simple-date',
       options         : {
-        dateFormat: 'MMMM DD, YYYY - HH:mm A'
+        dateFormat: 'D MMM, YYYY h:mm A'
       }
     }
 

--- a/app/controllers/admin/sales/invoices.js
+++ b/app/controllers/admin/sales/invoices.js
@@ -27,7 +27,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/cell-date',
         options         : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {
@@ -36,7 +36,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent : 'ui-table/cell/cell-date',
         options       : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {

--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -34,7 +34,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {
@@ -44,7 +44,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {
@@ -54,7 +54,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {

--- a/app/controllers/admin/users/list.js
+++ b/app/controllers/admin/users/list.js
@@ -79,7 +79,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         headerComponent : 'tables/headers/sort',
         cellComponent   : 'ui-table/cell/cell-simple-date',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       }
     ];

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -15,7 +15,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         headerComponent : 'tables/headers/sort',
         cellComponent   : 'ui-table/cell/cell-event-general',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {

--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -73,7 +73,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'submittedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {
@@ -82,7 +82,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'lastModifiedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {

--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -26,7 +26,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-date',
         headerComponent : 'tables/headers/sort',
         width           : 100,
-        dateFormat      : 'MMMM DD, YYYY - HH:mm A',
+        dateFormat      : 'D MMM, YYYY h:mm A',
         isSortable      : true
       },
       {

--- a/app/helpers/general-date.js
+++ b/app/helpers/general-date.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export function generalDate(params) {
   const timezone = params[1] || moment.tz.guess();
-  const format = params[2] || 'h:mm A, MMMM Do YYYY (z)';
+  const format = params[2] || 'D MMM, YYYY h:mm A';
   return moment(params[0]).tz(timezone).format(format);
 }
 

--- a/app/helpers/header-date.js
+++ b/app/helpers/header-date.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export function headerDate(params) {
   const timezone = params[1] ? params[1] : moment.tz.guess();
-  return `${moment(params[0]).tz(timezone).format('dddd, MMMM Do YYYY, h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
+  return `${moment(params[0]).tz(timezone).format('dddd, D MMMM, YYYY h:mm A')} (${moment.tz(params[0], timezone).zoneAbbr()})`;
 }
 
 export default Helper.helper(headerDate);

--- a/app/templates/admin/sales/revenue.hbs
+++ b/app/templates/admin/sales/revenue.hbs
@@ -38,7 +38,7 @@
                 {{order.name}}
               </td>
               <td>
-                {{moment-format order.eventDate 'MM/DD/YYYY'}} 
+                {{moment-format order.eventDate 'D MMM, YYYY'}} 
               </td>
               <td class="right aligned">
                 {{order.ticketCount}}

--- a/app/templates/components/event-invoice/invoice-summary.hbs
+++ b/app/templates/components/event-invoice/invoice-summary.hbs
@@ -26,8 +26,8 @@
     <tbody>
       <tr>
         <td>{{this.event.name}}</td>
-        <td>{{moment-format this.data.issuedAt 'MM/DD/YYYY'}}</td>
-        <td>{{moment-format this.data.completedAt 'MM/DD/YYYY'}}</td>
+        <td>{{moment-format this.data.issuedAt 'D MMM, YYYY'}}</td>
+        <td>{{moment-format this.data.completedAt 'D MMM, YYYY'}}</td>
         <td>{{currency-symbol this.eventCurrency}} {{format-money this.data.amount}}</td>
       </tr>
     </tbody>

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -58,7 +58,7 @@
       <Widgets::Forms::DatePicker
         @type="text"
         @name="start_date"
-        @placeholder="MM/DD/YYYY"
+        @placeholder="D MMM, YYYY"
         @value={{this.data.event.startsAtDate}}
         @onChange={{pipe-action (action "updateSalesEndDate") (action "onChange")}} />
     </div>
@@ -67,7 +67,7 @@
       <Widgets::Forms::TimePicker
         @type="text"
         @name="start_time"
-        @placeholder="HH:MM"
+        @placeholder="H:MM"
         @onChange={{action "onChange"}}
         @value={{this.data.event.startsAtTime}} />
     </div>
@@ -76,7 +76,7 @@
       <Widgets::Forms::DatePicker
         @type="text"
         @name="end_date"
-        @placeholder="MM/DD/YYYY"
+        @placeholder="D MMM, YYYY"
         @rangePosition="end"
         @onChange={{action "onChange"}}
         @value={{this.data.event.endsAtDate}} />
@@ -86,7 +86,7 @@
       <Widgets::Forms::TimePicker
         @type="text"
         @name="end_time"
-        @placeholder="HH:MM"
+        @placeholder="H:MM"
         @onChange={{action "onChange"}}
         @value={{this.data.event.endsAtTime}} />
     </div>

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -88,7 +88,7 @@
           </div>
           <div class="{{unless this.device.isMobile 'four wide'}} field">
             <div class="ui action input fluid">
-              <Widgets::Forms::TimePicker @value={{sessionType.length}} @placeholder="HH:MM" @icon={{false}} />
+              <Widgets::Forms::TimePicker @value={{sessionType.length}} @placeholder="H:MM" @icon={{false}} />
               {{#if (gt this.sessionTypes.length 1)}}
                 <button class="ui icon red button" type="button" {{action 'removeItem' sessionType}}>
                   <i class="minus icon"></i>
@@ -130,19 +130,19 @@
       <div class="fields">
         <div class="five wide field">
           <label class="required" for="start_date">{{t 'Starts'}}</label>
-          <Widgets::Forms::DatePicker @type="text" @name="start_date" @placeholder="MM/DD/YYYY"  @onChange={{action "onChange"}} @value={{this.data.speakersCall.startsAtDate}} />
+          <Widgets::Forms::DatePicker @type="text" @name="start_date" @placeholder="D MMM, YYYY"  @onChange={{action "onChange"}} @value={{this.data.speakersCall.startsAtDate}} />
         </div>
         <div class="two wide field">
           <label for="start_time">&nbsp;</label>
-          <Widgets::Forms::TimePicker @type="text" @name="start_time" @placeholder="HH:MM" @onChange={{action "onChange"}} @value={{this.data.speakersCall.startsAtTime}} />
+          <Widgets::Forms::TimePicker @type="text" @name="start_time" @placeholder="H:MM" @onChange={{action "onChange"}} @value={{this.data.speakersCall.startsAtTime}} />
         </div>
         <div class="five wide field">
           <label class="required" for="end_date">{{t 'Ends'}}</label>
-          <Widgets::Forms::DatePicker @type="text" @name="end_date" @placeholder="MM/DD/YYYY" @rangePosition="end" @onChange={{action "onChange"}} @value={{this.data.speakersCall.endsAtDate}} />
+          <Widgets::Forms::DatePicker @type="text" @name="end_date" @placeholder="D MMM, YYYY" @rangePosition="end" @onChange={{action "onChange"}} @value={{this.data.speakersCall.endsAtDate}} />
         </div>
         <div class="two wide field">
           <label for="end_time">&nbsp;</label>
-          <Widgets::Forms::TimePicker @type="text" @name="end_time" @placeholder="HH:MM" @onChange={{action "onChange"}} @value={{this.data.speakersCall.endsAtTime}} />
+          <Widgets::Forms::TimePicker @type="text" @name="end_time" @placeholder="H:MM" @onChange={{action "onChange"}} @value={{this.data.speakersCall.endsAtTime}} />
         </div>
         <div class="five wide field">
           <label class="required" for="timezone">{{t 'Timezone'}}</label>

--- a/app/templates/components/order-card.hbs
+++ b/app/templates/components/order-card.hbs
@@ -27,7 +27,7 @@
       </SmartOverflow>
       <div class="meta">
         <span class="date">
-          {{moment-format this.order.event.startsAt 'ddd, DD MMMM YYYY, h:mm A'}}
+          {{moment-format this.order.event.startsAt 'D MMM, YYYY h:mm A'}}
         </span>
       </div>
       <SmartOverflow @class="description">
@@ -46,7 +46,7 @@
         </span>
         <span>#{{this.order.identifier}}</span>
         {{#if this.order.completedAt}}
-          <span>{{t 'on'}} {{moment-format this.order.completedAt 'MMMM DD, YYYY h:mm A'}}</span>
+          <span>{{t 'on'}} {{moment-format this.order.completedAt 'D MMM, YYYY h:mm A'}}</span>
         {{/if}}
       </span>
     </div>

--- a/app/templates/components/public/call-for-speakers.hbs
+++ b/app/templates/components/public/call-for-speakers.hbs
@@ -4,15 +4,15 @@
   {{#if this.data.speakersCall.isOpen}}
     <a href="#" class="ui basic green label">{{t 'Open'}}</a>
     <div class="sub header">
-      {{t 'Call for Speakers is open until'}} {{moment-format this.data.speakersCall.endsAt 'ddd, MMM DD h:mm A'}}
+      {{t 'Call for Speakers is open until'}} {{moment-format this.data.speakersCall.endsAt 'dddd, D MMMM, YYYY h:mm A'}}
     </div>
   {{else}}
     <a href="#" class="ui basic red label">{{t 'Closed'}}</a>
     <div class="sub header">
       {{#if this.data.speakersCall.isInFuture}}
-        {{t 'Call for Speakers will open at'}} {{moment-format this.data.speakersCall.startsAt 'ddd, MMM DD h:mm A' }}
+        {{t 'Call for Speakers will open at'}} {{moment-format this.data.speakersCall.startsAt 'dddd, D MMMM, YYYY h:mm A' }}
       {{else}}
-        {{t 'Call for Speakers was closed at'}} {{moment-format this.data.speakersCall.endsAt 'ddd, MMM DD h:mm A'}}
+        {{t 'Call for Speakers was closed at'}} {{moment-format this.data.speakersCall.endsAt 'dddd, D MMMM, YYYY h:mm A'}}
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -28,7 +28,7 @@
                 <small class="ui gray-text tiny">{{ticket.description}}</small>
               {{/if}}
               <div>
-                <small class="ui gray-text small">Sale ends on {{moment-format ticket.salesEndsAt 'ddd, DD MMMM YY, h:mm A'}}</small>
+                <small class="ui gray-text small">Sale ends on {{moment-format ticket.salesEndsAt 'dddd, D MMMM, YYYY h:mm A'}}</small>
               </div>
             </td>
             <td></td>

--- a/app/templates/components/session-card.hbs
+++ b/app/templates/components/session-card.hbs
@@ -20,7 +20,7 @@
       <div class="meta">
         <span class="time">
           {{#if this.session.startsAt}}
-            {{moment-format this.session.startsAt 'ddd, MMM DD h:mm A'}}
+            {{moment-format this.session.startsAt 'D MMM, YYYY h:mm A'}}
           {{else}}
             {{t 'Session Not Yet Scheduled'}}
           {{/if}}

--- a/app/templates/components/ui-table/cell/cell-simple-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-date.hbs
@@ -4,6 +4,6 @@
   </span>
 {{else if this.record}}
   <span>
-    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat 'MMMM DD, YYYY - HH:mm A')}}
+    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat 'D MMM, YYYY h:mm A')}}
   </span>
 {{/if}}

--- a/app/templates/components/ui-table/cell/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/cell-validity.hbs
@@ -1,5 +1,5 @@
 <span>
-  {{moment-format this.record 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.record 'D MMM, YYYY h:mm A'}}
   <br>To<br>
-  {{moment-format this.extraRecords.validTill 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.extraRecords.validTill 'D MMM, YYYY h:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
@@ -14,10 +14,10 @@
       </span>
     {{/if}}
     {{#if (eq this.record.status 'completed')}}
-      {{moment-format this.record.completedAt 'MMMM Do YYYY, h:mm A -'}}
+      {{moment-format this.record.completedAt 'D MMM, YYYY h:mm A'}}
       {{moment-from-now this.record.completedAt}}
     {{else}}
-      {{moment-format this.record.createdAt 'MMMM Do YYYY, h:mm A -'}}
+      {{moment-format this.record.createdAt 'D MMM, YYYY h:mm A'}}
       {{moment-from-now this.record.createdAt}}
     {{/if}}
   </div>

--- a/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
@@ -1,3 +1,3 @@
 <span>
-  {{moment-format this.record 'MMMM Do YYYY, h:mm a'}}
+  {{moment-format this.record 'D MMM, YYYY h:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-date.hbs
@@ -1,9 +1,9 @@
 {{#if this.record}}
   <div>
-    {{moment-format this.record 'MMMM DD, YYYY - hh:mm A'}}
+    {{moment-format this.record 'D MMM, YYYY h:mm A'}}
   </div>
 {{else}}
   <div>
-    {{moment-format this.extraRecords.createdAt 'MMMM DD, YYYY - hh:mm A'}}
+    {{moment-format this.extraRecords.createdAt 'D MMM, YYYY h:mm A'}}
   </div>
 {{/if}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -16,9 +16,9 @@
     {{/if}}
     <span class="muted text">
       {{#if this.extraRecords.completedAt}}
-        {{moment-format this.extraRecords.completedAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.completedAt}}
+        {{moment-format this.extraRecords.completedAt 'D MMM, YYYY h:mm A'}} {{moment-from-now this.extraRecords.completedAt}}
       {{else}}
-        {{moment-format this.extraRecords.createdAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.createdAt}}
+        {{moment-format this.extraRecords.createdAt 'D MMM, YYYY h:mm A'}} {{moment-from-now this.extraRecords.createdAt}}
       {{/if}}
     </span>
   </div>

--- a/app/templates/components/widgets/forms/ticket-input.hbs
+++ b/app/templates/components/widgets/forms/ticket-input.hbs
@@ -132,7 +132,7 @@
           <Widgets::Forms::DatePicker
 @type="text"
 @name="ticket_start_date"
-@placeholder="MM/DD/YYYY"
+@placeholder="D MMM, YYYY"
 @rangePosition="start"
 @value={{this.ticket.salesStartAtDate}} />
         </div>
@@ -141,7 +141,7 @@
           <Widgets::Forms::TimePicker
 @type="text"
 @name="ticket_start_time"
-@placeholder="HH:MM"
+@placeholder="H:MM"
 @rangePosition="start"
 @value={{this.ticket.salesStartAtTime}} />
         </div>
@@ -150,7 +150,7 @@
           <Widgets::Forms::DatePicker
 @type="text"
 @name="ticket_end_date"
-@placeholder="MM/DD/YYYY"
+@placeholder="D MMM, YYYY"
 @rangePosition="end"
 @value={{this.ticket.salesEndsAtDate}} />
         </div>
@@ -159,7 +159,7 @@
           <Widgets::Forms::TimePicker
 @type="text"
 @name="ticket_end_time"
-@placeholder="HH:MM"
+@placeholder="H:MM"
 @rangePosition="end"
 @value={{this.ticket.salesEndsAtTime}} />
         </div>

--- a/app/templates/event-invoice/review.hbs
+++ b/app/templates/event-invoice/review.hbs
@@ -15,10 +15,10 @@
                 <strong>{{t 'Event Name'}}:</strong> {{this.model.event.name}}
               </div>
               <div class="item">
-                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'D MMM, YYYY h:mm A'}} 
               </div>
               <div class="item">
-                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'D MMM, YYYY h:mm A'}} 
               </div>
               <div class="item">
                 <strong>{{t 'Total Invoice Amount'}}:</strong> {{currency-symbol this.model.event.paymentCurrency}} {{format-money this.model.amount}}

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -25,13 +25,13 @@
       {{/if}}
       {{#if this.filters.start_date}}
         <div class="ui mini label">
-          {{moment-format this.filters.start_date 'ddd, MMM DD'}}
+          {{moment-format this.filters.start_date 'dddd, D MMMM, YYYY h:mm A'}}
           <a href="#" role="button" {{action 'clearFilter' 'start_date'}}><i class="icon close"></i></a>
         </div>
       {{/if}}
       {{#if this.filters.end_date}}
         <div class="ui mini label">
-          {{moment-format this.filters.end_date 'ddd, MMM DD'}}
+          {{moment-format this.filters.end_date 'dddd, D MMMM, YYYY h:mm A'}}
           <a href="#" role="button" {{action 'clearFilter' 'end_date'}}><i class="icon close"></i></a>
         </div>
       {{/if}}

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -3,7 +3,7 @@
 <div class="d-flex wrap">
   <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=null}} class="ui button mb-2">{{t 'All'}}</LinkTo>
   {{#each this.allDates as |date|}}
-    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=(moment-format date "YYYY-MM-DD")}} class="ui button mb-2">{{moment-format date 'ddd, MMM Do'}}</LinkTo>
+    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=(moment-format date "D MMM, YYYY")}} class="ui button mb-2">{{moment-format date 'D MMM, YYYY'}}</LinkTo>
   {{/each}}
 
   <Widgets::TimeZonePicker


### PR DESCRIPTION
Fixes #5490 

#### Short description of what this resolves:

Use of date and time formats reduced to two formats:- 
For tables -
1. D MMMM, YYYY h:mm A
e.g  6 October, 2020 5:45 PM

For public places - 
2. D MMM, YYYY h:mm A 
e.g  8 Dec, 2020 4:30 PM

#### Changes proposed in this pull request:

i) Date and time formats reduced from ~20 to two formats
ii) Removed "0" in front of single digit date or time formats
iii) Used D MMM, YYYY( 4 Dec, 2020 ) in place of MM/DD/YYYY( 12/04/2020 )

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
