### PR TITLE
fix: Add status "Withdrawn" and "canceled"  into sessions and speakers column

### DIFF
--- a/app/models/event-statistics-general.js
+++ b/app/models/event-statistics-general.js
@@ -11,6 +11,8 @@ export default ModelBase.extend({
   sessionsSubmitted : attr('number'),
   sessionsRejected  : attr('number'),
   sessionsConfirmed : attr('number'),
+  sessionsWithdrawn : attr('number'),
+  sessionsCanceled  : attr('number'),
   identifier        : attr('string'),
   sessionsAccepted  : attr('number'),
   sessionsDraft     : attr('number'),
@@ -18,5 +20,7 @@ export default ModelBase.extend({
   speakersConfirmed : attr('number'),
   speakersPending   : attr('number'),
   speakersRejected  : attr('number'),
+  speakersWithdrawn : attr('number'),
+  speakersCanceled  : attr('number'),
   event             : belongsTo('event')
 });

--- a/app/serializers/event-statistics-general.js
+++ b/app/serializers/event-statistics-general.js
@@ -6,6 +6,8 @@ export default ApplicationSerializer.extend({
     payload.data.attributes.speakersConfirmed = payload.data.attributes.speakers.confirmed;
     payload.data.attributes.speakersPending = payload.data.attributes.speakers.pending;
     payload.data.attributes.speakersRejected = payload.data.attributes.speakers.rejected;
+    payload.data.attributes.speakersWithdrawn = payload.data.attributes.speakers.withdrawn;
+    payload.data.attributes.speakersCanceled = payload.data.attributes.speakers.canceled;
     payload.data.attributes.speakersTotal = payload.data.attributes.speakers.total;
     return this._super(...arguments);
   },
@@ -14,6 +16,8 @@ export default ApplicationSerializer.extend({
     speakersConfirmed : 'speakersConfirmed',
     speakersPending   : 'speakersPending',
     speakersRejected  : 'speakersRejected',
+    speakersWithdrawn : 'speakersWithdrawn',
+    speakersCanceled  : 'speakersCanceled',
     speakers          : 'speakersTotal'
   }
 });

--- a/app/templates/components/ui-table/cell/cell-sessions-dashboard.hbs
+++ b/app/templates/components/ui-table/cell/cell-sessions-dashboard.hbs
@@ -5,6 +5,8 @@
     <div class="item">{{t 'Confirmed'}}: {{this.record.sessionsConfirmed}}</div>
     <div class="item">{{t 'Pending'}}: {{this.record.sessionsPending}}</div>
     <div class="item">{{t 'Rejected'}}: {{this.record.sessionsRejected}}</div>
+    <div class="item">{{t 'Withdrawn'}}: {{this.record.sessionsWithdrawn}}</div>
+    <div class="item">{{t 'Canceled'}}: {{this.record.sessionsCanceled}}</div>
   </div>
 {{else}}
   {{t 'No Session Information Added Yet'}}

--- a/app/templates/components/ui-table/cell/cell-speakers-dashboard.hbs
+++ b/app/templates/components/ui-table/cell/cell-speakers-dashboard.hbs
@@ -5,6 +5,8 @@
     <div class="item">{{t 'Confirmed'}}: {{this.record.speakersConfirmed}}</div>
     <div class="item">{{t 'Pending'}}: {{this.record.speakersPending}}</div>
     <div class="item">{{t 'Rejected'}}: {{this.record.speakersRejected}}</div>
+    <div class="item">{{t 'Withdrawn'}}: {{this.record.speakersWithdrawn}}</div>
+    <div class="item">{{t 'Canceled'}}: {{this.record.speakersCanceled}}</div>
   </div>
 {{else}}
   {{t 'No Speaker Added Yet'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5010 

required https://github.com/fossasia/open-event-server/pull/7453

#### Short description of what this resolves:

On the events dashboard at https://eventyay.com/events/live in the speakers and sessions column the status "Withdrawn" and "Canceled" are missing. This PR add them. 


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__Screenshots__

![r1](https://user-images.githubusercontent.com/72552281/99379576-e12bbe80-28ee-11eb-8cb6-f6f1b377762b.png)

