### PR TITLE
video room edit form

### DIFF
--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -30,28 +30,16 @@
 </div>
 <br>
 <form class="ui form {{if this.isLoading 'loading'}}">
+  {{#if this.data.stream.event}}
+    <div class="field">
+      <label class="required">{{t 'Room'}}</label>
+      <input id="rooms" value="Event Video Room" readonly="true">
+    </div>
+  {{/if}}
   {{#unless this.data.stream.event}}
     <div class="field">
       <label class="required">{{t 'Room'}}</label>
-      <input type="hidden" id="rooms">
-      <UiDropdown
-        @class="fluid selection"
-        @selected={{this.room}}
-        @onChange={{action this.setRoom}} as |execute mapper|>
-        <i class="dropdown icon"></i>
-        <div class="default text">
-          {{t 'Select Rooms'}}
-        </div>
-        <div class="menu">
-          {{#each this.rooms as |room|}}
-            {{#if room.name}}
-              <div data-value="{{map-value mapper room}}" class="item">
-                {{room.name}}
-              </div>
-            {{/if}}
-          {{/each}}
-        </div>
-      </UiDropdown>
+      <input id="rooms" value={{this.room.name}} readonly="true">
     </div>
   {{/unless}}
   {{#if (not-eq this.data.stream.videoChannel.provider 'bbb')}}

--- a/app/components/forms/events/view/videoroom-form.js
+++ b/app/components/forms/events/view/videoroom-form.js
@@ -56,14 +56,6 @@ export default class VideoroomForm extends Component.extend(FormMixin) {
               prompt : this.l10n.t('Please enter a valid url')
             }
           ]
-        },
-        rooms: {
-          rules: [
-            {
-              type   : 'checkVideoRoomsLength',
-              prompt : this.l10n.t('Please select a room')
-            }
-          ]
         }
       }
     };


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6068 

#### Short description of what this resolves:
In video room edit page of microlocations. room field is showing room name and event video room form field is showing room as "Event Video Room" and dropdown is removed.

#### Changes proposed in this pull request:

![image](https://user-images.githubusercontent.com/60281688/102684151-3b74b380-41fc-11eb-88b9-0f751a299971.png)
![image](https://user-images.githubusercontent.com/60281688/102684226-b342de00-41fc-11eb-81fa-7b498b23f207.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
