### PR TITLE
fix: Organizer Menu Tab: Change Order

### DIFF
--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -28,20 +28,20 @@
         <LinkTo @route="events.view.tickets" class="item">
           {{t 'Tickets'}}
         </LinkTo>
-        <LinkTo @route="events.view.scheduler" class="item">
-          {{t 'Scheduler'}}
+        <LinkTo @route="events.view.speakers" class="item">
+          {{t 'Speakers'}}
         </LinkTo>
         <LinkTo @route="events.view.sessions" class="item">
           {{t 'Sessions'}}
         </LinkTo>
-        <LinkTo @route="events.view.speakers" class="item">
-          {{t 'Speakers'}}
-        </LinkTo>
-        <LinkTo @route="events.view.team" class="item">
-          {{t 'Team'}}
+        <LinkTo @route="events.view.scheduler" class="item">
+          {{t 'Scheduler'}}
         </LinkTo>
         <LinkTo @route="events.view.videoroom" class="item">
           {{t 'Video'}}
+        </LinkTo>
+        <LinkTo @route="events.view.team" class="item">
+          {{t 'Team'}}
         </LinkTo>
         {{#if (or this.authManager.currentUser.isAnAdmin (eq this.model.owner.email this.authManager.currentUser.email))}}
           <LinkTo @route="events.view.settings" class="item">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6277 

#### Short description of what this resolves:
ordered the menu tab to the following order: Overview, Tickets, Speakers, Sessions, Scheduler, Video, Team, Settings

#### Changes proposed in this pull request:

- Replaced the tabs
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
