### PR TITLE
fix: Public Event Sidebar: Hide icons in side menu dekstop

### DIFF
--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -108,5 +108,3 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     display: inline !important;
   }
 }
-
-

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -98,3 +98,15 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
 .no-wrap {
   white-space: nowrap;
 }
+
+.mobile-icon {
+  display: none !important;
+}
+
+@media screen and (max-width: 767px) {
+  .mobile-icon {
+    display: inline !important;
+  }
+}
+
+

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -98,13 +98,3 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
 .no-wrap {
   white-space: nowrap;
 }
-
-.mobile-icon {
-  display: none !important;
-}
-
-@media screen and (max-width: 767px) {
-  .mobile-icon {
-    display: inline !important;
-  }
-}

--- a/app/styles/partials/utils.scss
+++ b/app/styles/partials/utils.scss
@@ -145,6 +145,10 @@
   margin-right: .5rem !important;
 }
 
+.mr-4 {
+  margin-right: 1rem !important;
+}
+
 .mr--4 {
   margin-right: -1rem !important;
 }

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,80 +1,80 @@
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#info' {{action "scrollToTarget" 'info' }} class='item active scroll'>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item mr-2'}} info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
   </a>
   {{#if this.event.tickets.length}}
     <a href='#tickets' {{action "scrollToTarget" 'tickets' }} class='item scroll'>
-      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </a>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
    {{/if}}
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'info' }}>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
   </LinkTo>
   {{#if this.event.tickets.length}}
     <LinkTo class="item" @route="public.index" {{action 'goToSection' 'tickets' }}>
-      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </LinkTo>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
   {{/if}}
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.sessions" class="item">
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Schedule'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Schedule'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.schedule" class="item">
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} calendar icon"></i>{{t 'Calendar'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} calendar icon"></i>{{t 'Calendar'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.shouldShowCallforSpeakers }}
   <LinkTo @route="public.cfs" class="item">
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.event.isSponsorsEnabled this.event.sponsors)}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#sponsor' {{action "scrollToTarget" 'sponsor' }} class='item scroll'>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'sponsor' }}>
-      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
+      <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if this.event.hasOwnerInfo}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#organizer' {{action "scrollToTarget" 'organizer' }} class='item scroll'>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'organizer' }}>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#getting-here' {{action "scrollToTarget" 'getting-here' }} class='item scroll'>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </a>
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'getting-here' }}>
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.event.codeOfConduct}}
   <LinkTo @route="public.coc" class="item">
