### PR TITLE
Fixing issue #5857 Making Access Form similar to Discount Form

### DIFF
--- a/app/models/access-code.js
+++ b/app/models/access-code.js
@@ -7,8 +7,8 @@ import { computedDateTimeSplit } from 'open-event-frontend/utils/computed-helper
 export default ModelBase.extend({
   code          : attr('string'),
   accessUrl     : attr('string'),
-  isActive      : attr('boolean', { defaultValue: false }),
-  ticketsNumber : attr('number'),
+  isActive      : attr('boolean', { defaultValue: true }),
+  ticketsNumber : attr('number',  { defaultValue: 10 }),
   minQuantity   : attr('number'),
   maxQuantity   : attr('number'),
   validFrom     : attr('moment'),

--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -44,7 +44,7 @@ export default ModelBase.extend({
   }),
 
   buttonColor: computed('normalizedName', function() {
-    return buttonColor[this.normalizedName] ;
+    return buttonColor[this.normalizedName];
   })
 
 });

--- a/app/models/social-link.js
+++ b/app/models/social-link.js
@@ -44,7 +44,7 @@ export default ModelBase.extend({
   }),
 
   buttonColor: computed('normalizedName', function() {
-    return buttonColor[this.normalizedName];
+    return buttonColor[this.normalizedName] ;
   })
 
 });

--- a/app/templates/components/forms/events/view/create-access-code.hbs
+++ b/app/templates/components/forms/events/view/create-access-code.hbs
@@ -11,28 +11,8 @@
     <Input
       @type="number"
       @name="number_of_access_tickets"
-      placeholder="0"
       @min={{0}}
       @value={{this.data.ticketsNumber}} />
-  </div>
-  <div class="grouped inline fields">
-    <label class="required">{{t 'Status'}}</label>
-    <div class="field">
-      <UiRadio
-        @current={{this.data.isActive}}
-        @name="status"
-        @label={{t "Active"}}
-        @value="true"
-        @onChange={{action (mut this.data.isActive)}} />
-    </div>
-    <div class="field">
-      <UiRadio
-        @name="status"
-        @label="Inactive"
-        @value="false"
-        @current={{this.data.isActive}}
-        @onChange={{action (mut this.data.isActive)}} />
-    </div>
   </div>
   {{#if this.hiddenTickets}}
     <div class="inline field">
@@ -60,65 +40,40 @@
     {{/each}}
   </div>
   <div>
-    <div class="inline field">
-      <UiCheckbox
-        @class="toggle"
-        @label={{t "Show more options"}}
-        @checked={{this.showMoreOptions}}
-        @onChange={{action (mut this.showMoreOptions)}} />
-    </div>
-    {{#if this.showMoreOptions}}
-      {{t 'Set the min and max quantity allowed to purchase per order (Optional)'}}
-      <div class="{{unless this.device.isMobile 'fields'}}">
-        <div class="wide field {{if this.device.isMobile 'sixteen' 'five'}}">
-          <label>{{t 'Min'}}</label>
-          <Input
-            @type="number"
-            @name="min"
-            @min={{0}}
-            @value={{this.data.minQuantity}} />
-        </div>
-        {{#if this.device.isMobile}}
-          <div class="ui hidden divider"></div>
-        {{/if}}
-        <div class="wide field {{if this.device.isMobile 'sixteen' 'five'}}">
-          <label>{{t 'Max'}}</label>
-          <Input
-            @type="number"
-            @name="max"
-            @min={{0}}
-            @value={{this.data.maxQuantity}} />
-        </div>
-      </div>
-      <div class="ui hidden divider"></div>
-      {{t 'Validity Period (Optional)'}}
-      <div class="fields">
-        <div class="wide field {{if this.device.isMobile 'sixteen' 'five'}}">
-          <label>{{t 'Valid from'}}</label>
+    <div class="field">
+      <label>{{t 'Access Valid from'}}</label>
+      <div class="{{if this.device.isMobile 'grouped'}} fields">
+        <div class="{{unless this.device.isMobile 'four wide'}} field">
           <Widgets::Forms::DatePicker
             @id="start_date"
             @value={{this.data.validFromDate}}
             @rangePosition="start" />
-          <div class="ui hidden divider"></div>
+        </div>
+        <div class="{{unless this.device.isMobile 'four wide'}} field">
           <Widgets::Forms::TimePicker
             @id="start_time"
             @value={{this.data.validFromTime}}
             @rangePosition="start" />
         </div>
-        <div class="wide field {{if this.device.isMobile 'sixteen' 'five'}}">
-          <label>{{t 'Expires on'}}</label>
+      </div>
+    </div>
+    <div class="field">
+       <label>{{t 'Access Expires on'}}</label>
+       <div class="{{if this.device.isMobile 'grouped'}} fields">
+        <div class="{{unless this.device.isMobile 'four wide'}} field">
           <Widgets::Forms::DatePicker
             @id="end_date"
             @value={{this.data.validTillDate}}
             @rangePosition="end" />
-          <div class="ui hidden divider"></div>
+        </div>
+        <div class="{{unless this.device.isMobile 'four wide'}} field">
           <Widgets::Forms::TimePicker
             @id="end_time"
             @value={{this.data.validTillTime}}
             @rangePosition="end" />
         </div>
       </div>
-    {{/if}}
+    </div>
     <div class="field">
       <label>{{t 'Access Link'}}</label>
       <div class="ui action input fluid">

--- a/app/templates/components/forms/events/view/create-access-code.hbs
+++ b/app/templates/components/forms/events/view/create-access-code.hbs
@@ -58,8 +58,8 @@
       </div>
     </div>
     <div class="field">
-       <label>{{t 'Access Expires on'}}</label>
-       <div class="{{if this.device.isMobile 'grouped'}} fields">
+      <label>{{t 'Access Expires on'}}</label>
+      <div class="{{if this.device.isMobile 'grouped'}} fields">
         <div class="{{unless this.device.isMobile 'four wide'}} field">
           <Widgets::Forms::DatePicker
             @id="end_date"

--- a/app/templates/events/view/tickets/access-codes/create.hbs
+++ b/app/templates/events/view/tickets/access-codes/create.hbs
@@ -1,6 +1,6 @@
 <div class="ui stackable grid">
   <div class="row">
-    <h2 class="ui header column">{{t 'Create an access code'}}</h2>
+    <h2 class="ui header column">{{t 'Create a New Access Code'}}</h2>
   </div>
   <div class="row">
     <div class="sixteen wide column">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5857 

#### Short description of what this resolves:
As per instruction in isssue #5857 , I have made the access form just like Discount form

#### Changes proposed in this pull request:
1.Pre-fill "Number of access tickets" with "10"
2.Change "Valid from" to "Access valid from"
3.Change "Expires on" to "Access expires on"
4.Show time in the same line with dates
5.Show timezone of the event in the same way as in the wizard
6.Take out "Show more options" switch and always show below option
7.Take out "Status" and always make the status active

![Screenshot from 2020-12-03 19-25-28](https://user-images.githubusercontent.com/64575577/101028377-bf912f00-359e-11eb-9cd6-4786b6f2bc30.png)
![Screenshot from 2020-12-03 19-25-16](https://user-images.githubusercontent.com/64575577/101028780-ddf72a80-359e-11eb-83af-e9dbda530192.jpeg)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
