### PR TITLE
fix: Dashboard: session/speaker page button overflow fixed

### DIFF
--- a/app/templates/events/view/sessions.hbs
+++ b/app/templates/events/view/sessions.hbs
@@ -2,7 +2,7 @@
   <div class="ui grid stackable">
     {{#if this.onSessionRoute}}
       <div class="row">
-        <div class="eight wide column">
+        <div class="{{if this.device.isTablet 'sixteen' 'twelve'}} wide column">
           <TabbedNavigation @isNonPointing={{true}}>
             <LinkTo @route="events.view.sessions.list" @model="all" class="item">
               {{t 'All'}}
@@ -14,7 +14,7 @@
             {{/each}}
           </TabbedNavigation>
         </div>
-        <div class="eight wide right aligned column">
+        <div class="{{if this.device.isTablet 'sixteen' 'four'}} wide right aligned column">
           <div class="ui labeled input">
             <button class="ui blue button right-floated {{if this.isLoading 'loading'}}" {{action 'export'}}>{{t 'Export as CSV'}}</button>
             <LinkTo @route="events.view.sessions.create" class="ui blue button right floated">

--- a/app/templates/events/view/speakers.hbs
+++ b/app/templates/events/view/speakers.hbs
@@ -2,7 +2,7 @@
   <div class="ui grid stackable">
     {{#if (and (not-eq this.session.currentRouteName 'events.view.speakers.edit') (not-eq this.session.currentRouteName 'events.view.speakers.create'))}}
       <div class="row">
-        <div class="six wide column">
+        <div class="{{if this.device.isTablet 'sixteen' 'twelve'}} wide column">
           <TabbedNavigation @isNonPointing={{true}}>
             <LinkTo @route="events.view.speakers.list" @model="all" class="item">
               {{t 'All'}}
@@ -27,7 +27,7 @@
             </LinkTo>
           </TabbedNavigation>
         </div>
-        <div class="ten wide right aligned column">
+        <div class="{{if this.device.isTablet 'sixteen' 'four'}} wide right aligned column">
           <div class="ui labeled input">
             <button class="ui blue button right-floated {{if this.isLoading 'loading'}}" {{action 'export'}}>{{t 'Export as CSV'}}</button>
             <LinkTo @route="events.view.speakers.create" class="ui blue button right floated">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5907

#### Short description of what this resolves:
In Session and Speakers page, the links(canceled, withdrawn etc) were disabled due to the overlapping buttons.

SCREENSHOTS -

DESKTOP
![2020-12-09](https://user-images.githubusercontent.com/61330148/101659122-b6570500-3a6b-11eb-8e35-213dda501b45.png)

TABLET
![2020-12-09 (1)](https://user-images.githubusercontent.com/61330148/101659216-d38bd380-3a6b-11eb-816f-a3bb07b84aca.png)

MOBILE 
![2020-12-09 (2)](https://user-images.githubusercontent.com/61330148/101659184-c7a01180-3a6b-11eb-8b39-2155ae4989f7.png)



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
