### PR TITLE
fix: Sponsors logo max height and width added

### DIFF
--- a/app/templates/components/ui-table/cell/cell-sponsor-image.hbs
+++ b/app/templates/components/ui-table/cell/cell-sponsor-image.hbs
@@ -1,1 +1,1 @@
-<img class="ui tiny image" src="{{if this.record this.record '/images/placeholders/Other.jpg'}}" alt="Event logo">
+<img style="max-width:80px; max-height: 40px;" class="ui image" src="{{if this.record this.record '/images/placeholders/Other.jpg'}}" alt="Event logo">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5844

#### Short description of what this resolves:
Max height and width of sponsor logos are now 40px and 80px respectively.

SCREENSHOTS - 

Before-

![2020-12-06 (3)](https://user-images.githubusercontent.com/61330148/101265982-3aaa3f00-3771-11eb-82c0-17bca1e690fd.png)

After-

![2020-12-06 (1)](https://user-images.githubusercontent.com/61330148/101265988-43027a00-3771-11eb-81e6-14093ba8d7de.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
