### PR TITLE
Wizard Step3/Scheduler: Rooms are not sortable

### DIFF
--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -184,7 +184,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
           this.data.tracks.addObject(this.store.createRecord('track'));
           break;
         case 'microlocation':
-          this.data.microlocations.addObject(this.store.createRecord('microlocation', {position}));
+          this.data.microlocations.addObject(this.store.createRecord('microlocation', { position }));
           break;
       }
     },

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -213,6 +213,9 @@ export default Component.extend(EventWizardMixin, FormMixin, {
         isComplex : true
       }));
     },
+    removeField(field) {
+      this.data.customForms.removeObject(field);
+    },
     resetCFS() {
       this.set('data.speakersCall.announcement', null);
     },

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -140,7 +140,12 @@ export default Component.extend(EventWizardMixin, FormMixin, {
   }),
 
   microlocations: computed('data.microlocations.@each.isDeleted', 'data.microlocations.@each.position', function() {
-    return this.data.event.microlocations.sortBy('position').filterBy('isDeleted', false);
+    const sortedRooms = this.data.event.microlocations.sortBy('position').filterBy('isDeleted', false);
+    sortedRooms.forEach((room, idx) => {
+      room.set('position', idx);
+    });
+    
+    return sortedRooms;
   }),
 
   complexCustomForms: computed('data.customForms.@each.isComplex', function() {
@@ -191,16 +196,14 @@ export default Component.extend(EventWizardMixin, FormMixin, {
         const pos = room.get('position');
         pos > index && room.set('position', pos + 1);
       });
-      this.data.microlocations.addObject(this.store.createRecord('microlocation', { position: index + 1 }));
+      this.data.event.microlocations.addObject(this.store.createRecord('microlocation', { position: index + 1 }));
     },
 
     removeRoom(room, index) {
       room.deleteRecord();
-      this.data.microlocations.forEach(item => {
+      this.microlocations.forEach(item => {
         const pos = item.get('position');
-        if (pos > index) {
-          item.set('position', pos - 1);
-        }
+        pos > index && item.set('position', pos - 1);
       });
     },
 
@@ -219,7 +222,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
     moveRoom(item, direction) {
       const idx = item.get('position');
       const otherIdx = direction === 'up' ? (idx - 1) : (idx + 1);
-      const other = this.data.microlocations.find(item => item.get('position') === otherIdx);
+      const other = this.microlocations.find(item => item.get('position') === otherIdx);
       other.set('position', idx);
       item.set('position', otherIdx);
     }

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -213,9 +213,6 @@ export default Component.extend(EventWizardMixin, FormMixin, {
         isComplex : true
       }));
     },
-    removeField(field) {
-      this.data.customForms.removeObject(field);
-    },
     resetCFS() {
       this.set('data.speakersCall.announcement', null);
     },

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -144,7 +144,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
     sortedRooms.forEach((room, idx) => {
       room.set('position', idx);
     });
-    
+
     return sortedRooms;
   }),
 

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -139,8 +139,8 @@ export default Component.extend(EventWizardMixin, FormMixin, {
     return grouped;
   }),
 
