### PR TITLE
fix: Show full name and remove date and time in Organizer Orders Overview Page

### DIFF
--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -11,7 +11,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath       : 'identifier',
         extraValuePaths : ['user', 'status', 'paidVia', 'completedAt', 'createdAt'],
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-order',
-        width           : 200,
+        width           : 170,
         actions         : {
           completeOrder      : this.completeOrder.bind(this),
           deleteOrder        : this.deleteOrder.bind(this),
@@ -20,7 +20,17 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         }
       },
       {
-        name            : 'Date And Time',
+        name            : 'First Name',
+        valuePath       : 'user.firstName',
+        width           : 50
+      },
+      {
+        name            : 'Last Name',
+        valuePath       : 'user.lastName',
+        width           : 50
+      },
+      {
+        name            : 'Date and Time',
         valuePath       : 'completedAt',
         extraValuePaths : ['createdAt'],
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-date',
@@ -35,7 +45,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         extraValuePaths : ['discountCode', 'event'],
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-amount',
         headerComponent : 'tables/headers/sort',
-        width           : 100,
+        width           : 60,
         isSortable      : true
       },
       {
@@ -46,7 +56,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       {
         name      : 'Buyer/Registration Contact',
         valuePath : 'user.email',
-        width     : 140
+        width     : 100
 
       }
     ];

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-amount.hbs
@@ -1,4 +1,4 @@
-<div class="weight-400">
+<div class="center aligned weight-400">
   <CurrencyAmount @currency={{this.extraRecords.event.paymentCurrency}} @amount={{this.record}}/>
 </div>
 {{#if this.extraRecords.discountCode.code}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -3,7 +3,12 @@
     {{this.record}}
   </a>
   <span class="weight-400">
-    {{t 'by'}} {{if this.extraRecords.user.firstName this.extraRecords.user.firstName (t 'Name not provided')}}
+    {{t 'by'}}
+    {{#if this.extraRecords.user.firstName}}
+      {{this.extraRecords.user.firstName}} {{if this.extraRecords.user.lastName this.extraRecords.user.lastName}}
+    {{else}} 
+      (t 'Name not provided')}}
+    {{/if}}
   </span>
   <div class="ui basic mini {{order-color this.extraRecords.status}} label">
     {{this.extraRecords.status}}
@@ -14,13 +19,6 @@
         {{t 'Payment via'}} {{this.extraRecords.paidVia}}
       </span>
     {{/if}}
-    <span class="muted text">
-      {{#if this.extraRecords.completedAt}}
-        {{moment-format this.extraRecords.completedAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.completedAt}}
-      {{else}}
-        {{moment-format this.extraRecords.createdAt 'MMMM Do YYYY, h:mm A -'}} {{moment-from-now this.extraRecords.createdAt}}
-      {{/if}}
-    </span>
   </div>
 </div>
 <div class="ui horizontal compact basic buttons">

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -2,14 +2,6 @@
   <a class="main content" href="{{href-to 'orders.view' this.record}}">
     {{this.record}}
   </a>
-  <span class="weight-400">
-    {{t 'by'}}
-    {{#if this.extraRecords.user.firstName}}
-      {{this.extraRecords.user.firstName}} {{if this.extraRecords.user.lastName this.extraRecords.user.lastName}}
-    {{else}} 
-      (t 'Name not provided')}}
-    {{/if}}
-  </span>
   <div class="ui basic mini {{order-color this.extraRecords.status}} label">
     {{this.extraRecords.status}}
   </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5668 

#### Changes proposed in this pull request:

- In the first column show full name.
- take out the date and time in the first column (we already have it in the second column)

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

__screenshots__ 

![l1](https://user-images.githubusercontent.com/72552281/99386568-b2b2e100-28f8-11eb-9726-696c28b0710e.png)
