### PR TITLE
fix: Preselect Ticket holder same as Ticket Buyer in Order Form

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -24,10 +24,16 @@ export default Component.extend(FormMixin, {
   buyerHasFirstName : readOnly('data.user.firstName'),
   buyerHasLastName  : readOnly('data.user.lastName'),
   holders           : computed('data.attendees', function() {
-    this.data.attendees.forEach(attendee => {
-      attendee.set('firstname', this.buyerFirstName);
-      attendee.set('lastname', this.buyerLastName);
-      attendee.set('email', this.buyer.content.email);
+    this.data.attendees.forEach((attendee, index) => {
+      if (index === 0) {
+        attendee.set('firstname', this.buyerFirstName);
+        attendee.set('lastname', this.buyerLastName);
+        attendee.set('email', this.buyer.content.email);
+      } else {
+        attendee.set('firstname', '');
+        attendee.set('lastname', '');
+        attendee.set('email', '');
+      }
     });
     return this.data.attendees;
   }),

--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -25,9 +25,9 @@ export default Component.extend(FormMixin, {
   buyerHasLastName  : readOnly('data.user.lastName'),
   holders           : computed('data.attendees', function() {
     this.data.attendees.forEach(attendee => {
-      attendee.set('firstname', '');
-      attendee.set('lastname', '');
-      attendee.set('email', '');
+      attendee.set('firstname', this.buyerFirstName);
+      attendee.set('lastname', this.buyerLastName);
+      attendee.set('email', this.buyer.content.email);
     });
     return this.data.attendees;
   }),
@@ -38,7 +38,7 @@ export default Component.extend(FormMixin, {
     }
     return true;
   }),
-  sameAsBuyer: false,
+  sameAsBuyer: true,
 
   isBillingInfoNeeded: computed('event', 'data.isBillingEnabled', function() {
     return this.event.isBillingInfoMandatory || this.data.isBillingEnabled;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5851 

#### Short description of what this resolves:
Checkbox for selecting ticket holder same as ticket buyer is checked initially (with details displayed). User can toggle to turn it off.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
