### PR TITLE
fix: Go to Event link added in Expired event page

### DIFF
--- a/app/templates/components/orders/event-info.hbs
+++ b/app/templates/components/orders/event-info.hbs
@@ -32,7 +32,7 @@
       <strong>{{t 'Organized By'}}:</strong> {{this.data.event.ownerName}}
     {{/if}}
   </div>
-  {{#if (eq this.data.status 'completed')}}
+  {{#if (or (eq this.data.status 'expired') (eq this.data.status 'completed'))}}
     <div class="ui padded segment">
       <i class="globe icon"></i>
       <a href="{{this.data.event.url}}">{{t 'Go to event page'}}</a>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5863 

#### Short description of what this resolves:
"Go to event page" link added in expired event page

Image of the change : 
![2020-12-02 (1)](https://user-images.githubusercontent.com/61330148/100891788-a4abb580-34df-11eb-9cd5-18a6e60a9ed4.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
