### PR TITLE
fix: Get rid of unsed spaces between boxes in templates of the order page

### DIFF
--- a/app/templates/orders/new.hbs
+++ b/app/templates/orders/new.hbs
@@ -21,15 +21,7 @@
           @tickets={{this.model.tickets}}
           @event={{this.model.event}}
           @eventCurrency={{this.model.order.event.paymentCurrency}} />
-      </div>
-      <div class="mobile hidden six wide column">
-        <Orders::EventInfo
-          @data={{this.model.order}}
-          @showBanner={{false}} />
-      </div>
-    </div>
-    <div class="row">
-      <div class="ten wide column">
+        <br/>
         <Forms::Orders::OrderForm
           @save="save"
           @data={{this.model.order}}
@@ -38,6 +30,10 @@
           @settings={{this.settings}} />
       </div>
       <div class="six wide column">
+        <Orders::EventInfo
+          @data={{this.model.order}}
+          @showBanner={{false}} />
+        <br/>
         {{#if this.model.order.event.ownerName}}
           <div class="mobile hidden row">
             <Orders::OrganizerInfo


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5603 

#### Short description of what this resolves:
remove empty space from new order page.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__screenshots__ 

__before__
![kaaaatuuuu old](https://user-images.githubusercontent.com/72552281/99074825-7290ed00-25de-11eb-810e-cca52a94169e.png)

__after__ 
![kaaaatuuuu](https://user-images.githubusercontent.com/72552281/99074839-791f6480-25de-11eb-8d6e-08613a3f5a96.png)

