### PR TITLE
fix: sort attendee orders according to date and time

### DIFF
--- a/app/controllers/events/view/tickets/attendees/list.js
+++ b/app/controllers/events/view/tickets/attendees/list.js
@@ -5,6 +5,8 @@ import moment from 'moment';
 
 
 export default class extends Controller.extend(EmberTableControllerMixin) {
+  sort_by = 'order.completed_at';
+  sort_dir = 'ASC';
   get columns() {
     return [
       {


### PR DESCRIPTION


Fixes #6111 

#### Short description of what this resolves:
Sort attendee orders with latest orders on top.

#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
