### PR TITLE
fix: Change position of Paypal/Pay Now Button

### DIFF
--- a/app/templates/orders/pending.hbs
+++ b/app/templates/orders/pending.hbs
@@ -20,64 +20,58 @@
           @data={{this.model.order}}
           @event={{this.model.event}}
           @eventCurrency={{this.model.order.event.paymentCurrency}} />
-      </div>
-      <div class="mobile hidden seven wide column">
-        <Orders::EventInfo
-          @data={{this.model.order}} />
-      </div>
-    </div>
-    <div class="row">
-      <div class="nine wide right aligned column">
-        {{#if this.isStripe}}
-          <StripeCheckout
-            @image="https://stripe.com/img/documentation/checkout/marketplace.png"
-            @currency={{this.model.order.event.paymentCurrency}}
-            @locale="auto"
-            @name="Open Event"
-            @class="ui right labeled icon blue button"
-            @description={{this.paymentDescription}}
-            @amount={{this.paymentAmount}}
-            @key={{this.model.order.event.stripeAuthorization.stripePublishableKey}}
-            @onToken={{action "processStripeToken"}}
-            @onClosed={{action "checkoutClosed"}}
-            @onOpened={{action "checkoutOpened"}}>
-            {{t 'Pay Now'}}
-            <i class="credit card icon"></i>
-          </StripeCheckout>
-        {{/if}}
-        {{#if this.isPaypal}}
-          <div class='paypal-button'>
-            <PaypalButton
-              @data={{this.model.order}}
-              @paymentFor="order" />
-          </div>
-        {{/if}}
-        {{#if this.isOmise}}
-          <div>
-            <form class="checkout-form" name="checkoutForm" method='POST' action={{this.omiseFormAction}}>
-              <script type="text/javascript" src="https://cdn.omise.co/omise.js" data-key="{{this.publicKeyOmise}}" data-amount="{{this.paymentAmount}}" data-currency="{{this.model.order.event.paymentCurrency}}" data-default-payment-method="credit_card">
-                </script>
-            </form>
-          </div>
-        {{/if}}
-        {{#if this.isPaytm}}
-          <button class="ui button primary" {{action "openPaytmModal"}}>{{t 'Pay with PayTM'}}</button>
-        {{/if}}
-        {{#if this.isAliPay}}
-          <button class="ui button primary"
-            {{action "alipayCheckout" this.model.order.identifier}}>{{t 'Pay with AliPay'}}</button>
-        {{/if}}
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="nine wide column">
+          <br/>
         <Forms::Orders::AttendeeList
           @save="save"
           @data={{this.model.order}}
           @fields={{this.model.form}} />
       </div>
       <div class="seven wide column">
+        <Orders::EventInfo
+          @data={{this.model.order}} />
+        <br/>
+        <div>
+          {{#if this.isStripe}}
+            <StripeCheckout
+              @image="https://stripe.com/img/documentation/checkout/marketplace.png"
+              @currency={{this.model.order.event.paymentCurrency}}
+              @locale="auto"
+              @name="Open Event"
+              @class="ui right labeled icon blue button"
+              @description={{this.paymentDescription}}
+              @amount={{this.paymentAmount}}
+              @key={{this.model.order.event.stripeAuthorization.stripePublishableKey}}
+              @onToken={{action "processStripeToken"}}
+              @onClosed={{action "checkoutClosed"}}
+              @onOpened={{action "checkoutOpened"}}>
+              {{t 'Pay Now'}}
+              <i class="credit card icon"></i>
+            </StripeCheckout>
+          {{/if}}
+          {{#if this.isPaypal}}
+            <div class='paypal-button ui fluid button'>
+              <PaypalButton
+                @data={{this.model.order}}
+                @paymentFor="order" />
+            </div>
+          {{/if}}
+          {{#if this.isOmise}}
+            <div>
+              <form class="checkout-form" name="checkoutForm" method='POST' action={{this.omiseFormAction}}>
+                <script type="text/javascript" src="https://cdn.omise.co/omise.js" data-key="{{this.publicKeyOmise}}" data-amount="{{this.paymentAmount}}" data-currency="{{this.model.order.event.paymentCurrency}}" data-default-payment-method="credit_card">
+                </script>
+              </form>
+            </div>
+          {{/if}}
+          {{#if this.isPaytm}}
+            <button class="ui fluid button primary" {{action "openPaytmModal"}}>{{t 'Pay with PayTM'}}</button>
+          {{/if}}
+          {{#if this.isAliPay}}
+            <button class="ui fluid button primary"
+              {{action "alipayCheckout" this.model.order.identifier}}>{{t 'Pay with AliPay'}}</button>
+          {{/if}}
+        </div>
+        <br/>
         <Orders::TicketHolder
           @data={{this.model.order}} />
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Aims to fix -->

Fixes #5615

#### Short description of what this resolves:

Moves the Paypal/Pay Now button (on the order page) to the right hand side as requested. (refer image attached) and removes the extra white space.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Attachments -

![2020-11-14 (5)](https://user-images.githubusercontent.com/61330148/99140775-c0533700-266a-11eb-9d75-8c8d62360401.png)