-    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Code of Conduct'}}</div>
+    <div><i class="mr-4 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Code of Conduct'}}</div>
   </LinkTo>
 {{/if}}

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,80 +1,80 @@
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#info' {{action "scrollToTarget" 'info' }} class='item active scroll'>
-    <div><i class="mobile-icon info icon"></i>{{t 'Info'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
   </a>
   {{#if this.event.tickets.length}}
     <a href='#tickets' {{action "scrollToTarget" 'tickets' }} class='item scroll'>
-      <div><i class="mobile-icon ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="{{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </a>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="mobile-icon bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
    {{/if}}
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'info' }}>
-    <div><i class="mobile-icon info icon"></i>{{t 'Info'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
   </LinkTo>
   {{#if this.event.tickets.length}}
     <LinkTo class="item" @route="public.index" {{action 'goToSection' 'tickets' }}>
-      <div><i class="mobile-icon ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="{{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </LinkTo>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="mobile-icon bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
   {{/if}}
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.sessions" class="item">
-    <div><i class="mobile-icon book icon"></i>{{t 'Schedule'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Schedule'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.schedule" class="item">
-    <div><i class="mobile-icon calendar icon"></i>{{t 'Calendar'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} calendar icon"></i>{{t 'Calendar'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.shouldShowCallforSpeakers }}
   <LinkTo @route="public.cfs" class="item">
-    <div><i class="mobile-icon bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.event.isSponsorsEnabled this.event.sponsors)}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#sponsor' {{action "scrollToTarget" 'sponsor' }} class='item scroll'>
-    <div><i class="mobile-icon dollar icon"></i>{{t 'Sponsors'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'sponsor' }}>
-      <div><i class="mobile-icon dollar icon"></i>{{t 'Sponsors'}}</div>
+      <div><i class="{{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if this.event.hasOwnerInfo}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#organizer' {{action "scrollToTarget" 'organizer' }} class='item scroll'>
-    <div><i class="mobile-icon users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'organizer' }}>
-    <div><i class="mobile-icon users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#getting-here' {{action "scrollToTarget" 'getting-here' }} class='item scroll'>
-    <div><i class="mobile-icon icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </a>
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'getting-here' }}>
-    <div><i class="mobile-icon icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.event.codeOfConduct}}
   <LinkTo @route="public.coc" class="item">
-    <div><i class="mobile-icon book icon"></i>{{t 'Code of Conduct'}}</div>
+    <div><i class="{{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Code of Conduct'}}</div>
   </LinkTo>
 {{/if}}

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,80 +1,80 @@
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#info' {{action "scrollToTarget" 'info' }} class='item active scroll'>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item mr-2'}} info icon"></i>{{t 'Info'}}</div>
   </a>
   {{#if this.event.tickets.length}}
     <a href='#tickets' {{action "scrollToTarget" 'tickets' }} class='item scroll'>
-      <div><i class="{{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </a>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
    {{/if}}
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'info' }}>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} info icon"></i>{{t 'Info'}}</div>
   </LinkTo>
   {{#if this.event.tickets.length}}
     <LinkTo class="item" @route="public.index" {{action 'goToSection' 'tickets' }}>
-      <div><i class="{{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} ticket icon"></i>{{t 'Tickets'}}</div>
     </LinkTo>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
   {{/if}}
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.sessions" class="item">
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Schedule'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Schedule'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.schedule" class="item">
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} calendar icon"></i>{{t 'Calendar'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} calendar icon"></i>{{t 'Calendar'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.shouldShowCallforSpeakers }}
   <LinkTo @route="public.cfs" class="item">
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.event.isSponsorsEnabled this.event.sponsors)}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#sponsor' {{action "scrollToTarget" 'sponsor' }} class='item scroll'>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'sponsor' }}>
-      <div><i class="{{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
+      <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} dollar icon"></i>{{t 'Sponsors'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if this.event.hasOwnerInfo}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#organizer' {{action "scrollToTarget" 'organizer' }} class='item scroll'>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'organizer' }}>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} users icon"></i>{{t 'Organizer'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#getting-here' {{action "scrollToTarget" 'getting-here' }} class='item scroll'>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </a>
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'getting-here' }}>
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.event.codeOfConduct}}
   <LinkTo @route="public.coc" class="item">
-    <div><i class="{{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Code of Conduct'}}</div>
+    <div><i class="mr-2 {{unless this.device.isMobile 'hidden-item'}} book icon"></i>{{t 'Code of Conduct'}}</div>
   </LinkTo>
 {{/if}}

--- a/app/templates/components/public/side-menu.hbs
+++ b/app/templates/components/public/side-menu.hbs
@@ -1,80 +1,80 @@
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#info' {{action "scrollToTarget" 'info' }} class='item active scroll'>
-    <div><i class="info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mobile-icon info icon"></i>{{t 'Info'}}</div>
   </a>
   {{#if this.event.tickets.length}}
     <a href='#tickets' {{action "scrollToTarget" 'tickets' }} class='item scroll'>
-      <div><i class="ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mobile-icon ticket icon"></i>{{t 'Tickets'}}</div>
     </a>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mobile-icon bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
    {{/if}}
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'info' }}>
-    <div><i class="info icon"></i>{{t 'Info'}}</div>
+    <div><i class="mobile-icon info icon"></i>{{t 'Info'}}</div>
   </LinkTo>
   {{#if this.event.tickets.length}}
     <LinkTo class="item" @route="public.index" {{action 'goToSection' 'tickets' }}>
-      <div><i class="ticket icon"></i>{{t 'Tickets'}}</div>
+      <div><i class="mobile-icon ticket icon"></i>{{t 'Tickets'}}</div>
     </LinkTo>
   {{/if}}
   {{#if this.showSpeakers}}
     <LinkTo @route="public.speakers" class="item">
-      <div><i class="bullhorn icon"></i>{{t 'Speakers'}}</div>
+      <div><i class="mobile-icon bullhorn icon"></i>{{t 'Speakers'}}</div>
     </LinkTo>
   {{/if}}
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.sessions" class="item">
-    <div><i class="book icon"></i>{{t 'Schedule'}}</div>
+    <div><i class="mobile-icon book icon"></i>{{t 'Schedule'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.isSchedulePublished this.showSessions)}}
   <LinkTo @route="public.schedule" class="item">
-    <div><i class="calendar icon"></i>{{t 'Calendar'}}</div>
+    <div><i class="mobile-icon calendar icon"></i>{{t 'Calendar'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.shouldShowCallforSpeakers }}
   <LinkTo @route="public.cfs" class="item">
-    <div><i class="bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
+    <div><i class="mobile-icon bullhorn icon"></i>{{t 'Call for Speakers'}}</div>
   </LinkTo>
 {{/if}}
 {{#if (and this.event.isSponsorsEnabled this.event.sponsors)}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#sponsor' {{action "scrollToTarget" 'sponsor' }} class='item scroll'>
-    <div><i class="dollar icon"></i>{{t 'Sponsors'}}</div>
+    <div><i class="mobile-icon dollar icon"></i>{{t 'Sponsors'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'sponsor' }}>
-      <div><i class="dollar icon"></i>{{t 'Sponsors'}}</div>
+      <div><i class="mobile-icon dollar icon"></i>{{t 'Sponsors'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if this.event.hasOwnerInfo}}
  {{#if (eq this.session.currentRouteName 'public.index')}}
    <a href='#organizer' {{action "scrollToTarget" 'organizer' }} class='item scroll'>
-    <div><i class="users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mobile-icon users icon"></i>{{t 'Organizer'}}</div>
    </a>
  {{else}}
    <LinkTo class="item" @route="public.index" {{action 'goToSection' 'organizer' }}>
-    <div><i class="users icon"></i>{{t 'Organizer'}}</div>
+    <div><i class="mobile-icon users icon"></i>{{t 'Organizer'}}</div>
    </LinkTo>
  {{/if}}
 {{/if}}
 {{#if (eq this.session.currentRouteName 'public.index')}}
   <a href='#getting-here' {{action "scrollToTarget" 'getting-here' }} class='item scroll'>
-    <div><i class="icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mobile-icon icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </a>
 {{else}}
   <LinkTo class="item" @route="public.index" {{action 'goToSection' 'getting-here' }}>
-    <div><i class="icon map marker alternate"></i>{{t 'Getting here'}}</div>
+    <div><i class="mobile-icon icon map marker alternate"></i>{{t 'Getting here'}}</div>
   </LinkTo>
 {{/if}}
 {{#if this.event.codeOfConduct}}
   <LinkTo @route="public.coc" class="item">
-    <div><i class="book icon"></i>{{t 'Code of Conduct'}}</div>
+    <div><i class="mobile-icon book icon"></i>{{t 'Code of Conduct'}}</div>
   </LinkTo>
 {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6118

#### Short description of what this resolves:
remove icons on the desktop view.

Screenshot -

![2020-12-23 (6)](https://user-images.githubusercontent.com/61330148/103000024-34c5a380-4550-11eb-9b77-3e30bc05123c.png)


### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
