### PR TITLE
Removed event start date limit

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -464,9 +464,7 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     updateSalesEndDate(eventStartDate) {
       eventStartDate = moment(new Date(eventStartDate));
       this.data.event.tickets.forEach(ticket => {
-        if (moment(eventStartDate).isBefore(ticket.get('salesEndsAt'))) {
-          ticket.set('salesEndsAt', moment(eventStartDate, 'MM/DD/YYYY').toDate());
-        }
+        ticket.set('salesEndsAt', moment(eventStartDate, 'MM/DD/YYYY').toDate());
       });
     },
 

--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -1,18 +1,9 @@
-<div class="item">
-  <div class="ui input">
-    <Input
-      @name="name"
-      @value={{this.event_name}}
-      @type="text"
-      @placeholder={{t "Enter Event Name"}} />
-  </div>
-</div>
 {{#if this.showFiltersOnMobile}}
   <div class="item">
     <UiAccordion>
       <span class="title">
         <i class="dropdown icon"></i>
-        {{t 'Event Location Type' }}
+        {{t 'Setting' }}
       </span>
       <div class="content menu">
         <div class="ui form">

--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -1,9 +1,20 @@
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet"/>
 <div class="mobile hidden row">
   <div class="ui menu">
     <LinkTo
       @route="index" class="header item" @activeClass="">
       <h3>{{this.settings.appName}}</h3>
     </LinkTo>
+    <div class="ui container" style="max-width: 400px;">
+      <div class="ui input" style="padding: 10px; margin-left: 160px; min-width: 900px;">
+        <button type="submit" style="color: white; border-color: white;"><i class="fa fa-search" style="color: lightgray;"></i></button>
+        <Input
+          @name="name"
+          @value={{this.event_name}}
+          @type="text"
+          @placeholder={{t "Search Events"}} />  
+      </div>
+    </div>
     <div class="right menu nav-bar">
     {{#if (and (not this.session.isAuthenticated) this.isNotEventPageRoute)}}
       <LinkTo

--- a/app/templates/explore.hbs
+++ b/app/templates/explore.hbs
@@ -3,7 +3,6 @@
     <Explore::SideBar @model={{this.model}} @category={{this.category}} @sub_category={{this.sub_category}} @event_type={{this.event_type}} @startDate={{this.start_date}} @endDate={{this.end_date}} @event_name={{this.event_name}} @is_past={{this.is_past}} @is_online={{this.is_online}} @has_logo={{this.has_logo}} @has_image={{this.has_image}} @location={{this.location}} @ticket_type={{this.ticket_type}} @cfs={{this.cfs}} />
   </div>
   <div class="thirteen wide column">
-    <h1 class="ui header">{{t 'Events'}}</h1>
     <div class="ui labels">
       {{#if this.filters.category}}
         <div class="ui mini label">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6021 

#### Short description of what this resolves:

Removed the if statement regarding the date limit from starting point

#### Changes proposed in this pull request:

In the wizard step 1, there is a start date limit, that the start of the event has to be before the current date. But, actually, there are use cases where the event should start before the current date, e.g. when the user wants to change the end date of an event after it has started. Then the user will receive the error message "event start date should be before the current date".

Considering this use case, please take out the requirement that the start date of an event has to be before the current date.

This issue is removed.
![Screenshot (220)](https://user-images.githubusercontent.com/47476857/102092932-97c78400-3e46-11eb-808a-04e92688052b.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
