### PR TITLE
Handled bug for unnecessary comma

### DIFF
--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -40,7 +40,15 @@
            </div>
            <div class="left floated nine wide column">
              {{#each @session.speakers as |speaker|}}
-                {{speaker.name}} ({{speaker.position}}, {{speaker.organisation}})
+                {{speaker.name}}(
+                  {{#if speaker.position}}
+                      {{speaker.position}}
+                      {{#if speaker.organisation}}               
+                      , {{speaker.organisation}}
+                      {{/if}}
+                    {{else}}
+                   {{speaker.organisation}}
+                  {{/if}})
                 <br>
               {{/each}}
             </div>


### PR DESCRIPTION
Fixes #5774

**Changes proposed in this pull request:**
1) No comma needed if there is no position filled


**Before**
![100347884-634e6e00-2fe6-11eb-881d-1995adc460e5](https://user-images.githubusercontent.com/53913514/100366809-530ab300-3027-11eb-8342-998e2464643b.png)


**After**
![Screenshot 2020-11-26 at 8 08 50 PM](https://user-images.githubusercontent.com/53913514/100366858-61f16580-3027-11eb-8ad7-c43a7681c1ec.png)
