### PR TITLE
fix: Show 0.00 instead of 0 for Sales

### DIFF
--- a/app/controllers/events/view/tickets/index.js
+++ b/app/controllers/events/view/tickets/index.js
@@ -11,7 +11,7 @@ export default class IndexController extends Controller {
 
   @computed('model.orderStats.sales.completed', 'model.orderStats.sales.placed')
   get totalAmount() {
-    return this.model.orderStats.sales.completed + this.model.orderStats.sales.placed;
+    return (this.model.orderStats.sales.completed + this.model.orderStats.sales.placed).toFixed(2);
   }
 
   @computed('model.orderStats.orders.completed', 'model.orderStats.orders.placed')

--- a/app/templates/events/view/tickets/index.hbs
+++ b/app/templates/events/view/tickets/index.hbs
@@ -4,7 +4,9 @@
   </div>
   <div class="ui {{if this.device.isMobile 'horizontal'}} three statistics">
     <div class="statistic"><div class="value">{{this.totalOrders}}</div><div class="label">{{t 'Orders'}}</div></div>
-    <div class="statistic"><div class="value">{{#if (eq this.totalAmount 0)}}{{t '0.00'}}{{else}}{{round this.totalAmount decimals=2}}{{/if}}</div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
+    <div class="statistic"><div class="value">
+      {{this.totalAmount}}
+      </div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
     <div class="statistic"><div class="value">{{this.totalSales}}</div><div class="label">{{t 'Tickets sold'}}</div></div>
   </div>
 </div>

--- a/app/templates/events/view/tickets/index.hbs
+++ b/app/templates/events/view/tickets/index.hbs
@@ -4,9 +4,7 @@
   </div>
   <div class="ui {{if this.device.isMobile 'horizontal'}} three statistics">
     <div class="statistic"><div class="value">{{this.totalOrders}}</div><div class="label">{{t 'Orders'}}</div></div>
-    <div class="statistic"><div class="value">
-      {{this.totalAmount}}
-      </div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
+    <div class="statistic"><div class="value">{{this.totalAmount}}</div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
     <div class="statistic"><div class="value">{{this.totalSales}}</div><div class="label">{{t 'Tickets sold'}}</div></div>
   </div>
 </div>

--- a/app/templates/events/view/tickets/index.hbs
+++ b/app/templates/events/view/tickets/index.hbs
@@ -4,7 +4,7 @@
   </div>
   <div class="ui {{if this.device.isMobile 'horizontal'}} three statistics">
     <div class="statistic"><div class="value">{{this.totalOrders}}</div><div class="label">{{t 'Orders'}}</div></div>
-    <div class="statistic"><div class="value">{{round this.totalAmount decimals=2}}</div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
+    <div class="statistic"><div class="value">{{#if (eq this.totalAmount 0)}}{{t '0.00'}}{{else}}{{round this.totalAmount decimals=2}}{{/if}}</div><div class="label">{{t 'Sales'}}{{#if this.totalAmount}}({{currency-symbol this.model.eventDetail.paymentCurrency}}){{/if}}</div></div>
     <div class="statistic"><div class="value">{{this.totalSales}}</div><div class="label">{{t 'Tickets sold'}}</div></div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5780 

#### Short description of what this resolves:
Sales in orders now shows 0.00 instead of 0 if the income of sales has been zero. 

After : 
![2020-11-27](https://user-images.githubusercontent.com/61330148/100465227-f1b11580-30f4-11eb-8fe7-803a38489f0e.png)



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
