### PR TITLE
fix: list front page restriction in frontpage tab

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -201,6 +201,7 @@ Router.map(function() {
       this.route('payment-gateway');
       this.route('ticket-fees');
       this.route('billing');
+      this.route('frontpage');
     });
     this.route('content', function() {
       this.route('social-links');

--- a/app/templates/admin/settings.hbs
+++ b/app/templates/admin/settings.hbs
@@ -23,6 +23,9 @@
         <LinkTo @route="admin.settings.billing" class="item">
           {{t 'Billing'}}
         </LinkTo>
+        <LinkTo @route="admin.settings.frontpage" class="item">
+          {{t 'Front Page'}}
+        </LinkTo>
       </TabbedNavigation>
     </div>
   </div>

--- a/app/templates/admin/settings/frontpage.hbs
+++ b/app/templates/admin/settings/frontpage.hbs
@@ -1,17 +1,112 @@
-<div class="ui segments">
-    <div class="ui raised segment">
-        <i class="check icon green"></i> {{ t 'Do not show an event on start page if it does not have any public ticket.' }}
-    </div>
-    <div class="ui raised segment">
-        <i class="check icon green"></i> {{ t 'If the sales time of the ticket is passed then event should not show on the start page.' }}
-    </div>
-    <div class="ui raised segment">
-        <i class="check icon green"></i> {{ t 'Do not show an event on start page if it all tickets are sold or only hidden ticket remain.' }}
-    </div>
-    <div class="ui raised segment">
-        <i class="check icon green"></i> {{ t 'Event should have a header Image and logo otherwise do not show on front page.' }}
-    </div>
-    <div class="ui raised segment">
-        <i class="check icon green"></i> {{ t 'Event should have Event Type, Event Topic, and Event Sub Topic.' }}
-    </div>
-</div>
+<table class="ui celled padded table">
+    <thead>
+    <tr>
+        <th class="single line"><h3>Featured Events</h3></th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Any event that is switched to Featured Event by admins is listed here.' }}
+            </td>
+        </tr>
+    </tbody>
+</table>
+<table class="ui celled padded table">
+    <thead>
+    <tr>
+        <th class="single line"><h3>Upcoming Events</h3></th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'up to 21 events should be listed here.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'admins have the option to move any event without restrictions to the top of this line by switching events to Promoted Events in the event admin panel' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'promoted events should always show up on the top of Upcoming Events' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have location or online link and a date' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have Tickets.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Do not show an event on start page if it does not have any public ticket.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'If the sales time of the ticket is passed then event should not show on the start page.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Do not show an event on start page if it all tickets are sold or only hidden ticket remain.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have an Image.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have an logo.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have an Event Topic.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have an Event Sub Topic.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'The event should have a twitter link.' }}
+            </td>
+        </tr>
+    </tbody>
+</table>
+<table class="ui celled padded table">
+    <thead>
+    <tr>
+        <th class="single line"><h3>Call for Speakers</h3></th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Up to 12 events would be listed here and there is a more link below to show more events on the cfs page if there are more events.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Events listed here have a Call For Speaker.' }}
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <i class="check icon green"></i> {{ t 'Requirements of Upcoming Events.' }}
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/app/templates/admin/settings/frontpage.hbs
+++ b/app/templates/admin/settings/frontpage.hbs
@@ -1,0 +1,17 @@
+<div class="ui segments">
+    <div class="ui raised segment">
+        <i class="check icon green"></i> {{ t 'Do not show an event on start page if it does not have any public ticket.' }}
+    </div>
+    <div class="ui raised segment">
+        <i class="check icon green"></i> {{ t 'If the sales time of the ticket is passed then event should not show on the start page.' }}
+    </div>
+    <div class="ui raised segment">
+        <i class="check icon green"></i> {{ t 'Do not show an event on start page if it all tickets are sold or only hidden ticket remain.' }}
+    </div>
+    <div class="ui raised segment">
+        <i class="check icon green"></i> {{ t 'Event should have a header Image and logo otherwise do not show on front page.' }}
+    </div>
+    <div class="ui raised segment">
+        <i class="check icon green"></i> {{ t 'Event should have Event Type, Event Topic, and Event Sub Topic.' }}
+    </div>
+</div>

--- a/app/templates/admin/settings/frontpage.hbs
+++ b/app/templates/admin/settings/frontpage.hbs
@@ -56,7 +56,7 @@
         </tr>
         <tr>
             <td>
-                <i class="check icon green"></i> {{ t 'Do not show an event on start page if it all tickets are sold or only hidden ticket remain.' }}
+                <i class="close icon red"></i> {{ t 'Do not show an event on start page if it all tickets are sold or only hidden ticket remain.' }}
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/5110

> List all start page restrictions in a subtab on the Admin Settings page here https://eventyay.com/admin/settings -> in https://eventyay.com/admin/settings/frontpage

related https://github.com/fossasia/open-event-frontend/issues/4697
- [x] In https://eventyay.com/admin/settings add a sub tab "Front Page"
- [x] Show 3 sections: Featured Events, Upcoming Events, Call for Speakers
- [x] Below each section list the requirements to be listed in the section (as listed above)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
