### PR TITLE
feat: Make search event name specific and add location type filter

### DIFF
--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -49,32 +49,9 @@ export default class SideBar extends Component {
   }
 
   @action
-  setLocationType(val) {
-    if (this.is_online === 'true') {
-      if (this.eventLocationType === null) {
-        this.set('is_online', val === 'venue' ? 'false' : 'true');
-      }
-      else {
-        if (this.eventLocationType === val) {
-          this.set('is_online', null);
-        }
-        else if (val === 'venue') {
-          this.set('is_online', 'false');
-        }
-      }
-    }
-    else if (this.is_online === 'false') {
-      if (this.eventLocationType === null) {
-        this.set('is_online', val === 'venue' ? 'false' : 'true');
-      }
-      else {
-        this.set('is_online', this.eventLocationType === val ? null : 'true');
-      }
-    }
-    else {
-      this.set('is_online', val === 'venue' ? 'false' : 'true');
-    }
-    this.set('eventLocationType', this.eventLocationType === val ? null : val);
+  setLocationType(locationType, val) {
+    this.set('is_online', this.eventLocationType === locationType ? null : val);
+    this.set('eventLocationType', this.eventLocationType === locationType ? null : locationType);
     this.set('location', null);
   }
 

--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -16,10 +16,11 @@ export default class SideBar extends Component {
   customEndDate = null;
   @tracked showFilters = false;
   isMapVisible = true;
+  eventLocationType = null;
 
-  @computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', 'location', 'ticket_type', 'cfs')
+  @computed('category', 'sub_category', 'event_type', 'startDate', 'endDate', 'location', 'ticket_type', 'cfs', 'event_name', 'is_online')
   get hideClearFilters() {
-    return !(this.category || this.sub_category || this.event_type || this.startDate || this.endDate || this.location || this.ticket_type || this.cfs);
+    return !(this.category || this.sub_category || this.event_type || this.startDate || this.endDate || this.location || this.ticket_type || this.cfs || this.event_name || this.is_online);
   }
 
   @computed('category', 'sub_category')
@@ -45,6 +46,36 @@ export default class SideBar extends Component {
       lat,
       lng
     });
+  }
+
+  @action
+  setLocationType(val) {
+    if(this.is_online === 'true') {
+      if(this.eventLocationType === null) {
+        this.set('is_online', val === 'venue' ? 'false' : 'true');
+      }
+      else {
+        if(this.eventLocationType === val) {
+          this.set('is_online', null);
+        }
+        else if(val === 'venue') {
+          this.set('is_online', 'false');
+        }
+      }
+    }
+    else if(this.is_online === 'false') {
+      if(this.eventLocationType === null) {
+        this.set('is_online', val === 'venue' ? 'false' : 'true');
+      }
+      else {
+        this.set('is_online', this.eventLocationType === val ? null : 'true');
+      }
+    }
+    else {
+      this.set('is_online', val === 'venue' ? 'false' : 'true');
+    }
+    this.set('eventLocationType', this.eventLocationType === val ? null : val);
+    this.set('location', null)
   }
 
   @action
