### PR TITLE
fix: online event and enhance date/time in front page

### DIFF
--- a/app/components/event-card.js
+++ b/app/components/event-card.js
@@ -3,6 +3,7 @@ import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';
 import { forOwn } from 'lodash-es';
+import moment from 'moment';
 import { pascalCase } from 'open-event-frontend/utils/string';
 
 @classic
@@ -40,7 +41,8 @@ export default class EventCard extends Component {
     this.set('eventType', eventType === this.eventType ? null : eventType);
   }
 
-  isSingleDay() {
-    return this.startsAt.isSame(this.endsAt, 'day');
+  @computed('event.startsAt', 'event.endsAt')
+  get isSingleDay() {
+    return moment(this.event.startsAt).isSame(this.event.endsAt, 'day');
   }
 }

--- a/app/components/event-card.js
+++ b/app/components/event-card.js
@@ -39,4 +39,8 @@ export default class EventCard extends Component {
   selectEventType(eventType) {
     this.set('eventType', eventType === this.eventType ? null : eventType);
   }
+
+  isSingleDay() {
+    return this.startsAt.isSame(this.endsAt, 'day');
+  }
 }

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -98,3 +98,7 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
 .no-wrap {
   white-space: nowrap;
 }
+
+.card-height {
+  min-height: 165px;
+}

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -17,11 +17,11 @@
           @src={{if this.event.thumbnailImageUrl this.event.thumbnailImageUrl this.event.originalImageUrl}} />
       </a>
     {{/unless}}
-    <a style="min-height:165px" class="main content" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.identifier}}">
+    <a class="{{if this.device.isMobile '' 'card-height'}} main content" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.identifier}}">
       <SmartOverflow @class="header">
         {{this.event.name}}
       </SmartOverflow>
-      <div class="meta">
+      <div class="meta" style="margin-bottom: 0.5em">
         <span class="date">
           {{#if this.isSingleDay}}
             {{general-date this.event.startsAt 'date-time-long' tz=this.event.timezone}}
@@ -41,12 +41,12 @@
         </p>
       {{/if}}
       {{#if this.event.shortLocationName}}
-        <p style="color: #000000AD">
-          <i class="map marker alternate icon"></i>
+          <span style="color: #000000AD">
+            <i class="map marker alternate icon"></i>
+          </span>
           <SmartOverflow @class="d-inline description">
             {{this.event.shortLocationName}}
           </SmartOverflow>
-        </p>
       {{/if}}
     </a>
     <div class="extra content small text">

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -23,10 +23,18 @@
       </SmartOverflow>
       <div class="meta">
         <span class="date">
-          {{general-date this.event.startsAt tz=this.event.timezone}}
+          {{general-date this.event.startsAt 'date-time-long'}}
+          -
+          {{general-date this.event.endsAt 'date-time-long'}}
         </span>
       </div>
       <SmartOverflow @class="description">
+        {{#if this.event.online}}
+          Online Event
+        {{/if}}
+        {{#if (and this.event.online this.event.shortLocationName)}}
+          and at
+        {{/if}}
         {{this.event.shortLocationName}}
       </SmartOverflow>
     </a>

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -21,7 +21,7 @@
       <SmartOverflow @class="header">
         {{this.event.name}}
       </SmartOverflow>
-      <div class="meta" style="margin-bottom: 0.5em">
+      <div class="meta mb-2">
         <span class="date">
           {{#if this.isSingleDay}}
             {{general-date this.event.startsAt 'date-time-long' tz=this.event.timezone}}

--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -17,26 +17,37 @@
           @src={{if this.event.thumbnailImageUrl this.event.thumbnailImageUrl this.event.originalImageUrl}} />
       </a>
     {{/unless}}
-    <a class="main content" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.identifier}}">
+    <a style="min-height:165px" class="main content" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.identifier}}">
       <SmartOverflow @class="header">
         {{this.event.name}}
       </SmartOverflow>
       <div class="meta">
         <span class="date">
-          {{general-date this.event.startsAt 'date-time-long'}}
-          -
-          {{general-date this.event.endsAt 'date-time-long'}}
+          {{#if this.isSingleDay}}
+            {{general-date this.event.startsAt 'date-time-long' tz=this.event.timezone}}
+            - 
+            {{general-date this.event.endsAt 'time-tz-short' tz=this.event.timezone}}
+          {{else}}
+            {{general-date this.event.startsAt 'date-time-long' tz=this.event.timezone}}
+            -
+            {{general-date this.event.endsAt 'date-time-tz-long' tz=this.event.timezone}}
+          {{/if}}
         </span>
       </div>
-      <SmartOverflow @class="description">
-        {{#if this.event.online}}
-          Online Event
-        {{/if}}
-        {{#if (and this.event.online this.event.shortLocationName)}}
-          and at
-        {{/if}}
-        {{this.event.shortLocationName}}
-      </SmartOverflow>
+      {{#if this.event.online}}
+        <p style="color: #000000AD">
+          <i class="wifi icon"></i>
+          {{t 'Online Event'}}
+        </p>
+      {{/if}}
+      {{#if this.event.shortLocationName}}
+        <p style="color: #000000AD">
+          <i class="map marker alternate icon"></i>
+          <SmartOverflow @class="d-inline description">
+            {{this.event.shortLocationName}}
+          </SmartOverflow>
+        </p>
+      {{/if}}
     </a>
     <div class="extra content small text">
       <span class="right floated">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5926 

#### Short description of what this resolves:
1. the info "Online Event" if the event is not location based and
2. "Online Event and at [address here]" if it is a mixed event
3. show long date type for the event
4. show both start and end time of event 

**Screenshots -**

![2020-12-06 (4)](https://user-images.githubusercontent.com/61330148/101275353-fea3c800-37ca-11eb-9625-6de55c8757a1.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
