### PR TITLE
fix: Hide search box on wizard pages

### DIFF
--- a/app/components/nav-bar.js
+++ b/app/components/nav-bar.js
@@ -10,6 +10,12 @@ export default class NavBar extends Component {
   }
 
   @computed('session.currentRouteName')
+  get isNotWizardPageRoute() {
+    return !(String(this.session.currentRouteName).includes('edit'))
+    && String(this.session.currentRouteName) !== 'create';
+  }
+
+  @computed('session.currentRouteName')
   get isNotExplorePageRoute() {
     return !(String(this.session.currentRouteName).includes('explore'));
   }

--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -5,7 +5,7 @@
       <h3>{{this.settings.appName}}</h3>
     </LinkTo>
     <div class="right menu nav-bar">
-    {{#if (and this.isNotEventPageRoute this.isNotExplorePageRoute)}}
+    {{#if (and this.isNotEventPageRoute this.isNotExplorePageRoute this.isNotWizardPageRoute)}}
       <div class="search-bar d-flex items-center space-between m-2 p-2">
         <Input @class="prompt" @type="text" @key-up={{"handleKeyPress"}} @value={{this.event_name}} placeholder={{t "Search Events"}} />
         <i class="search icon"></i>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6220 

#### Short description of what this resolves:
Removed search box from all attendee, other-details, session-speakers, sponsors & basic-details page.

![Screenshot from 2021-01-03 19-45-41](https://user-images.githubusercontent.com/42090582/103481015-11c3ab00-4dfe-11eb-917b-71fa7382467b.png)
