### PR TITLE
fix: No error shown when image upload fails

### DIFF
--- a/app/components/widgets/forms/image-upload.js
+++ b/app/components/widgets/forms/image-upload.js
@@ -41,7 +41,9 @@ export default class ImageUpload extends Component {
       })
       .catch(e => {
         console.error('Error while uploading and setting image URL', e);
+        this.notify.error(this.l10n.t('Error while uploading and setting image URL'));
         this.set('uploadingImage', false);
+        this.set('selectedImage', null);
         this.set('errorMessage', this.i18n.t('An unexpected error has occurred.'));
       });
   }

--- a/app/components/widgets/forms/image-upload.js
+++ b/app/components/widgets/forms/image-upload.js
@@ -44,7 +44,6 @@ export default class ImageUpload extends Component {
         this.notify.error(this.l10n.t('Error while uploading and setting image URL'));
         this.set('uploadingImage', false);
         this.set('selectedImage', null);
-        this.set('errorMessage', this.i18n.t('An unexpected error has occurred.'));
       });
   }
 

--- a/app/components/widgets/forms/image-upload.js
+++ b/app/components/widgets/forms/image-upload.js
@@ -41,7 +41,7 @@ export default class ImageUpload extends Component {
       })
       .catch(e => {
         console.error('Error while uploading and setting image URL', e);
-        this.notify.error(this.l10n.t('Error while uploading and setting image URL'));
+        this.notify.error(this.l10n.t('An unexpected error has occurred.'));
         this.set('uploadingImage', false);
         this.set('selectedImage', null);
       });


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4222

#### Short description of what this resolves:
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/61289472/98985124-1f208f80-2549-11eb-9576-f4838b1ec8b1.gif)


#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
