### PR TITLE
fix: Convert non-cached pages to array before sorting

### DIFF
--- a/app/components/footer-main.js
+++ b/app/components/footer-main.js
@@ -27,6 +27,6 @@ export default class FooterMain extends Component {
   }
 
   async didInsertElement() {
-    this.set('pages', sortBy(await this.cache.query('pages', 'page', { public: true }), 'index'));
+    this.set('pages', sortBy((await this.cache.query('pages', 'page', { public: true })).toArray(), 'index'));
   }
 }


### PR DESCRIPTION
Fixes #5814 