### PR TITLE
Settings Location, Online etc. menu translatable 

### DIFF
--- a/app/components/forms/wizard/basic-details-step.js
+++ b/app/components/forms/wizard/basic-details-step.js
@@ -20,9 +20,9 @@ export default Component.extend(FormMixin, EventWizardMixin, {
 
   torii: service(),
 
-  locationMenuItems: ['Venue', 'Online', 'Mixed', 'To be announced'],
+  locationMenuItems: [this.l10n.t('Venue'), this.l10n.t('Online'), this.l10n.t('Mixed'), this.l10n.t('To be announced')],
 
-  selectedLocationType: 'Venue',
+  selectedLocationType: this.l10n.t('Venue'),
 
   deletedTickets: [],
 
@@ -30,19 +30,19 @@ export default Component.extend(FormMixin, EventWizardMixin, {
     this._super(...arguments);
     if (this.data.event.online) {
       if (this.data.event.locationName) {
-        this.selectedLocationType = 'Mixed';
+        this.selectedLocationType = this.l10n.t('Mixed');
       } else {
-        this.selectedLocationType = 'Online';
+        this.selectedLocationType = this.l10n.t('Online');
       }
     } else if (this.data.event.locationName) {
-      this.selectedLocationType = 'Venue';
+      this.selectedLocationType = this.l10n.t('Venue');
     } else {
-      this.selectedLocationType = 'To be announced';
+      this.selectedLocationType = this.l10n.t('To be announced');
     }
   },
 
   isLocationRequired: computed('selectedLocationType', function() {
-    return ['Venue', 'Mixed'].includes(this.selectedLocationType);
+    return [this.l10n.t('Venue'), this.l10n.t('Mixed')].includes(this.selectedLocationType);
   }),
 
   countries: computed(function() {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6339 

#### Short description of what this resolves:
Translated the Settings menu for location etc.

#### Changes proposed in this pull request:

- Added translations
-
-

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
