### PR TITLE
fix: Fetch pages before findBy

### DIFF
--- a/app/routes/pages.js
+++ b/app/routes/pages.js
@@ -1,8 +1,12 @@
 import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 @classic
 export default class PagesRoute extends Route {
+
+  @service cache;
+
   // Enumerate possible page names for extraction for localization
   pages() {
     return [this.l10n.t('Terms'), this.l10n.t('Contact'), this.l10n.t('Refund Policy'), this.l10n.t('Privacy')];
@@ -12,8 +16,8 @@ export default class PagesRoute extends Route {
     return this.l10n.tVar(model?.name) || this.l10n.t('Pages');
   }
 
-  model(params) {
-    return this.modelFor('application').pages.findBy('url', params.path);
+  async model(params) {
+    return (await this.cache.query('pages', 'page', { public: true })).toArray().findBy('url', params.path);
   }
 
   renderTemplate(model) {


### PR DESCRIPTION
Fixes #5875

In #5775, application stopped loading pages as its model and since, the footer pages were broken