### PR TITLE
fix: Show Location, Online Event, Mixed Event or To be Announced info correctly

### DIFF
--- a/app/templates/components/orders/event-info.hbs
+++ b/app/templates/components/orders/event-info.hbs
@@ -12,7 +12,17 @@
     <h3 class="weight-400">{{t 'When & Where'}}</h3>
   </div>
   <div class="ui padded segment">
-    <strong>{{t 'At'}} {{this.data.event.locationName}}</strong>
+    {{#if this.data.event.online}}
+      {{#if this.data.event.locationName}}
+        <strong>{{t 'Event taking place online and at'}} {{this.data.event.locationName}}</strong>
+      {{else}}
+        <strong>{{t 'Online Event'}}</strong>
+      {{/if}}
+    {{else if this.data.event.locationName}}
+      <strong>{{t 'At'}} {{this.data.event.locationName}}</strong>
+    {{else}}
+      <strong>{{t 'Location or online event details to be announced'}}</strong>
+    {{/if}}
     <br>
     <strong>{{t 'From'}}:</strong> {{header-date this.data.event.startsAt}}
     <br>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5614 

#### Short description of what this resolves:

This PR update the area to show the information according to the attendee pdf as follows:
- When an event has a location, show "At" and the location behind.
- When an event is an online event show "Online Event"
- When the event is a mixed event show "Event taking place online and at [location here]."
- When an event location or online details are "to be announced" show: "Location or online event details to be announced".


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__screenshots__

![s1](https://user-images.githubusercontent.com/72552281/99181363-0e903500-2754-11eb-9053-0880da8b53f2.png)

![s2](https://user-images.githubusercontent.com/72552281/99181365-0fc16200-2754-11eb-83b8-1faaf9bb6592.png)

![s3](https://user-images.githubusercontent.com/72552281/99181367-1059f880-2754-11eb-93e5-1284b94ddf10.png)

![s4](https://user-images.githubusercontent.com/72552281/99181368-10f28f00-2754-11eb-8001-9ab1b17ad846.png)