-  microlocations: computed('data.microlocations.@each.isDeleted', function() {
-    return this.data.event.microlocations.filterBy('isDeleted', false);
+  microlocations: computed('data.microlocations.@each.isDeleted', 'data.microlocations.@each.position', function() {
+    return this.data.event.microlocations.sortBy('position').filterBy('isDeleted', false);
   }),
 
   complexCustomForms: computed('data.customForms.@each.isComplex', function() {
@@ -175,7 +175,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
   },
 
   actions: {
-    addItem(type) {
+    addItem(type, position) {
       switch (type) {
         case 'sessionType':
           this.data.sessionTypes.addObject(this.store.createRecord('session-type'));
@@ -184,7 +184,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
           this.data.tracks.addObject(this.store.createRecord('track'));
           break;
         case 'microlocation':
-          this.data.microlocations.addObject(this.store.createRecord('microlocation'));
+          this.data.microlocations.addObject(this.store.createRecord('microlocation', {position}));
           break;
       }
     },
@@ -199,6 +199,12 @@ export default Component.extend(EventWizardMixin, FormMixin, {
     },
     onChange() {
       this.onValid(() => {});
+    },
+    moveItem(item, type, direction) {
+      const index = item.get('position');
+      const otherItem = this.data.event.get(type).find(otherItem => otherItem.get('position') === (direction === 'up' ? (index - 1) : (index + 1)));
+      otherItem.set('position', index);
+      item.set('position', direction === 'up' ? (index - 1) : (index + 1));
     }
   }
 });

--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -175,7 +175,7 @@ export default Component.extend(EventWizardMixin, FormMixin, {
   },
 
   actions: {
-    addItem(type, position) {
+    addItem(type) {
       switch (type) {
         case 'sessionType':
           this.data.sessionTypes.addObject(this.store.createRecord('session-type'));
@@ -183,11 +183,27 @@ export default Component.extend(EventWizardMixin, FormMixin, {
         case 'track':
           this.data.tracks.addObject(this.store.createRecord('track'));
           break;
-        case 'microlocation':
-          this.data.microlocations.addObject(this.store.createRecord('microlocation', { position }));
-          break;
       }
     },
+
+    addRoom(index) {
+      this.microlocations.forEach(room => {
+        const pos = room.get('position');
+        pos > index && room.set('position', pos + 1);
+      });
+      this.data.microlocations.addObject(this.store.createRecord('microlocation', { position: index + 1 }));
+    },
+
+    removeRoom(room, index) {
+      room.deleteRecord();
+      this.data.microlocations.forEach(item => {
+        const pos = item.get('position');
+        if (pos > index) {
+          item.set('position', pos - 1);
+        }
+      });
+    },
+
     addCustomField() {
       this.data.customForms.addObject(this.store.createRecord('customForm', {
         event     : this.data.event,
@@ -200,11 +216,12 @@ export default Component.extend(EventWizardMixin, FormMixin, {
     onChange() {
       this.onValid(() => {});
     },
-    moveItem(item, type, direction) {
-      const index = item.get('position');
-      const otherItem = this.data.event.get(type).find(otherItem => otherItem.get('position') === (direction === 'up' ? (index - 1) : (index + 1)));
-      otherItem.set('position', index);
-      item.set('position', direction === 'up' ? (index - 1) : (index + 1));
+    moveRoom(item, direction) {
+      const idx = item.get('position');
+      const otherIdx = direction === 'up' ? (idx - 1) : (idx + 1);
+      const other = this.data.microlocations.find(item => item.get('position') === otherIdx);
+      other.set('position', idx);
+      item.set('position', otherIdx);
     }
   }
 });

--- a/app/models/microlocation.ts
+++ b/app/models/microlocation.ts
@@ -7,7 +7,7 @@ export default class Microlocation extends ModelBase.extend({
   floor     : attr('number'),
   latitude  : attr('number'),
   longitude : attr('number'),
-  position  : attr('number', { defaultValue: 0}),
+  position  : attr('number', { defaultValue: 0 }),
 
   sessions    : hasMany('session'),
   event       : belongsTo('event'),

--- a/app/models/microlocation.ts
+++ b/app/models/microlocation.ts
@@ -7,6 +7,7 @@ export default class Microlocation extends ModelBase.extend({
   floor     : attr('number'),
   latitude  : attr('number'),
   longitude : attr('number'),
+  position  : attr('number', { defaultValue: 0}),
 
   sessions    : hasMany('session'),
   event       : belongsTo('event'),

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -78,12 +78,12 @@
           </div>
           <div class="ui icon buttons {{if this.device.isLargeMonitor 'right floated'}}">
             {{#if (not-eq index 0)}}
-              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "up"}} data-content="Move ticket up">
+              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "up"}} data-content="Move room up">
                 <i class="up arrow icon"></i>
               </button>
             {{/if}}
             {{#if (not-eq microlocation.position (dec this.microlocations.length))}}
-              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "down"}} data-content="Move ticket down">
+              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "down"}} data-content="Move room down">
                 <i class="down arrow icon"></i>
               </button>
             {{/if}}

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -67,23 +67,23 @@
             <div class="ui action input fluid">
               <Input @type="number" @value={{microlocation.floor}} placeholder="Floor" />
               {{#if (gt this.microlocations.length 1)}}
-                <button class="ui icon red button" type="button" {{action 'removeItem' microlocation}}>
+                <button class="ui icon red button" type="button" {{action 'removeRoom' microlocation index}}>
                   <i class="minus icon"></i>
                 </button>
               {{/if}}
-              <button class="ui icon primary button" type="button" {{action 'addItem' 'microlocation' this.microlocations.length}}>
+              <button class="ui icon primary button" type="button" {{action 'addRoom' index}}>
                 <i class="plus icon"></i>
               </button>
             </div>
           </div>
           <div class="ui icon buttons {{if this.device.isLargeMonitor 'right floated'}}">
             {{#if (not-eq index 0)}}
-              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "up"}} data-content="Move room up">
+              <button type="button" class="ui button" {{action "moveRoom" microlocation "up"}} data-content="Move room up">
                 <i class="up arrow icon"></i>
               </button>
             {{/if}}
             {{#if (not-eq microlocation.position (dec this.microlocations.length))}}
-              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "down"}} data-content="Move room down">
+              <button type="button" class="ui button" {{action "moveRoom" microlocation "down"}} data-content="Move room down">
                 <i class="down arrow icon"></i>
               </button>
             {{/if}}

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -211,7 +211,8 @@
         <Forms::Wizard::CustomForms::Table
           @headerText="Collect Speaker Details"
           @fields={{this.customForm.speaker}}
-          @updateField={{action (mut this.speakerField)}} />
+          @updateField={{action (mut this.speakerField)}} 
+          @removeField={{action "removeField"}} />
 
         <Forms::Wizard::CustomFormInput
           @customForms={{this.data.customForms}}
@@ -225,7 +226,8 @@
         <Forms::Wizard::CustomForms::Table
           @headerText="Collect Session Details"
           @fields={{this.customForm.session}}
-          @updateField={{action (mut this.sessionField)}} />
+          @updateField={{action (mut this.sessionField)}}
+          @removeField={{action "removeField"}}/>
 
         <Forms::Wizard::CustomFormInput
           @customForms={{this.data.customForms}}

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -58,7 +58,7 @@
 
     <div class="field">
       <label class="required">{{t 'Microlocations or Virtual Online Rooms'}}</label>
-      {{#each this.microlocations as |microlocation|}}
+      {{#each this.microlocations as |microlocation index|}}
         <div class="{{if this.device.isMobile 'grouped'}} fields">
           <div class="{{unless this.device.isMobile 'three wide'}} field">
             <Input @type="text" @value={{microlocation.name}} placeholder="Name" />
@@ -71,10 +71,22 @@
                   <i class="minus icon"></i>
                 </button>
               {{/if}}
-              <button class="ui icon primary button" type="button" {{action 'addItem' 'microlocation'}}>
+              <button class="ui icon primary button" type="button" {{action 'addItem' 'microlocation' this.microlocations.length}}>
                 <i class="plus icon"></i>
               </button>
             </div>
+          </div>
+          <div class="ui icon buttons {{if this.device.isLargeMonitor 'right floated'}}">
+            {{#if (not-eq index 0)}}
+              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "up"}} data-content="Move ticket up">
+                <i class="up arrow icon"></i>
+              </button>
+            {{/if}}
+            {{#if (not-eq microlocation.position (dec this.microlocations.length))}}
+              <button type="button" class="ui button" {{action "moveItem" microlocation "microlocations" "down"}} data-content="Move ticket down">
+                <i class="down arrow icon"></i>
+              </button>
+            {{/if}}
           </div>
         </div>
       {{/each}}

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -211,8 +211,7 @@
         <Forms::Wizard::CustomForms::Table
           @headerText="Collect Speaker Details"
           @fields={{this.customForm.speaker}}
-          @updateField={{action (mut this.speakerField)}} 
-          @removeField={{action "removeField"}} />
+          @updateField={{action (mut this.speakerField)}} />
 
         <Forms::Wizard::CustomFormInput
           @customForms={{this.data.customForms}}
@@ -226,8 +225,7 @@
         <Forms::Wizard::CustomForms::Table
           @headerText="Collect Session Details"
           @fields={{this.customForm.session}}
-          @updateField={{action (mut this.sessionField)}}
-          @removeField={{action "removeField"}}/>
+          @updateField={{action (mut this.sessionField)}} />
 
         <Forms::Wizard::CustomFormInput
           @customForms={{this.data.customForms}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4164

#### Short description of what this resolves:
This resolved ordering issue of rooms on Session-Speaker Step when creating event.

#### Changes proposed in this pull request:

-position field is added to Microlocation.ts model.
-addItem action is modified and moveItem action is added newly in sessions-speakers-step.js component.
-sessions-speakers-step.hbs template is modified.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
