### PR TITLE
fix: Session table styling

### DIFF
--- a/app/controllers/events/view/sessions/list.js
+++ b/app/controllers/events/view/sessions/list.js
@@ -15,7 +15,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         name            : this.l10n.t('State'),
         headerComponent : 'tables/headers/sort',
         cellComponent   : 'ui-table/cell/events/view/sessions/cell-buttons',
-        width           : 75,
+        width           : 90,
         valuePath       : 'state',
         isSortable      : true,
         extraValuePaths : ['id', 'status'],
@@ -29,7 +29,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       {
         name            : this.l10n.t('Title'),
         valuePath       : 'title',
-        width           : 230,
+        width           : 180,
         extraValuePaths : ['id', 'event', 'isLocked'],
         isSortable      : true,
         headerComponent : 'tables/headers/sort',
@@ -42,7 +42,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       },
       {
         name          : this.l10n.t('Speakers'),
-        width         : 70,
+        width         : 120,
         valuePath     : 'speakers',
         cellComponent : 'ui-table/cell/cell-speakers'
       },
@@ -72,13 +72,13 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       },
       {
         name          : this.l10n.t('Submission Date'),
-        width         : 90,
+        width         : 100,
         valuePath     : 'submittedAt',
         cellComponent : 'ui-table/cell/cell-simple-date'
       },
       {
         name          : this.l10n.t('Last Modified'),
-        width         : 90,
+        width         : 100,
         valuePath     : 'lastModifiedAt',
         cellComponent : 'ui-table/cell/cell-simple-date'
       },
@@ -92,7 +92,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       {
         name            : this.l10n.t('Lock Session'),
         valuePath       : 'id',
-        width           : 40,
+        width           : 70,
         extraValuePaths : ['isLocked'],
         cellComponent   : 'ui-table/cell/events/view/sessions/cell-lock-session',
         actions         : {

--- a/app/styles/partials/buttons.scss
+++ b/app/styles/partials/buttons.scss
@@ -9,6 +9,6 @@
   color: rgba(0, 0, 0, .95);
 }
 
-.max-content-button {
+.w-content-button {
   width: max-content;
 }

--- a/app/styles/partials/buttons.scss
+++ b/app/styles/partials/buttons.scss
@@ -8,3 +8,7 @@
   box-shadow: 0 0 0 1px transparent inset;
   color: rgba(0, 0, 0, .95);
 }
+
+.max-content-button {
+  width: max-content;
+}

--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
@@ -1,4 +1,4 @@
-<UiDropdown @class="ui floating dropdown button">
+<UiDropdown @class="ui floating dropdown button max-content-button">
   <div class="ui {{this.color}} empty circular label"></div>
   {{t-var (capitalize this.extraRecords.status)}}
   <div class="menu">

--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-buttons.hbs
@@ -1,4 +1,4 @@
-<UiDropdown @class="ui floating dropdown button max-content-button">
+<UiDropdown @class="ui floating dropdown button w-content-button">
   <div class="ui {{this.color}} empty circular label"></div>
   {{t-var (capitalize this.extraRecords.status)}}
   <div class="menu">

--- a/app/templates/components/ui-table/cell/events/view/sessions/cell-lock-session.hbs
+++ b/app/templates/components/ui-table/cell/events/view/sessions/cell-lock-session.hbs
@@ -1,9 +1,9 @@
 {{#if this.extraRecords.isLocked}}
-  <UiPopup @content={{t "Unlock Session"}} @class="ui basic button" @click={{action this.props.actions.lockSession this.record false}} @position="left center">
+  <UiPopup @content={{t "Unlock Session"}} @class="ui basic icon button" @click={{action this.props.actions.lockSession this.record false}} @position="left center">
     <i class="lock icon"></i>		
   </UiPopup>
 {{else}}
-  <UiPopup @content={{t "Lock Session"}} @class="ui basic button" @click={{action this.props.actions.lockSession this.record true}} @position="left center">
+  <UiPopup @content={{t "Lock Session"}} @class="ui basic icon button" @click={{action this.props.actions.lockSession this.record true}} @position="left center">
     <i class="unlock icon"></i>		
   </UiPopup>
 {{/if}}


### PR DESCRIPTION
Fixes #6221 

#### Short description of what this resolves:
This PR enchances the look of session table.


- [x] Make the status button on the left, e.g. "Confirmed" into one line
- [x] Make "Lock Box" square and avoid that it touches the right side of the table
- [x] Ensure Lock Session heading is in one line
- [x] Ensure table borders/spacing between columns is same everywhere (it looks different on some columns)
- [x] Ensure dates/times always fit into one row
- [x] Increase width of speakers columns a bit to also show slightly longer speaker names in one row
- [x] Improve anything else that could distort the view
- [x] Get rid of the internal scroll bar on the bottom of the table in some resolutions and when fonts are larger
 
The last task is covered in the PR #6207 


Screenshot with normal font size

![Screenshot from 2021-01-04 05-06-59](https://user-images.githubusercontent.com/65965202/103491598-3c882080-4e4b-11eb-81ba-8ab99220e8ca.png)

Screenshot after 10% increment in font-size(see 110% in url bar)

![Screenshot from 2021-01-04 05-06-56](https://user-images.githubusercontent.com/65965202/103491602-4447c500-4e4b-11eb-9462-9d6fd6d7c15b.png)

Screenshot after 20% increment in font-size

![Screenshot from 2021-01-04 05-06-53](https://user-images.githubusercontent.com/65965202/103491603-4578f200-4e4b-11eb-91a1-179f9fd9fc10.png)

Screenshot after 33% increment in font-size

![Screenshot from 2021-01-04 05-06-46](https://user-images.githubusercontent.com/65965202/103491607-46118880-4e4b-11eb-8044-accf7c7ef0e5.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