@@ -153,15 +184,18 @@ export default class SideBar extends Component {
   @action
   clearFilters() {
     this.setProperties({
-      startDate    : null,
-      endDate      : null,
-      dateType     : null,
-      category     : null,
-      sub_category : null,
-      event_type   : null,
-      location     : null,
-      ticket_type  : null,
-      cfs          : null
+      startDate         : null,
+      endDate           : null,
+      dateType          : null,
+      category          : null,
+      sub_category      : null,
+      event_type        : null,
+      location          : null,
+      ticket_type       : null,
+      cfs               : null,
+      event_name        : null,
+      is_online         : null,
+      eventLocationType : null
     });
   }
 

--- a/app/components/explore/side-bar.js
+++ b/app/components/explore/side-bar.js
@@ -50,21 +50,21 @@ export default class SideBar extends Component {
 
   @action
   setLocationType(val) {
-    if(this.is_online === 'true') {
-      if(this.eventLocationType === null) {
+    if (this.is_online === 'true') {
+      if (this.eventLocationType === null) {
         this.set('is_online', val === 'venue' ? 'false' : 'true');
       }
       else {
-        if(this.eventLocationType === val) {
+        if (this.eventLocationType === val) {
           this.set('is_online', null);
         }
-        else if(val === 'venue') {
+        else if (val === 'venue') {
           this.set('is_online', 'false');
         }
       }
     }
-    else if(this.is_online === 'false') {
-      if(this.eventLocationType === null) {
+    else if (this.is_online === 'false') {
+      if (this.eventLocationType === null) {
         this.set('is_online', val === 'venue' ? 'false' : 'true');
       }
       else {
@@ -75,7 +75,7 @@ export default class SideBar extends Component {
       this.set('is_online', val === 'venue' ? 'false' : 'true');
     }
     this.set('eventLocationType', this.eventLocationType === val ? null : val);
-    this.set('location', null)
+    this.set('location', null);
   }
 
   @action

--- a/app/controllers/explore.js
+++ b/app/controllers/explore.js
@@ -4,7 +4,9 @@ import Controller from '@ember/controller';
 
 @classic
 export default class ExploreController extends Controller {
-  queryParams = ['category', 'sub_category', 'event_type', 'start_date', 'end_date', 'location', 'ticket_type', 'cfs'];
+  queryParams = ['category', 'sub_category', 'event_type', 'start_date', 'end_date', 'location', 'ticket_type', 'cfs', 'event_name', 'is_online'];
+  event_name = null;
+  is_online = null;
   category = null;
   sub_category = null;
   event_type = null;
@@ -22,6 +24,12 @@ export default class ExploreController extends Controller {
 
   @action
   clearFilter(filterType) {
+    if (filterType === 'event_name') {
+      this.set('event_name', null);
+    }
+    if (filterType === 'is_online') {
+      this.set('is_online', null);
+    }
     if (filterType === 'start_date') {
       this.set('startDate', null);
     }

--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -76,7 +76,7 @@ export default class ExploreRoute extends Route {
       filterOptions.push({
         name : 'online',
         op   : 'eq',
-        val  :  params.is_online
+        val  : params.is_online
       });
     }
     if (params.location) {

--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -72,7 +72,13 @@ export default class ExploreRoute extends Route {
         }
       });
     }
-
+    if (params.is_online) {
+      filterOptions.push({
+        name : 'online',
+        op   : 'eq',
+        val  :  params.is_online
+      });
+    }
     if (params.location) {
       filterOptions.push({
         name : 'location_name',
@@ -80,6 +86,14 @@ export default class ExploreRoute extends Route {
         val  : `%${params.location}%`
       });
     }
+    if (params.event_name) {
+      filterOptions.push({
+        name : 'name',
+        op   : 'ilike',
+        val  : `%${params.event_name}%`
+      });
+    }
+
     if (params.cfs) {
       filterOptions.push({
         name : 'is_sessions_speakers_enabled',

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -1,13 +1,59 @@
 <div class="item">
   <div class="ui input">
     <Input
-      @name="location"
-      @value={{this.location}}
+      @name="name"
+      @value={{this.event_name}}
       @type="text"
-      @placeholder={{t "Enter Location"}} />
+      @placeholder={{t "Enter Event Name"}} />
   </div>
 </div>
 {{#if this.showFiltersOnMobile}}
+  <div class="item">
+    <UiAccordion>
+      <span class="title">
+        <i class="dropdown icon"></i>
+        {{t 'Event Location Type' }}
+      </span>
+      <div class="content menu">
+        <div class="ui form">
+          <div class="grouped fields">
+            <div class="field">
+              <UiCheckbox
+                @label={{t "Online"}}
+                @class="ui checkbox"
+                @checked={{if (eq this.eventLocationType "online") "active"}}
+                @onChange={{action "setLocationType" "online"}} />
+            </div>
+            <div class="field">
+              <UiCheckbox
+                @label={{t "Location"}}
+                @class="ui checkbox"
+                @checked={{if (eq this.eventLocationType "venue") "active"}}
+                @onChange={{action "setLocationType" "venue"}} />
+            </div>
+            <div class="field">
+              <UiCheckbox
+                @label={{t "Mixed"}}
+                @class="ui checkbox"
+                @checked={{if (eq this.eventLocationType "mixed") "active"}}
+                @onChange={{action "setLocationType" "mixed"}} />
+            </div>
+            {{#if (or (eq this.eventLocationType "venue") (eq this.eventLocationType "mixed"))}}
+                <div class="explore sub menu">
+                  <div class="ui input">
+                    <Input
+                      @name="location"
+                      @value={{this.location}}
+                      @type="text"
+                      @placeholder={{t "Enter Location"}} />
+                  </div>
+                </div>
+              {{/if}}
+          </div>
+        </div>
+      </div>
+    </UiAccordion>
+  </div>
   <div class="item">
     <UiAccordion>
       <span class="title">

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -22,21 +22,21 @@
                 @label={{t "Online"}}
                 @class="ui checkbox"
                 @checked={{if (eq this.eventLocationType "online") "active"}}
-                @onChange={{action "setLocationType" "online"}} />
+                @onChange={{action "setLocationType" "online" "true"}} />
             </div>
             <div class="field">
               <UiCheckbox
                 @label={{t "Location"}}
                 @class="ui checkbox"
                 @checked={{if (eq this.eventLocationType "venue") "active"}}
-                @onChange={{action "setLocationType" "venue"}} />
+                @onChange={{action "setLocationType" "venue" "false"}} />
             </div>
             <div class="field">
               <UiCheckbox
                 @label={{t "Mixed"}}
                 @class="ui checkbox"
                 @checked={{if (eq this.eventLocationType "mixed") "active"}}
-                @onChange={{action "setLocationType" "mixed"}} />
+                @onChange={{action "setLocationType" "mixed" "true"}} />
             </div>
             {{#if (or (eq this.eventLocationType "venue") (eq this.eventLocationType "mixed"))}}
                 <div class="explore sub menu">

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -1,6 +1,6 @@
 <div class="ui stackable grid">
   <div class="three wide column">
-    <Explore::SideBar @model={{this.model}} @category={{this.category}} @sub_category={{this.sub_category}} @event_type={{this.event_type}} @startDate={{this.start_date}} @endDate={{this.end_date}} @location={{this.location}} @ticket_type={{this.ticket_type}} @cfs={{this.cfs}} />
+    <Explore::SideBar @model={{this.model}} @category={{this.category}} @sub_category={{this.sub_category}} @event_type={{this.event_type}} @startDate={{this.start_date}} @endDate={{this.end_date}} @event_name={{this.event_name}} @is_online={{this.is_online}} @location={{this.location}} @ticket_type={{this.ticket_type}} @cfs={{this.cfs}} />
   </div>
   <div class="thirteen wide column">
     <h1 class="ui header">{{t 'Events'}}</h1>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4993 

#### Short description of what this resolves:

Standard Search box should be for event name.
and Provide an option to choose between "Mixed Event", "Online", "Location based" and similar to areas like > Date


#### Changes proposed in this pull request:
- Show a standard search box "Event Name" above the filter box (instead of Location)
- Provide an option to choose between "Mixed Event", "Online", "Location based" and similar to areas like > Date
- When location based event is chosen provide an option to enter a certain location (as of now)
- Finally standardize width of left sidebar to match width of the left public event pages sidebar

__screenshots__

![a1](https://user-images.githubusercontent.com/72552281/101066781-b7e08300-35bc-11eb-896e-9d3bf8a850f4.png)
![a2](https://user-images.githubusercontent.com/72552281/101066784-b911b000-35bc-11eb-973b-68ba5a900487.png)


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

