### PR TITLE
fix: Implementation of Short Answer and Paragraph in Custom Form

### DIFF
--- a/app/components/forms/wizard/custom-form-input.hbs
+++ b/app/components/forms/wizard/custom-form-input.hbs
@@ -6,16 +6,36 @@
   </span>
 </div>
 <div {{did-update this.updated @field}} class="ui action input" style="width: inherit;">
-  <Input type="text" placeholder="Field Name" @value={{this.name}} />
+  <Input type="text" id="shortField" placeholder="Field Name" @value={{this.name}} style="display: none;" />
+  <Textarea cols="60" rows="1" id="paraField" style="width: 100%; overflow: hidden; display: block;" placeholder="Field Name" oninput="auto_height(this)" @value={{this.name}}></Textarea>
   <UiDropdown class="ui selection dropdown" @selected={{this.type}} @onChange={{action (mut this.type)}}>
     <div class="default text">
       {{ this.type }}
     </div>
     <i class="dropdown icon"></i>
     <div class="menu">
-      <div class="item" data-value="text">Text</div>
-      <div class="item" data-value="number">Number</div>
+      <div class="item" data-value="text" id="sh-ansBtn">Short Answer</div>
+      <div class="item" data-value="text" id="paraBtn">Paragraph</div>
+      <div class="item" data-value="number" id="numBtn">Number</div>
     </div>
   </UiDropdown>
   <button class="ui button" {{action 'addFormField'}} disabled={{not this.validIdentifier}}>{{if @field (t 'Save') (t 'Add')}}</button>
 </div>
+
+<script>
+  function auto_height(elem) { 
+    elem.style.height = "1px";
+    elem.style.height = (elem.scrollHeight)+"px"; };
+
+  document.getElementById("sh-ansBtn").onclick = function () {
+  document.getElementById("shortField").style.display = "block";
+  document.getElementById("paraField").style.display = "none"; };
+
+  document.getElementById("paraBtn").onclick = function () {
+  document.getElementById("shortField").style.display = "none";
+  document.getElementById("paraField").style.display = "block"; };
+
+  document.getElementById("numBtn").onclick = function () {
+  document.getElementById("shortField").style.display = "block";
+  document.getElementById("paraField").style.display = "none"; };
+</script>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5832 

#### Short description of what this resolves:
Instead of text field in custom field of attendee form, there are 2 fields now, Short Answer and Paragraph.

#### Changes proposed in this pull request:

- Text field in Custom form is removed and instead 2 fields are added, Paragraph and Short Answer. 
- Short Answer is one liner field and Paragraph uses auto-increasing textarea. 

![image](https://user-images.githubusercontent.com/60281688/102327540-e3477280-3fab-11eb-8fca-3aed6a86eb84.png)
![image](https://user-images.githubusercontent.com/60281688/102327619-ffe3aa80-3fab-11eb-91da-47f483afa4b5.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
