### PR TITLE
fix: creating events with same starting and ending time

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -203,7 +203,7 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             },
             {
               type   : 'checkValidTimeDifference',
-              prompt : this.l10n.t('Starting time should be less than ending time')
+              prompt : this.l10n.t('Starting time should be lesser than the ending time')
             }
           ]
         },
@@ -217,7 +217,7 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             },
             {
               type   : 'checkValidTimeDifference',
-              prompt : this.l10n.t('Ending time should be greater than starting time')
+              prompt : this.l10n.t('Ending time should be greater than the starting time')
             }
           ]
         },

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -141,7 +141,14 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     $.fn.form.settings.rules.checkMaxMinOrder = () => {
       return parseInt($('.ui.form').form('get value', 'ticket_min_order'), 10) <= parseInt($('.ui.form').form('get value', 'ticket_max_order'), 10);
     };
-
+    window.$.fn.form.settings.rules.checkValidTimeDifference = () => {
+      const STA = document.getElementsByName('start_time')[0].value.split(':');
+      const STIS = (parseInt(STA[0]) + parseInt(STA[1])) * 60;
+      const ETA = document.getElementsByName('end_time')[0].value.split(':');
+      const ETIS = (parseInt(ETA[0]) + parseInt(ETA[1])) * 60;
+      return STIS < ETIS;
+    };
+      
     const validationRules = {
       inline : true,
       delay  : false,
@@ -198,6 +205,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give a start time')
+            },
+            {
+              type   : 'checkValidTimeDifference',
+              prompt : this.l10n.t('Starting time should be less than ending time')
             }
           ]
         },
@@ -208,6 +219,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
             {
               type   : 'empty',
               prompt : this.l10n.t('Please give an end time')
+            },
+            {
+              type   : 'checkValidTimeDifference',
+              prompt : this.l10n.t('Ending time should be greater than starting time')
             }
           ]
         },

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -141,12 +141,8 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     $.fn.form.settings.rules.checkMaxMinOrder = () => {
       return parseInt($('.ui.form').form('get value', 'ticket_min_order'), 10) <= parseInt($('.ui.form').form('get value', 'ticket_max_order'), 10);
     };
-    window.$.fn.form.settings.rules.checkValidTimeDifference = () => {
-      const STA = document.getElementsByName('start_time')[0].value.split(':');
-      const STIS = (parseInt(STA[0]) + parseInt(STA[1])) * 60;
-      const ETA = document.getElementsByName('end_time')[0].value.split(':');
-      const ETIS = (parseInt(ETA[0]) + parseInt(ETA[1])) * 60;
-      return STIS < ETIS;
+    $.fn.form.settings.rules.checkValidTimeDifference = () => {
+      return moment(document.getElementsByName('start_time')[0].value , 'HH:mm').isBefore(moment(document.getElementsByName('end_time')[0].value, 'HH:mm'));
     };
       
     const validationRules = {

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -140,11 +140,10 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     };
     $.fn.form.settings.rules.checkMaxMinOrder = () => {
       return parseInt($('.ui.form').form('get value', 'ticket_min_order'), 10) <= parseInt($('.ui.form').form('get value', 'ticket_max_order'), 10);
-    };
+    }; 
     $.fn.form.settings.rules.checkValidTimeDifference = () => {
-      return moment($("[name=start_time]")[0].value , 'HH:mm').isBefore(moment($("[name=end_time]")[0].value, 'HH:mm'));
+      return moment($('[name=start_time]')[0].value , 'HH:mm').isBefore(moment($('[name=end_time]')[0].value, 'HH:mm'));
     };
