### PR TITLE
fix: Change Download Invoice Icon

### DIFF
--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -38,7 +38,7 @@
         </button>
         <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
           class="ui labeled icon blue {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
-          <i class="download icon"></i>
+          <i class="file alternate icon"></i>
           {{t 'Download Invoice'}}
         </button>
       </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5632 

#### Short description of what this resolves:
Changed Download Invoice icon

![Screenshot from 2020-11-15 22-27-04](https://user-images.githubusercontent.com/71120226/99191333-271f4000-2792-11eb-848a-e9188366730d.png)

