### PR TITLE
 Admin: By default sort users by last date joined with the most recent users showing up on top 

### DIFF
--- a/app/controllers/admin/users/list.js
+++ b/app/controllers/admin/users/list.js
@@ -9,6 +9,8 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
 
   sort_dir = 'ASC';
 
+  per_page = 50;
+
   @or('authManager.currentUser.isSuperAdmin', 'authManager.currentUser.isAdmin') hasRestorePrivileges;
 
   get columns() {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5157

#### Short description of what this resolves:
User per page = 50