-      
     const validationRules = {
       inline : true,
       delay  : false,

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -142,7 +142,7 @@ export default Component.extend(FormMixin, EventWizardMixin, {
       return parseInt($('.ui.form').form('get value', 'ticket_min_order'), 10) <= parseInt($('.ui.form').form('get value', 'ticket_max_order'), 10);
     };
     $.fn.form.settings.rules.checkValidTimeDifference = () => {
-      return moment(document.getElementsByName('start_time')[0].value , 'HH:mm').isBefore(moment(document.getElementsByName('end_time')[0].value, 'HH:mm'));
+      return moment($("[name=start_time]")[0].value , 'HH:mm').isBefore(moment($("[name=end_time]")[0].value, 'HH:mm'));
     };
       
     const validationRules = {

--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -140,9 +140,9 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     };
     $.fn.form.settings.rules.checkMaxMinOrder = () => {
       return parseInt($('.ui.form').form('get value', 'ticket_min_order'), 10) <= parseInt($('.ui.form').form('get value', 'ticket_max_order'), 10);
-    }; 
+    };
     $.fn.form.settings.rules.checkValidTimeDifference = () => {
-      return moment($('[name=start_time]')[0].value , 'HH:mm').isBefore(moment($('[name=end_time]')[0].value, 'HH:mm'));
+      return moment($('[name=start_time]')[0].value, 'HH:mm').isBefore(moment($('[name=end_time]')[0].value, 'HH:mm'));
     };
     const validationRules = {
       inline : true,

--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -6,7 +6,7 @@ import { FORM_TIME_FORMAT } from 'open-event-frontend/utils/dictionary/date-time
 
 export default Component.extend({
 
-  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'flex-column'],
+  classNames: ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'flex-column', 'd-initial-imp'],
   classNameBindings : ['icon:left', 'icon'],
 
   icon: true,

--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -6,7 +6,7 @@ import { FORM_TIME_FORMAT } from 'open-event-frontend/utils/dictionary/date-time
 
 export default Component.extend({
 
-  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'd-initial'],
+  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'flex-column'],
   classNameBindings : ['icon:left', 'icon'],
 
   icon: true,

--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -6,7 +6,7 @@ import { FORM_TIME_FORMAT } from 'open-event-frontend/utils/dictionary/date-time
 
 export default Component.extend({
 
-  classNames: ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'flex-column', 'd-initial-imp'],
+  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid'],
   classNameBindings : ['icon:left', 'icon'],
 
   icon: true,

--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -6,7 +6,7 @@ import { FORM_TIME_FORMAT } from 'open-event-frontend/utils/dictionary/date-time
 
 export default Component.extend({
 
-  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field' , 'd-initial'],
+  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field', 'd-initial'],
   classNameBindings : ['icon:left', 'icon'],
 
   icon: true,

--- a/app/components/widgets/forms/time-picker.js
+++ b/app/components/widgets/forms/time-picker.js
@@ -6,7 +6,7 @@ import { FORM_TIME_FORMAT } from 'open-event-frontend/utils/dictionary/date-time
 
 export default Component.extend({
 
-  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field'],
+  classNames        : ['ui', 'calendar', 'time', 'picker', 'input', 'fluid', 'field' , 'd-initial'],
   classNameBindings : ['icon:left', 'icon'],
 
   icon: true,

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -75,6 +75,10 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   display: inline-block;
 }
 
+.d-initial-imp {
+  display: initial !important;
+}
+
 .flex-column {
   flex-direction: column;
 }

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -75,14 +75,6 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   display: inline-block;
 }
 
-.d-initial-imp {
-  display: initial !important;
-}
-
-.flex-column {
-  flex-direction: column;
-}
-
 .items-center {
   align-items: center;
 }

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -75,6 +75,10 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   display: inline-block;
 }
 
+.d-initial {
+  display: initial !important;
+}
+
 .items-center {
   align-items: center;
 }

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -75,8 +75,8 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   display: inline-block;
 }
 
-.d-initial {
-  display: initial !important;
+.flex-column {
+  flex-direction: column;
 }
 
 .items-center {

--- a/app/templates/components/widgets/forms/time-picker.hbs
+++ b/app/templates/components/widgets/forms/time-picker.hbs
@@ -1,4 +1,1 @@
-{{#if this.icon}}
-  <i class="time icon"></i>
-{{/if}}
 <Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />

--- a/app/templates/components/widgets/forms/time-picker.hbs
+++ b/app/templates/components/widgets/forms/time-picker.hbs
@@ -1,6 +1,3 @@
-{{#if this.icon}}
-  <i class="time icon"></i>
-{{/if}}
 <div class="ui input">
   <Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />
 </div>

--- a/app/templates/components/widgets/forms/time-picker.hbs
+++ b/app/templates/components/widgets/forms/time-picker.hbs
@@ -1,6 +1,4 @@
 {{#if this.icon}}
   <i class="time icon"></i>
 {{/if}}
-<div class="ui input">
-  <Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />
-</div>
+<Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />

--- a/app/templates/components/widgets/forms/time-picker.hbs
+++ b/app/templates/components/widgets/forms/time-picker.hbs
@@ -1,3 +1,6 @@
+{{#if this.icon}}
+  <i class="time icon"></i>
+{{/if}}
 <div class="ui input">
   <Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />
 </div>

--- a/app/templates/components/widgets/forms/time-picker.hbs
+++ b/app/templates/components/widgets/forms/time-picker.hbs
@@ -1,1 +1,6 @@
-<Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />
+<div class="ui {{if this.icon 'left icon'}} input">
+  {{#if this.icon}}
+    <i class="time icon"></i>
+  {{/if}}
+  <Input @type="text" @value={{value}} placeholder={{this.placeholder}} @name={{name}} @focus-out={{action "onChange"}} />
+</div>


### PR DESCRIPTION
Fixes #6117 

#### Short description of what this resolves:
Previously we were able to create the events keeping the starting time and ending time same and this pr fixes that issue.

#### Changes proposed in this pull request:

### Screenshot after changes
![Screenshot_2020-12-25 Create an Event Open Event](https://user-images.githubusercontent.com/65965202/103116130-4fe8fe00-468b-11eb-9bbd-f6f717d1aef2.png)


#### Checklist 

- [YES ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ YES] My branch is up-to-date with the Upstream `development` branch.
- [ NOT CHECKED YET] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ NO] I have added tests that prove my fix is effective or that my feature works
- [ NOT REQUIRED] I have added necessary documentation (if appropriate)
