### PR TITLE
fix: Footer use same width as above tiles in mobile view

### DIFF
--- a/app/templates/components/footer-main.hbs
+++ b/app/templates/components/footer-main.hbs
@@ -1,6 +1,8 @@
-<div class="ui grid">
-  <div class="three wide column"></div>
-  <div class="ten wide column">
+<div class="ui {{if this.device.isMobile 'center aligned container' 'grid'}}">
+  {{#if (eq this.device.isMobile false)}}
+    <div class="three wide column"></div>
+  {{/if}}
+  <div class="{{if (eq this.device.isMobile false) 'ten wide column'}}">
     <div class="ui stackable inverted divided grid">
       <div class="four wide column">
         <div class="ui left aligned container inverted link list">
@@ -126,5 +128,7 @@
       </div>
     </div>
   </div>
-  <div class="three wide column"></div>
+  {{#if (eq this.device.isMobile false)}}
+    <div class="three wide column"></div>
+  {{/if}}
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5563 

#### Short description of what this resolves:
With this PR the footer on the mobile view have the same spacing to the left and right as the above area - with the tiles.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__Screenshots__

__before__

![y1](https://user-images.githubusercontent.com/72552281/98752200-b79efe80-23e7-11eb-9320-eee2537ad5a5.png)

__after__

![z1](https://user-images.githubusercontent.com/72552281/98752208-bec60c80-23e7-11eb-8f3a-734f8b35f98e.png)
