### PR TITLE
fix: Prevent snackbar from blocking touches on mobile

### DIFF
--- a/app/styles/partials/snackbar.scss
+++ b/app/styles/partials/snackbar.scss
@@ -1,7 +1,7 @@
 .paper-snackbar {
   align-items: center;
   background-color: #323232;
-  bottom: 0;
+  bottom: -100px;
   color: #fff;
   display: flex;
   font-family: Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -36,7 +36,6 @@
 @media (min-width: 640px) {
   .paper-snackbar {
     border-radius: 2px;
-    bottom: -100px;
     display: inline-flex;
     margin: 24px;
     max-width: 568px;


### PR DESCRIPTION

#### Short description of what this resolves:

Because the snackbar is in-view on mobile (`bottom: 0`) rather than out of view like on desktop (`bottom: -100px`), clicking on elements in that area of the page on mobile will be blocked by the presence of a snackbar even though the snackbar is not visible. 

#### Changes proposed in this pull request:

- Snackbar always starts at -100px from bottom

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
