### PR TITLE
fix: "Click here to add" for social links directs to the wrong wizard step 

### DIFF
--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -39,7 +39,7 @@
               {{if (not-eq index 0) ','}} <a href="{{socialLink.link}}" target="_blank" rel="noopener noreferrer">{{socialLink.displayName}}</a>
             {{~/each}}
           {{else}}
-            {{t 'No social links present. '}} <a href="{{href-to 'events.view.edit.basic-details'}}#social-links">{{t 'Click here to add'}}</a>
+            {{t 'No social links present. '}} <a href="{{href-to 'events.view.edit.other-details'}}#social-links">{{t 'Click here to add'}}</a>
           {{/if}}
         </td>
       </tr>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6296 

#### Short description of what this resolves:
self explanatory

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
