### PR TITLE
fix: overflow of the data elements from the container

### DIFF
--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -28,12 +28,12 @@
                       {{field.name}}
                     </h4>
                     {{#if (is-input-field field.type) }}
-                      <span>{{get holder field.fieldIdentifier}}</span>
+                      <span class="word-break">{{get holder field.fieldIdentifier}}</span>
                     {{else if (eq field.type 'select')}}
-                      <span>{{get holder field.fieldIdentifier}}</span>
+                      <span class="word-break">{{get holder field.fieldIdentifier}}</span>
                     {{/if}}
                     {{#if field.isComplex}}
-                      <span>{{get holder.complexFieldValues field.fieldIdentifier}}</span>
+                      <span class="word-break">{{get holder.complexFieldValues field.fieldIdentifier}}</span>
                     {{/if}}
                 </div>
               {{/if}}
@@ -66,7 +66,7 @@
                   {{t 'Address'}}
                 </h4>
                 <div class="ui list">
-                  <div class="item">
+                  <div class="item word-break">
                     {{this.data.address}}
                   </div>
                   <div class="item">

--- a/app/templates/components/orders/ticket-holder.hbs
+++ b/app/templates/components/orders/ticket-holder.hbs
@@ -19,7 +19,7 @@
       <h4 class="weight-300">
         {{t 'Email'}}
       </h4>
-      <span>
+      <span class="word-break">
         {{this.buyer.email}}
       </span>
       {{#if (not-eq this.data.paymentMode 'free')}}


### PR DESCRIPTION
Fixes #6173 

#### Short description of what this resolves:
Previously on filling the large email adresses and the location adress , gets overflow through their containers, more on the screenshots.

![Screenshot_2021-01-01 Completed Order - e84156f6-fe89-46cf-bfff-33deade6276f Orders Open Event](https://user-images.githubusercontent.com/65965202/103437768-9d4c0900-4c51-11eb-8d5b-0d65b96f02f7.png)

But now this is fixed.

![Screenshot_2021-01-01 Completed Order - e84156f6-fe89-46cf-bfff-33deade6276f Orders Open Event(1)](https://user-images.githubusercontent.com/65965202/103437775-b05ed900-4c51-11eb-9090-38ecc8c4db8c.png)



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
