### PR TITLE
wip: limit front page event display logic

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -28,13 +28,14 @@ export default class IndexController extends Controller {
   @computed('filteredEvents.[]')
   get upcomingEvents() {
     return this.filteredEvents?.filter(event => {
-      let publicTicketAvailable=false;
+      let publicTicketAvailable = false;
       event.get('tickets').map(x => {
-        if(!x.isHidden) {
+        if (!x.isHidden) {
           return (publicTicketAvailable = true);
         }
-      }); 
-    {return (!event.isPromoted && publicTicketAvailable) }});
+      });
+      {return (!event.isPromoted && publicTicketAvailable) }
+    });
   }
 
   @action

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -27,7 +27,14 @@ export default class IndexController extends Controller {
 
   @computed('filteredEvents.[]')
   get upcomingEvents() {
-    return this.filteredEvents?.filter(event => !event.isPromoted);
+    return this.filteredEvents?.filter(event => {
+      let publicTicketAvailable=false;
+      event.get('tickets').map(x => {
+        if(!x.isHidden) {
+          return (publicTicketAvailable = true);
+        }
+      }); 
+    {return (!event.isPromoted && publicTicketAvailable) }});
   }
 
   @action


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/5110

- some of the things are not clear from issue. Like please clarify between public event page and start page. And Only organizer can know the sales so we can't know how much tickets are available. Then how to restrict on basis of that. And wht it exactly means - 
> limits the number of tickets and therefore no longer has a ticket on the public page
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
