### PR TITLE
fix: Missing info where Captcha is used in admin section

### DIFF
--- a/app/templates/components/forms/admin/settings/system/captcha-form.hbs
+++ b/app/templates/components/forms/admin/settings/system/captcha-form.hbs
@@ -5,21 +5,21 @@
       <div class="ui flowing popup top left transition hidden">
         <table class="ui fluid celled table">
           <thead>
-            <tr><th>Page</th>
-            <th>Functionality</th>
+            <tr><th> {{t 'Page'}}</th>
+            <th>{{t 'Functionality'}}</th>
           </tr></thead>
           <tbody>
             <tr>
-              <td>User Register Page</td>
-              <td>HCaptcha is enabled if new user is creating account.</td>
+              <td>{{t 'User Register Page'}}</td>
+              <td>{{t 'HCaptcha is enabled if new user is creating account.'}}</td>
             </tr>
             <tr>
-              <td>Login Page</td>
-              <td>HCaptcha is enabled if user try to login more than 2 times with wrong credentials.</td>
+              <td>{{t 'Login Page'}}</td>
+              <td>{{t 'HCaptcha is enabled if user try to login more than 2 times with wrong credentials.'}}</td>
             </tr>
             <tr>
-              <td>Forgot Password page</td>
-              <td>HCaptcha is always enabled.</td>
+              <td>{{t 'Forgot Password page'}}</td>
+              <td>{{t 'HCaptcha is always enabled.'}}</td>
             </tr>
           </tbody>
         </table>

--- a/app/templates/components/forms/admin/settings/system/captcha-form.hbs
+++ b/app/templates/components/forms/admin/settings/system/captcha-form.hbs
@@ -1,5 +1,30 @@
 <h3 class="ui header">
+  <div class="inline field">
   {{t 'Captcha Options'}}
+  <i class="small info circular icon link has popup"></i> 
+      <div class="ui flowing popup top left transition hidden">
+        <table class="ui fluid celled table">
+          <thead>
+            <tr><th>Page</th>
+            <th>Functionality</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td>User Register Page</td>
+              <td>HCaptcha is enabled if new user is creating account.</td>
+            </tr>
+            <tr>
+              <td>Login Page</td>
+              <td>HCaptcha is enabled if user try to login more than 2 times with wrong credentials.</td>
+            </tr>
+            <tr>
+              <td>Forgot Password page</td>
+              <td>HCaptcha is always enabled.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+  </div>
   <div class="sub header">
     {{t 'Captcha settings for sensitive actions in app.'}}
   </div>
@@ -8,7 +33,7 @@
   <label>
     {{t 'Enable Google reCAPTCHA'}}
   </label>
-  <UiCheckbox @class="toggle" @checked={{this.settings.isGoogleRecaptchaEnabled}} @onChange={{action (mut this.settings.isGoogleRecaptchaEnabled)}} />
+  <UiCheckbox @class="toggle disabled" @checked={{this.settings.isGoogleRecaptchaEnabled}} @onChange={{action (mut this.settings.isGoogleRecaptchaEnabled)}} />
 </div>
 {{#if this.settings.isGoogleRecaptchaEnabled}}
   <h3 class="ui header">


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-frontend/issues/3390

![Screenshot from 2021-01-05 21-39-39](https://user-images.githubusercontent.com/56407566/103673375-8126cf80-4fa3-11eb-9807-301914f101e0.png)

-  disabled `enable google recaptcha button`.
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
