### PR TITLE
fix: Don't override evenr ID if undefined

### DIFF
--- a/app/mixins/event-relation.js
+++ b/app/mixins/event-relation.js
@@ -7,8 +7,14 @@ export default Mixin.create({
 
   serializeBelongsTo(snapshot, json, relationship) {
     try {
-      if (snapshot.belongsTo('event')) {
-        snapshot.belongsTo('event').id = snapshot.belongsTo('event').attributes().originalId;
+      const event = snapshot.belongsTo('event');
+      if (event) {
+        const originalId = event.attributes().originalId;
+        // ID may have been already replaced and originalId may be undefined
+        // Overriding valid ID with undefined
+        if (originalId) {
+          event.id = originalId;
+        }
       }
     } catch (ignored) { /** ignore errors as some models won't be having event relationship **/ }
 
@@ -19,7 +25,11 @@ export default Mixin.create({
     try {
       if (snapshot.hasMany('events') && snapshot.hasMany('events').length > 0) {
         for (let i = 0; i < snapshot.hasMany('events').length; i++) {
-          snapshot.hasMany('events')[i].id = snapshot.hasMany('events')[i].attributes().originalId;
+          const event = snapshot.hasMany('events')[i];
+          const originalId = event.attributes().originalId;
+          if (originalId) {
+            event.id = originalId;
+          }
         }
       }
     } catch (ignored) { /** ignore errors as some models won't be having event relationship **/ }

--- a/app/mixins/event-relation.js
+++ b/app/mixins/event-relation.js
@@ -9,7 +9,7 @@ export default Mixin.create({
     try {
       const event = snapshot.belongsTo('event');
       if (event) {
-        const originalId = event.attributes().originalId;
+        const { originalId } = event.attributes();
         // ID may have been already replaced and originalId may be undefined
         // Overriding valid ID with undefined
         if (originalId) {
@@ -26,7 +26,7 @@ export default Mixin.create({
       if (snapshot.hasMany('events') && snapshot.hasMany('events').length > 0) {
         for (let i = 0; i < snapshot.hasMany('events').length; i++) {
           const event = snapshot.hasMany('events')[i];
-          const originalId = event.attributes().originalId;
+          const { originalId } = event.attributes();
           if (originalId) {
             event.id = originalId;
           }


### PR DESCRIPTION
A serializer was created to convert string event identifier to event ID while saving the event or event relationship. However, event ID may have already been replaced sometimes and sometimes originalId is undefined, so in this case, valid event ID was being replaced with undefined. So, we check for null or undefined before replacing event ID

Fixes #6263 