### PR TITLE
fix: time standardization in two formats only

### DIFF
--- a/app/components/public/add-to-calender.hbs
+++ b/app/components/public/add-to-calender.hbs
@@ -3,9 +3,9 @@
     <i class="clock alternate outline icon pt-1"></i>
     <div class="content">
       {{#if this.isSingleDay}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "dddd, D MMMM, YYYY"}}<br>{{general-date @event.startsAt @event.timezone "h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "h:mm A"}} 
       {{else}}
-        {{general-date @event.startsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "dddd, MMMM DD, YYYY h:mm A"}} 
+        {{general-date @event.startsAt @event.timezone "dddd, D MMMM, YYYY h:mm A"}} {{t 'to'}} {{general-date @event.endsAt @event.timezone "dddd, D MMMM, YYYY h:mm A"}} 
       {{/if}}
       ({{this.timezone}})
       <br>

--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -49,7 +49,7 @@
         <div class="right floated four wide column">
           {{#if @session.startsAt}}
             <div class=""><i class="icon map marker alternate"></i>{{@session.microlocation.name}}</div>
-            <div class="small text"><i class="wait icon"></i>{{general-date @session.startsAt @timezone 'hh:mm a / DD-MM-YYYY (z)'}}</div>
+            <div class="small text"><i class="wait icon"></i>{{general-date @session.startsAt @timezone 'D MMM, YYYY h:mm A (z)'}}</div>
           {{/if}}
         </div>
       {{/if}}

--- a/app/controllers/account/billing/invoices/list.js
+++ b/app/controllers/account/billing/invoices/list.js
@@ -28,7 +28,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/cell-date',
         options         : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {
@@ -37,7 +37,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent : 'ui-table/cell/cell-date',
         options       : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {

--- a/app/controllers/admin/sales/invoices.js
+++ b/app/controllers/admin/sales/invoices.js
@@ -27,7 +27,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/cell-date',
         options         : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {
@@ -36,7 +36,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent : 'ui-table/cell/cell-date',
         options       : {
           timezone   : 'UTC',
-          dateFormat : 'MMMM DD, YYYY'
+          dateFormat : 'D MMM, YYYY'
         }
       },
       {

--- a/app/controllers/admin/sessions/list.js
+++ b/app/controllers/admin/sessions/list.js
@@ -34,7 +34,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {
@@ -44,7 +44,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {

--- a/app/controllers/admin/users/list.js
+++ b/app/controllers/admin/users/list.js
@@ -82,7 +82,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         headerComponent : 'tables/headers/sort',
         cellComponent   : 'ui-table/cell/cell-simple-date',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - hh:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       }
     ];

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -18,7 +18,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         headerComponent : 'tables/headers/sort',
         cellComponent   : 'ui-table/cell/cell-event-general',
         options         : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm A'
+          dateFormat: 'D MMM, YYYY h:mm A'
         }
       },
       {

--- a/app/controllers/events/list.js
+++ b/app/controllers/events/list.js
@@ -6,7 +6,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
   sort_by = 'starts-at';
 
   sort_dir = 'DSC';
-  
+
   get columns() {
     return [
       {

--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -73,7 +73,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'submittedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm'
+          dateFormat: "D MMM, YYYY HH:MM A (z)"
         }
       },
       {
@@ -82,7 +82,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'lastModifiedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'MMMM DD, YYYY - HH:mm'
+          dateFormat: "D MMM, YYYY HH:MM A (z)"
         }
       },
       {

--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -73,7 +73,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'submittedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'D MMM, YYYY HH:MM A (z)'
+          dateFormat: 'D MMM, YYYY h:mm A (z)'
         }
       },
       {
@@ -82,7 +82,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'lastModifiedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: 'D MMM, YYYY HH:MM A (z)'
+          dateFormat: 'D MMM, YYYY h:mm A (z)'
         }
       },
       {

--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -73,7 +73,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'submittedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: "D MMM, YYYY HH:MM A (z)"
+          dateFormat: 'D MMM, YYYY HH:MM A (z)'
         }
       },
       {
@@ -82,7 +82,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         valuePath     : 'lastModifiedAt',
         cellComponent : 'ui-table/cell/cell-simple-date',
         options       : {
-          dateFormat: "D MMM, YYYY HH:MM A (z)"
+          dateFormat: 'D MMM, YYYY HH:MM A (z)'
         }
       },
       {

--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -35,7 +35,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-date',
         headerComponent : 'tables/headers/sort',
         width           : 100,
-        dateFormat      : "D MMM, YYYY HH:MM A (z)",
+        dateFormat      : 'D MMM, YYYY HH:MM A (z)',
         isSortable      : true
       },
       {

--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -35,7 +35,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-date',
         headerComponent : 'tables/headers/sort',
         width           : 100,
-        dateFormat      : 'D MMM, YYYY HH:MM A (z)',
+        dateFormat      : 'D MMM, YYYY h:mm A (z)',
         isSortable      : true
       },
       {

--- a/app/controllers/events/view/tickets/orders/list.js
+++ b/app/controllers/events/view/tickets/orders/list.js
@@ -35,7 +35,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         cellComponent   : 'ui-table/cell/events/view/tickets/orders/cell-date',
         headerComponent : 'tables/headers/sort',
         width           : 100,
-        dateFormat      : 'MMMM DD, YYYY - HH:mm A',
+        dateFormat      : "D MMM, YYYY HH:MM A (z)",
         isSortable      : true
       },
       {

--- a/app/templates/admin/sales/revenue.hbs
+++ b/app/templates/admin/sales/revenue.hbs
@@ -38,7 +38,7 @@
                 {{order.name}}
               </td>
               <td>
-                {{moment-format order.eventDate 'MM/DD/YYYY'}} 
+                {{moment-format order.eventDate 'D MMM, YYYY'}} 
               </td>
               <td class="right aligned">
                 {{order.ticketCount}}

--- a/app/templates/components/event-invoice/invoice-summary.hbs
+++ b/app/templates/components/event-invoice/invoice-summary.hbs
@@ -26,8 +26,8 @@
     <tbody>
       <tr>
         <td>{{this.event.name}}</td>
-        <td>{{moment-format this.data.issuedAt 'MM/DD/YYYY'}}</td>
-        <td>{{moment-format this.data.completedAt 'MM/DD/YYYY'}}</td>
+        <td>{{moment-format this.data.issuedAt 'D MMM, YYYY'}}</td>
+        <td>{{moment-format this.data.completedAt 'D MMM, YYYY'}}</td>
         <td>{{currency-symbol this.eventCurrency}} {{format-money this.data.amount}}</td>
       </tr>
     </tbody>

--- a/app/templates/components/order-card.hbs
+++ b/app/templates/components/order-card.hbs
@@ -27,7 +27,7 @@
       </SmartOverflow>
       <div class="meta">
         <span class="date">
-          {{moment-format this.order.event.startsAt 'ddd, DD MMMM YYYY, h:mm A'}}
+          {{general-date this.order.event.startsAt this.order.event.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}
         </span>
       </div>
       <SmartOverflow @class="description">

--- a/app/templates/components/public/call-for-speakers.hbs
+++ b/app/templates/components/public/call-for-speakers.hbs
@@ -4,15 +4,15 @@
   {{#if this.data.speakersCall.isOpen}}
     <a href="#" class="ui basic green label">{{t 'Open'}}</a>
     <div class="sub header">
-      {{t 'Call for Speakers is open until'}} {{moment-format this.data.speakersCall.endsAt 'ddd, MMM DD h:mm A'}}
+      {{t 'Call for Speakers is open until'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
     </div>
   {{else}}
     <a href="#" class="ui basic red label">{{t 'Closed'}}</a>
     <div class="sub header">
       {{#if this.data.speakersCall.isInFuture}}
-        {{t 'Call for Speakers will open at'}} {{moment-format this.data.speakersCall.startsAt 'ddd, MMM DD h:mm A' }}
+        {{t 'Call for Speakers will open at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
       {{else}}
-        {{t 'Call for Speakers was closed at'}} {{moment-format this.data.speakersCall.endsAt 'ddd, MMM DD h:mm A'}}
+        {{t 'Call for Speakers was closed at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/public/call-for-speakers.hbs
+++ b/app/templates/components/public/call-for-speakers.hbs
@@ -4,15 +4,15 @@
   {{#if this.data.speakersCall.isOpen}}
     <a href="#" class="ui basic green label">{{t 'Open'}}</a>
     <div class="sub header">
-      {{t 'Call for Speakers is open until'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
+      {{t 'Call for Speakers is open until'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}
     </div>
   {{else}}
     <a href="#" class="ui basic red label">{{t 'Closed'}}</a>
     <div class="sub header">
       {{#if this.data.speakersCall.isInFuture}}
-        {{t 'Call for Speakers will open at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
+        {{t 'Call for Speakers will open at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}
       {{else}}
-        {{t 'Call for Speakers was closed at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}
+        {{t 'Call for Speakers was closed at'}} {{general-date this.data.speakersCall.endsAt this.data.speakersCall.event.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -28,7 +28,7 @@
                 <small class="ui gray-text tiny">{{ticket.description}}</small>
               {{/if}}
               <div>
-                <small class="ui gray-text small">Sale ends on {{moment-format ticket.salesEndsAt 'ddd, DD MMMM YY, h:mm A'}}</small>
+                <small class="ui gray-text small">Sale ends on {{general-date ticket.salesEndsAt @event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}</small>
               </div>
             </td>
             <td></td>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -28,7 +28,7 @@
                 <small class="ui gray-text tiny">{{ticket.description}}</small>
               {{/if}}
               <div>
-                <small class="ui gray-text small">Sale ends on {{general-date ticket.salesEndsAt @event.timezone 'dddd, D MMMM, YYYY HH:mm A (z)'}}</small>
+                <small class="ui gray-text small">Sale ends on {{general-date ticket.salesEndsAt @event.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}</small>
               </div>
             </td>
             <td></td>

--- a/app/templates/components/session-card.hbs
+++ b/app/templates/components/session-card.hbs
@@ -20,7 +20,7 @@
       <div class="meta">
         <span class="time">
           {{#if this.session.startsAt}}
-            {{moment-format this.session.startsAt 'ddd, MMM DD h:mm A'}}
+            {{moment-format this.session.startsAt 'D MMM, YYYY h:mm A'}}
           {{else}}
             {{t 'Session Not Yet Scheduled'}}
           {{/if}}

--- a/app/templates/components/ui-table/cell/cell-event-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-event-date.hbs
@@ -1,11 +1,11 @@
 {{#if this.record}}
   {{#if this.extraRecords.endsAt}}
     <div>
-      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:MM A (z)"}}
+      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY h:mm A (z)"}}
     </div>
     (to)
     <div>
-      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:MM A (z)"}}
+      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY h:mm A (z)"}}
     </div>
   {{else}}
     <span>

--- a/app/templates/components/ui-table/cell/cell-event-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-event-date.hbs
@@ -1,11 +1,11 @@
 {{#if this.record}}
   {{#if this.extraRecords.endsAt}}
     <div>
-      {{general-date this.record this.extraRecords.timezone}}
+      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:MM A (z)"}}
     </div>
     (to)
     <div>
-      {{general-date this.extraRecords.endsAt this.extraRecords.timezone}}
+      {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:MM A (z)"}}
     </div>
   {{else}}
     <span>

--- a/app/templates/components/ui-table/cell/cell-simple-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-date.hbs
@@ -1,9 +1,9 @@
 {{#if this.extraRecords.timezone}}
   <span>
-    {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:mm A (z)"}}
+    {{general-date this.record this.extraRecords.timezone "D MMM, YYYY h:mm A (z)"}}
   </span>
 {{else if this.record}}
   <span>
-    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat "D MMM, YYYY HH:MM A")}}
+    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat "D MMM, YYYY h:mm A")}}
   </span>
 {{/if}}

--- a/app/templates/components/ui-table/cell/cell-simple-date.hbs
+++ b/app/templates/components/ui-table/cell/cell-simple-date.hbs
@@ -1,9 +1,9 @@
 {{#if this.extraRecords.timezone}}
   <span>
-    {{general-date this.record this.extraRecords.timezone}}
+    {{general-date this.record this.extraRecords.timezone "D MMM, YYYY HH:mm A (z)"}}
   </span>
 {{else if this.record}}
   <span>
-    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat 'MMMM DD, YYYY - HH:mm A')}}
+    {{moment-format this.record (if this.props.options.dateFormat this.props.options.dateFormat "D MMM, YYYY HH:MM A")}}
   </span>
 {{/if}}

--- a/app/templates/components/ui-table/cell/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/cell-validity.hbs
@@ -1,5 +1,5 @@
 <span>
-  {{moment-format this.record 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.record 'D MMM, YYYY h:mm A'}}
   <br>To<br>
-  {{moment-format this.extraRecords.validTill 'MMMM DD, YYYY - h:mm A'}}
+  {{moment-format this.extraRecords.validTill 'D MMM, YYYY h:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-date.hbs
@@ -1,5 +1,5 @@
 {{#if (eq @record.status 'completed')}}
-  {{moment-format @record.completedAt 'MMMM DD, YYYY - hh:mm A'}}
+  {{moment-format @record.completedAt "D MMM, YYYY HH:MM A"}}
 {{else}}
-  {{moment-format @record.createdAt 'MMMM DD, YYYY - hh:mm A'}}
+  {{moment-format @record.createdAt "D MMM, YYYY HH:MM A"}}
 {{/if}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-date.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-date.hbs
@@ -1,5 +1,5 @@
 {{#if (eq @record.status 'completed')}}
-  {{moment-format @record.completedAt "D MMM, YYYY HH:MM A"}}
+  {{moment-format @record.completedAt "D MMM, YYYY h:mm A"}}
 {{else}}
-  {{moment-format @record.createdAt "D MMM, YYYY HH:MM A"}}
+  {{moment-format @record.createdAt "D MMM, YYYY h:mm A"}}
 {{/if}}

--- a/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/attendees/cell-order.hbs
@@ -9,5 +9,12 @@
         {{t 'Payment via'}} {{this.record.paidVia}}
       </span>
     {{/if}}
+    {{#if (eq this.record.status 'completed')}}
+      {{moment-format this.record.completedAt 'D MMM, YYYY h:mm A'}}
+      {{moment-from-now this.record.completedAt}}
+    {{else}}
+      {{moment-format this.record.createdAt 'D MMM, YYYY h:mm A'}}
+      {{moment-from-now this.record.createdAt}}
+    {{/if}}
   </div>
 </div>

--- a/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/discount-codes/cell-validity.hbs
@@ -1,3 +1,3 @@
 <span>
-  {{moment-format this.record 'MMMM Do YYYY, h:mm a'}}
+	{{moment-format this.record 'D MMM, YYYY h:mm A'}}
 </span>

--- a/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
+++ b/app/templates/components/ui-table/cell/events/view/tickets/orders/cell-order.hbs
@@ -11,6 +11,13 @@
         {{t 'Payment via'}} {{this.extraRecords.paidVia}}
       </span>
     {{/if}}
+    <span class="muted text">
+      {{#if this.extraRecords.completedAt}}
+        {{moment-format this.extraRecords.completedAt 'D MMM, YYYY h:mm A'}} {{moment-from-now this.extraRecords.completedAt}}
+      {{else}}
+        {{moment-format this.extraRecords.createdAt 'D MMM, YYYY h:mm A'}} {{moment-from-now this.extraRecords.createdAt}}
+      {{/if}}
+    </span>
   </div>
 </div>
 <div class="ui horizontal compact basic buttons">

--- a/app/templates/event-invoice/review.hbs
+++ b/app/templates/event-invoice/review.hbs
@@ -15,10 +15,10 @@
                 <strong>{{t 'Event Name'}}:</strong> {{this.model.event.name}}
               </div>
               <div class="item">
-                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Date Issued'}}:</strong> {{general-date this.model.issuedAt 'UTC' 'D MMM, YYYY'}} 
               </div>
               <div class="item">
-                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'MMMM DD, YYYY'}} 
+                <strong>{{t 'Due Date'}}:</strong> {{general-date this.model.dueAt 'UTC' 'D MMM, YYYY'}} 
               </div>
               <div class="item">
                 <strong>{{t 'Total Invoice Amount'}}:</strong> {{currency-symbol this.model.event.paymentCurrency}} {{format-money this.model.amount}}

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -25,13 +25,13 @@
       {{/if}}
       {{#if this.filters.start_date}}
         <div class="ui mini label">
-          {{moment-format this.filters.start_date 'ddd, MMM DD'}}
+          {{moment-format this.filters.start_date 'D MMM, YYYY'}}
           <a href="#" role="button" {{action 'clearFilter' 'start_date'}}><i class="icon close"></i></a>
         </div>
       {{/if}}
       {{#if this.filters.end_date}}
         <div class="ui mini label">
-          {{moment-format this.filters.end_date 'ddd, MMM DD'}}
+          {{moment-format this.filters.end_date 'D MMM, YYYY'}}
           <a href="#" role="button" {{action 'clearFilter' 'end_date'}}><i class="icon close"></i></a>
         </div>
       {{/if}}

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -9,9 +9,9 @@
             <img src="{{this.model.logoUrl}}" class="logo mr-8" />
           {{/if}}
           <div>
-            <h4 class="event time">{{general-date this.model.startsAt this.model.timezone 'dddd, D MMMM, YYYY HH:MM A (z)'}}</h4>
+            <h4 class="event time">{{general-date this.model.startsAt this.model.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}</h4>
             {{#if this.displayEndDate}}
-              <h5 class="event time ends">{{t 'To'}} {{general-date this.model.endsAt this.model.timezone 'dddd, D MMMM, YYYY HH:MM A (z)'}}</h5>
+              <h5 class="event time ends">{{t 'To'}} {{general-date this.model.endsAt this.model.timezone 'dddd, D MMMM, YYYY h:mm A (z)'}}</h5>
             {{/if}}
             <h1 class="event name">{{this.model.name}}</h1>
             <h4 class="event location"><i class="icon map marker alternate"></i>{{this.headerLocation}}</h4>

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -9,9 +9,9 @@
             <img src="{{this.model.logoUrl}}" class="logo mr-8" />
           {{/if}}
           <div>
-            <h4 class="event time">{{header-date this.model.startsAt this.model.timezone}}</h4>
+            <h4 class="event time">{{general-date this.model.startsAt this.model.timezone 'dddd, D MMMM, YYYY HH:MM A (z)'}}</h4>
             {{#if this.displayEndDate}}
-              <h5 class="event time ends">{{t 'To'}} {{header-date this.model.endsAt this.model.timezone}}</h5>
+              <h5 class="event time ends">{{t 'To'}} {{general-date this.model.endsAt this.model.timezone 'dddd, D MMMM, YYYY HH:MM A (z)'}}</h5>
             {{/if}}
             <h1 class="event name">{{this.model.name}}</h1>
             <h4 class="event location"><i class="icon map marker alternate"></i>{{this.headerLocation}}</h4>

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -3,7 +3,7 @@
 <div class="d-flex wrap">
   <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=null}} class="ui button mb-2">{{t 'All'}}</LinkTo>
   {{#each this.allDates as |date|}}
-    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=(moment-format date "YYYY-MM-DD")}} class="ui button mb-2">{{moment-format date 'ddd, MMM Do'}}</LinkTo>
+    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=(moment-format date "YYYY-MM-DD")}} class="ui button mb-2">{{moment-format date 'D MMM, YYYY'}}</LinkTo>
   {{/each}}
 
   <Widgets::TimeZonePicker


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5490
Make event format as in this example: 4 Dec, 2020 5:00 PM (IST)
 - [x] table https://eventyay.com/events
 - [x] table https://eventyay.com/admin/events
 - [x] table https://eventyay.com/admin/sales
 - [x] table https://eventyay.com//admin/users/
- [x]  table event orders table /events/[event ID]/tickets/orders
- [x]  table event attebdees /events/[event ID]/tickets/attebdees
 - [x]  table session overview page events/[event ID]/sessions/all
This is good for most public pages
- [x]  Make event format as in this example: Friday, 4 December, 2020 5:00 PM (IST)
 - [x] tickets overview https://eventyay.com/my-tickets/past
 - [x] ticket order https://eventyay.com/orders/[order number here]
 - [x] events dashboard /events/[events ID]
- [x]  public events page header e/[eventpage], e.g. https://eventyay.com/e/a315169f
- [x]  public events page ticket section, e.g. https://eventyay.com/e/a315169f#tickets
 
 call for speakers, e.g. https://eventyay.com/e/a315169f/cfs
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
