### PR TITLE
fix: Video Tab: Icons aligned when event or video room has a long name 

### DIFF
--- a/app/styles/components/extras.scss
+++ b/app/styles/components/extras.scss
@@ -28,3 +28,9 @@ a.link-item {
     font-size: .9rem;
   }
 }
+
+@media screen and (max-width: 537px) {
+  .small-wrap {
+    flex-wrap: wrap !important;
+  }
+}

--- a/app/styles/components/extras.scss
+++ b/app/styles/components/extras.scss
@@ -28,9 +28,3 @@ a.link-item {
     font-size: .9rem;
   }
 }
-
-@media screen and (max-width: 537px) {
-  .small-wrap {
-    flex-wrap: wrap !important;
-  }
-}

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -63,6 +63,7 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   display: flex;
 }
 
+.wrap,
 .d-flex.wrap {
   flex-wrap: wrap;
 }

--- a/app/styles/partials/utils.scss
+++ b/app/styles/partials/utils.scss
@@ -81,6 +81,10 @@
   padding-bottom: 1rem !important;
 }
 
+.pl-2 {
+  padding-left: .5rem !important;
+}
+
 .pl-4 {
   padding-left: 1rem !important;
 }

--- a/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
+++ b/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
@@ -1,4 +1,4 @@
-<div class="d-flex">
+<div class="d-flex small-wrap">
   {{@record}}
   <div class="pl-2 ml-auto">
     {{#if (not @extraRecords.videoStream.id)}}

--- a/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
+++ b/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
@@ -1,4 +1,4 @@
-<div class="d-flex small-wrap">
+<div class="d-flex wrap">
   {{@record}}
   <div class="pl-2 ml-auto">
     {{#if (not @extraRecords.videoStream.id)}}

--- a/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
+++ b/app/templates/components/ui-table/cell/events/view/videoroom/cell-stream-title.hbs
@@ -1,6 +1,6 @@
 <div class="d-flex">
   {{@record}}
-  <div class="ml-auto">
+  <div class="pl-2 ml-auto">
     {{#if (not @extraRecords.videoStream.id)}}
       <LinkTo @route="events.view.videoroom.create" @query={{if (eq @extraRecords.constructor.modelName 'event') (hash event=true) (hash room=@extraRecords.id)}} class="ml-2">
         <UiPopup @content={{t "Add Video Channel"}} @class="ui circular icon button compact blue" @position="left center">
@@ -8,8 +8,8 @@
         </UiPopup>
       </LinkTo>
     {{else}}
-      <LinkTo @route="events.view.videoroom.edit" @model={{@extraRecords.videoStream.id}} class="ml-2">
-        <UiPopup @content={{t "Edit"}} @class="ui circular icon button compact positive" @position="left center">
+      <LinkTo @route="events.view.videoroom.edit" @model={{@extraRecords.videoStream.id}}>
+        <UiPopup @content={{t "Edit"}} @class="ml-2 ui circular icon button compact positive" @position="left center">
           <i class="edit icon"></i>
         </UiPopup>
       </LinkTo>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6187 

#### Short description of what this resolves:

![2021-01-01 (1)](https://user-images.githubusercontent.com/61330148/103438090-34ff2680-4c55-11eb-8a85-06753a5b05dd.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
