### PR TITLE
fix: Promotional code/ Cards displayed according to ticket type

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -71,6 +71,14 @@ export default Component.extend(FormMixin, {
     ) > 0;
   }),
 
+  hasPaidTickets: computed('tickets.@each.type', function() {
+    return this.tickets.toArray().filter(ticket => ticket.type === 'paid').length > 0;
+  }),
+
+  hasOnlyFreeTickets: computed('tickets.@each.type', function() {
+    return !this.tickets.toArray().filter(ticket => ticket.type !== 'free').length > 0;
+  }),
+
   donationTickets: computed.filterBy('data', 'type', 'donation'),
 
   isDonationPriceValid: computed('donationTickets.@each.orderQuantity', 'donationTickets.@each.price', function() {

--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -71,10 +71,6 @@ export default Component.extend(FormMixin, {
     ) > 0;
   }),
 
-  hasPaidTickets: computed('tickets.@each.type', function() {
-    return this.tickets.toArray().filter(ticket => ticket.type === 'paid').length > 0;
-  }),
-
   hasOnlyFreeTickets: computed('tickets.@each.type', function() {
     return !this.tickets.toArray().filter(ticket => ticket.type !== 'free').length > 0;
   }),

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -168,27 +168,31 @@
         </div>
       </div>
     {{else}}
-      <div class="ui row">
-        <div class="column right aligned">
-          {{#if this.device.isMobile}}
-            <div class="ui hidden divider"></div>
-          {{/if}}
-          <a href="#" {{action 'togglePromotionalCode'}}>{{t 'Enter promotional code'}}</a>
+      {{#if this.hasPaidTickets}}
+        <div class="ui row">
+          <div class="column right aligned">
+            {{#if this.device.isMobile}}
+              <div class="ui hidden divider"></div>
+            {{/if}}
+            <a href="#" {{action 'togglePromotionalCode'}}>{{t 'Enter promotional code'}}</a>
+          </div>
         </div>
-      </div>
+      {{/if}}
     {{/if}}
   </div>
   {{/unless}}
   <div class="ui grid">
     <div class="ui row stackable grid">
       <div class="ui no padding thirteen wide computer twelve wide tablet column right aligned floated payment icons">
-        <i class="colored cc amex link icon"></i>
-        <i class="colored credit card alternative link icon"></i>
-        <i class="colored cc diners club link icon"></i>
-        <i class="colored cc discover link icon"></i>
-        <i class="colored cc mastercard link icon"></i>
-        <i class="colored cc paypal card link icon"></i>
-        <i class="colored cc visa link icon"></i>
+        {{#unless this.hasOnlyFreeTickets}}
+          <i class="colored cc amex link icon"></i>
+          <i class="colored credit card alternative link icon"></i>
+          <i class="colored cc diners club link icon"></i>
+          <i class="colored cc discover link icon"></i>
+          <i class="colored cc mastercard link icon"></i>
+          <i class="colored cc paypal card link icon"></i>
+          <i class="colored cc visa link icon"></i>
+        {{/unless}}
       </div>
       <div class="ui no padding three wide computer four wide tablet column right aligned floated">
         <button id="total" class="ui primary small button no right margin" disabled={{this.shouldDisableOrderButton}} {{action this.placeOrder this.orderAmountInput}}>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -168,7 +168,7 @@
         </div>
       </div>
     {{else}}
-      {{#if (not this.hasOnlyFreeTickets)}}
+      {{#unless this.hasOnlyFreeTickets}}
         <div class="ui row">
           <div class="column right aligned">
             {{#if this.device.isMobile}}
@@ -177,7 +177,7 @@
             <a href="#" {{action 'togglePromotionalCode'}}>{{t 'Enter promotional code'}}</a>
           </div>
         </div>
-      {{/if}}
+      {{/unless}}
     {{/if}}
   </div>
   {{/unless}}

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -168,7 +168,7 @@
         </div>
       </div>
     {{else}}
-      {{#if this.hasPaidTickets}}
+      {{#if (not this.hasOnlyFreeTickets)}}
         <div class="ui row">
           <div class="column right aligned">
             {{#if this.device.isMobile}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5914

#### Short description of what this resolves:
If an event has only free and donation tickets do not show "promotional code". (Also reduce the spacing between "Total" and "Order now" then)
If an event has only free tickets and no other tickets do not show the credit card icons neither.

SCREENSHOTS -
![2020-12-10 (3)](https://user-images.githubusercontent.com/61330148/101767084-c1f90900-3b09-11eb-9505-c6636650b0ee.png)
![2020-12-10 (4)](https://user-images.githubusercontent.com/61330148/101767092-c45b6300-3b09-11eb-90d8-e7a0af204ea0.png)
![2020-12-10 (5)](https://user-images.githubusercontent.com/61330148/101767114-c9b8ad80-3b09-11eb-882c-594aa2429c98.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
