### PR TITLE
chore: Make team area translatable

### DIFF
--- a/app/routes/events/view/team/permissions.ts
+++ b/app/routes/events/view/team/permissions.ts
@@ -11,73 +11,73 @@ export default class EventsViewTeamPermissions extends Route.extend({
     return {
       permissions: [
         {
-          title  : 'Manage Events Page',
+          title  : this.l10n.t('Manage Events Page'),
           header : true
         },
         {
-          title     : 'Show event on manage events page',
+          title     : this.l10n.t('Show event on manage events page'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Overview',
+          title  : this.l10n.t('Overview'),
           header : true
         },
         {
-          title     : 'Update/Edit event',
+          title     : this.l10n.t('Update/Edit event'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'View event dashboard',
+          title     : this.l10n.t('View event dashboard'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Team',
+          title  : this.l10n.t('Team'),
           header : true
         },
         {
-          title     : 'View team members',
+          title     : this.l10n.t('View team members'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Invite team members',
+          title     : this.l10n.t('Invite team members'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Cancel invitations',
+          title     : this.l10n.t('Cancel invitations'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Delete team members',
+          title     : this.l10n.t('Delete team members'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Manage roles',
+          title     : this.l10n.t('Manage roles'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Tickets',
+          title  : this.l10n.t('Tickets'),
           header : true
         },
         {
-          title     : 'View orders and attendees',
+          title     : this.l10n.t('View orders and attendees'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Create discount codes',
+          title     : this.l10n.t('Create discount codes'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Edit discount codes',
+          title     : this.l10n.t('Edit discount codes'),
           owner     : true,
           organizer : true
         },
@@ -87,65 +87,65 @@ export default class EventsViewTeamPermissions extends Route.extend({
           organizer : true
         },
         {
-          title     : 'Edit view codes',
+          title     : this.l10n.t('Edit view codes'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Check-in attendees',
+          title     : this.l10n.t('Check-in attendees'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Change attendee check-in status',
+          title     : this.l10n.t('Change attendee check-in status'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Scheduler',
+          title  : this.l10n.t('Scheduler'),
           header : true
         },
         {
-          title     : 'View scheduler',
+          title     : this.l10n.t('View scheduler'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Edit schedule',
+          title     : this.l10n.t('Edit schedule'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Publish schedule',
+          title     : this.l10n.t('Publish schedule'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Unpublish schedule',
+          title     : this.l10n.t('Unpublish schedule'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Sessions and Speakers',
+          title  : this.l10n.t('Sessions and Speakers'),
           header : true
         },
         {
-          title     : 'View speaker profiles',
+          title     : this.l10n.t('View speaker profiles'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Edit speaker profiles',
+          title     : this.l10n.t('Edit speaker profiles'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Create speaker profiles',
+          title     : this.l10n.t('Create speaker profiles'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Feature speakers',
+          title     : this.l10n.t('Feature speakers'),
           owner     : true,
           organizer : true
         },
@@ -155,65 +155,65 @@ export default class EventsViewTeamPermissions extends Route.extend({
           organizer : true
         },
         {
-          title     : 'Edit session submissions',
+          title     : this.l10n.t('Edit session submissions'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Create sessions',
+          title     : this.l10n.t('Create sessions'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Change session status',
+          title     : this.l10n.t('Change session status'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Notify speakers of status change',
+          title     : this.l10n.t('Notify speakers of status change'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'View ratings',
+          title     : this.l10n.t('View ratings'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Rate session submissions',
+          title     : this.l10n.t('Rate session submissions'),
           owner     : true,
           organizer : true
         },
         {
-          title     : 'Lock/Unlock session submissions',
+          title     : this.l10n.t('Lock/Unlock session submissions'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Export',
+          title  : this.l10n.t('Export'),
           header : true
         },
         {
-          title     : 'View Export Info',
+          title     : this.l10n.t('View Export Info'),
           owner     : true,
           organizer : true
         },
         {
-          title  : 'Settings',
+          title  : this.l10n.t('Settings'),
           header : true
         },
         {
-          title     : 'View settings',
+          title     : this.l10n.t('View settings'),
           owner     : true,
           organizer : false
         },
         {
-          title     : 'Delete event',
+          title     : this.l10n.t('Delete event'),
           owner     : true,
           organizer : false
         },
         {
-          title     : 'Transfer ownership',
+          title     : this.l10n.t('Transfer ownership'),
           owner     : true,
           organizer : false
         }

--- a/app/routes/events/view/team/permissions.ts
+++ b/app/routes/events/view/team/permissions.ts
@@ -82,7 +82,7 @@ export default class EventsViewTeamPermissions extends Route.extend({
           organizer : true
         },
         {
-          title     : 'Create view codes',
+          title     : this.l10n.t('Create view codes'),
           owner     : true,
           organizer : true
         },
@@ -150,7 +150,7 @@ export default class EventsViewTeamPermissions extends Route.extend({
           organizer : true
         },
         {
-          title     : 'View session submissions',
+          title     : this.l10n.t('View session submissions'),
           owner     : true,
           organizer : true
         },


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5794 

#### Short description of what this resolves:
Adds translation to Teams permission page

#### Changes proposed in this pull request:
![lang_change](https://user-images.githubusercontent.com/58526162/102656303-a6d96980-4199-11eb-8c15-95f9d063794a.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
