### PR TITLE
fix: Move session description display to "expanded area"

### DIFF
--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -61,7 +61,6 @@
         {{sanitize @session.shortAbstract}}
       </div>
     </div>
-    <div class="ui divider"></div>
     {{#if (and @expanded (or @session.slidesUrl @session.videoUrl))}}
       <div class="row p-4">
         <div class="column" style={{css display='flex' align-items='center' flex-direction='column'}}>

--- a/app/components/public/session-item.hbs
+++ b/app/components/public/session-item.hbs
@@ -53,15 +53,15 @@
           {{/if}}
         </div>
       {{/if}}
-
-      <div class="row">
-        <div class="column session-description">
-          {{sanitize @session.shortAbstract}}
-        </div>
-      </div>
     </div>
   </div>
   <div class="content pt-0 p-4 rounded-t-none {{if @expanded 'active'}}" style={{css background-color='white' border-radius='0.2rem'}}>
+    <div class="ui pt-4 row">
+      <div class="column session-description">
+        {{sanitize @session.shortAbstract}}
+      </div>
+    </div>
+    <div class="ui divider"></div>
     {{#if (and @expanded (or @session.slidesUrl @session.videoUrl))}}
       <div class="row p-4">
         <div class="column" style={{css display='flex' align-items='center' flex-direction='column'}}>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5783 

#### Short description of what this resolves:
move the description to the expanded area

__screenshots__

__before__
![session card 2](https://user-images.githubusercontent.com/72552281/100477299-ed452680-310d-11eb-9579-1bddbaa2a2c2.png)

__after__
![sesssion card 1](https://user-images.githubusercontent.com/72552281/100477304-f504cb00-310d-11eb-86ae-91c4f8b34237.png)


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
