### PR TITLE
fix: Order Page: Remove empty spaces

### DIFF
--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -83,7 +83,6 @@ body.dimmable.undetached.dimmed {
   margin-top: auto !important;
 }
 
-.display-flex {
-  display: flex;
+.space-between {
   justify-content: space-between;
 }

--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -82,3 +82,8 @@ body.dimmable.undetached.dimmed {
   margin-left: auto !important;
   margin-top: auto !important;
 }
+
+.display-flex {
+  display: flex;
+  justify-content: space-between;
+}

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -39,7 +39,7 @@
     <h3 class="weight-400">{{t 'Order Summary'}}</h3>
   </div>
   {{#if (and (or (eq this.session.currentRouteName 'orders.new') (eq this.session.currentRouteName 'orders.view') (eq this.session.currentRouteName 'orders.pending')) (not-eq this.data.status 'cancelled'))}}
-    <table class="ui very basic tablet stackable table order-summary center aligned">
+    <table class="ui very basic unstackable table order-summary center aligned">
       <thead>
         <tr>
           {{#if (eq this.data.amount 0)}}

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -19,14 +19,7 @@
         @data={{this.model.order}}
         @event={{this.model.event}}
         @eventCurrency={{this.model.order.event.paymentCurrency}} />
-    </div>
-    <div class="mobile hidden six wide column">
-      <Orders::EventInfo
-        @data={{this.model.order}} />
-    </div>
-  </div>
-  <div class="row">
-    <div class="column right aligned">
+      <br/>
       <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
         {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
         <i class="ticket alternate icon"></i>
@@ -37,23 +30,19 @@
         <i class="download icon"></i>
         {{t 'Download Invoice'}}
       </button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="ten wide column">
+      <br/><br/>
       <Forms::Orders::AttendeeList
         @save="save"
         @data={{this.model.order}}
         @fields={{this.model.form}}
         @event={{this.model.event}} />
     </div>
-    <div class="six wide column">
-      <div class="row">
-        <div class="mobile hidden row">
-          <Orders::TicketHolder
+    <div class="mobile hidden six wide column">
+      <Orders::EventInfo
+        @data={{this.model.order}} />
+      <br/>
+      <Orders::TicketHolder
             @data={{this.model.order}} />
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -30,15 +30,12 @@
       <Orders::EventInfo
         @data={{this.model.order}} />
       <br/>
-      <div class="{{if (eq this.device.isMobile false) 'display-flex'}}">
+      <div class="d-flex space-between">
         <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
           {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
           <i class="ticket alternate icon"></i>
           {{t 'Download Tickets'}}
         </button>
-        {{#if this.device.isMobile}}
-          <br/>
-        {{/if}}
         <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
           class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
           <i class="download icon"></i>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -20,29 +20,32 @@
         @event={{this.model.event}}
         @eventCurrency={{this.model.order.event.paymentCurrency}} />
       <br/>
-      <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
-        {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
-        <i class="ticket alternate icon"></i>
-        {{t 'Download Tickets'}}
-      </button>
-      <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
-        class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
-        <i class="download icon"></i>
-        {{t 'Download Invoice'}}
-      </button>
-      <br/><br/>
       <Forms::Orders::AttendeeList
         @save="save"
         @data={{this.model.order}}
         @fields={{this.model.form}}
         @event={{this.model.event}} />
     </div>
-    <div class="mobile hidden six wide column">
+    <div class="six wide column">
       <Orders::EventInfo
         @data={{this.model.order}} />
       <br/>
+      <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
+        {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
+        <i class="ticket alternate icon"></i>
+        {{t 'Download Tickets'}}
+      </button>
+      {{#if this.device.isMobile}}
+        <br/>
+      {{/if}}
+      <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
+        class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
+        <i class="download icon"></i>
+        {{t 'Download Invoice'}}
+      </button>
+      <br/><br/>
       <Orders::TicketHolder
-            @data={{this.model.order}} />
+        @data={{this.model.order}} />
     </div>
   </div>
 </div>

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -30,20 +30,22 @@
       <Orders::EventInfo
         @data={{this.model.order}} />
       <br/>
-      <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
-        {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
-        <i class="ticket alternate icon"></i>
-        {{t 'Download Tickets'}}
-      </button>
-      {{#if this.device.isMobile}}
-        <br/>
-      {{/if}}
-      <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
-        class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
-        <i class="download icon"></i>
-        {{t 'Download Invoice'}}
-      </button>
-      <br/><br/>
+      <div class="{{if (eq this.device.isMobile false) 'display-flex'}}">
+        <button class="ui labeled icon {{if this.isLoadingTickets 'loading'}} {{if this.device.isMobile 'fluid'}} button"
+          {{action this.downloadTickets this.model.event.name this.model.order.identifier}}>
+          <i class="ticket alternate icon"></i>
+          {{t 'Download Tickets'}}
+        </button>
+        {{#if this.device.isMobile}}
+          <br/>
+        {{/if}}
+        <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
+          class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
+          <i class="download icon"></i>
+          {{t 'Download Invoice'}}
+        </button>
+      </div>
+      <br/>
       <Orders::TicketHolder
         @data={{this.model.order}} />
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5559 #5566 

#### Short description of what this resolves:
Remove spaces between boxes. Enhance mobile view.

#### Changes proposed in this pull request:

- remove spaces between boxes.
- Event Information box is visible in mobile view.
- Order summary table is also be a table in mobile view as well.
- Buttons "Tickets" and "Invoice should have some spacing in between.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__screenshots__

__before__
![000111111111111](https://user-images.githubusercontent.com/72552281/98684263-f7d09380-238b-11eb-95fe-1b76ae9e0fe2.png)

![d1](https://user-images.githubusercontent.com/72552281/98744770-4c016500-23d8-11eb-967e-a388807e8453.png)


__after__

![a1](https://user-images.githubusercontent.com/72552281/98744787-5459a000-23d8-11eb-9d3a-990df9d47478.png)

![b1](https://user-images.githubusercontent.com/72552281/98744804-5ae81780-23d8-11eb-8ce1-34e38ad16ccc.png)

![c1](https://user-images.githubusercontent.com/72552281/98744818-5faccb80-23d8-11eb-8369-07fb5124029f.png)


