### PR TITLE
fix: Show Room without dropdown and Video Source for BBB

### DIFF
--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -32,7 +32,7 @@
 <form class="ui form {{if this.isLoading 'loading'}}">
   <div class="field">
     <label class="required">{{t 'Room'}}</label>
-    <input value={{if this.data.stream.event 'Event Video Room' this.room.name}} readonly>
+    <input value={{this.data.stream.name}} readonly>
   </div>
   {{#if (eq this.data.stream.videoChannel.provider 'bbb')}}
     <div class="field">

--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -33,25 +33,7 @@
   {{#unless this.data.stream.event}}
     <div class="field">
       <label class="required">{{t 'Room'}}</label>
-      <input type="hidden" id="rooms">
-      <UiDropdown
-        @class="fluid selection"
-        @selected={{this.room}}
-        @onChange={{action this.setRoom}} as |execute mapper|>
-        <i class="dropdown icon"></i>
-        <div class="default text">
-          {{t 'Select Rooms'}}
-        </div>
-        <div class="menu">
-          {{#each this.rooms as |room|}}
-            {{#if room.name}}
-              <div data-value="{{map-value mapper room}}" class="item">
-                {{room.name}}
-              </div>
-            {{/if}}
-          {{/each}}
-        </div>
-      </UiDropdown>
+      <input id="rooms" value={{this.room.name}} readonly>
     </div>
   {{/unless}}
   {{#if (not-eq this.data.stream.videoChannel.provider 'bbb')}}

--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -32,8 +32,14 @@
 <form class="ui form {{if this.isLoading 'loading'}}">
   <div class="field">
     <label class="required">{{t 'Room'}}</label>
-    <input id="rooms" value={{if this.data.stream.event 'Event Video Room' this.room.name}} readonly>
+    <input value={{if this.data.stream.event 'Event Video Room' this.room.name}} readonly>
   </div>
+  {{#if (eq this.data.stream.videoChannel.provider 'bbb')}}
+    <div class="field">
+      <label class="required">{{t 'Video Source'}}</label>
+      <input value='Auto-Generated Big Blue Button Video Room' readonly> 
+    </div>
+  {{/if}}
   {{#if (not-eq this.data.stream.videoChannel.provider 'bbb')}}
     <div class="field">
       <label class="required">{{t 'Video Source URL'}}</label>

--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -30,12 +30,10 @@
 </div>
 <br>
 <form class="ui form {{if this.isLoading 'loading'}}">
-  {{#unless this.data.stream.event}}
-    <div class="field">
-      <label class="required">{{t 'Room'}}</label>
-      <input id="rooms" value={{this.room.name}} readonly>
-    </div>
-  {{/unless}}
+  <div class="field">
+    <label class="required">{{t 'Room'}}</label>
+    <input id="rooms" value={{if this.data.stream.event 'Event Video Room' this.room.name}} readonly>
+  </div>
   {{#if (not-eq this.data.stream.videoChannel.provider 'bbb')}}
     <div class="field">
       <label class="required">{{t 'Video Source URL'}}</label>

--- a/app/components/forms/events/view/videoroom-form.js
+++ b/app/components/forms/events/view/videoroom-form.js
@@ -56,14 +56,6 @@ export default class VideoroomForm extends Component.extend(FormMixin) {
               prompt : this.l10n.t('Please enter a valid url')
             }
           ]
-        },
-        rooms: {
-          rules: [
-            {
-              type   : 'checkVideoRoomsLength',
-              prompt : this.l10n.t('Please select a room')
-            }
-          ]
         }
       }
     };


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6068 

#### Changes proposed in this pull request:

  - [x]   Room name drop down field on the video room edit page of microlocations: Do not offer the option of a room drop-down. Instead only show the current room that is being edited.
  - [x]  Room name drop down field on the video room edit page of event video room: Show the field "Event Video Room" in the same place
  - [x]  Furthermore in the Big Blue Button option of the pages there should be a field with information in the area Video Source URL. Please show this as follows: Instead of "Video Source URL" show "Video Source" and in the field show "Auto-Generated Big Blue Button Video Room"


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
