### PR TITLE
feat: Add afterOrderMessage field in event

### DIFF
--- a/app/models/event.js
+++ b/app/models/event.js
@@ -26,6 +26,7 @@ export default class Event extends ModelBase.extend(CustomPrimaryKeyMixin, {
   identifier             : attr('string', { readOnly: true }),
   name                   : attr('string'),
   description            : attr('string'),
+  afterOrderMessage      : attr('string'),
   startsAt               : attr('moment', { defaultValue: () => moment.tz(detectedTimezone).add(1, 'months').startOf('day') }),
   endsAt                 : attr('moment', { defaultValue: () => moment.tz(detectedTimezone).add(1, 'months').hour(17).minute(0) }),
   timezone               : attr('string', { defaultValue: detectedTimezone }),

--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -605,6 +605,11 @@
       </div>
     </div>
   {{/if}}
+  <div class="field">
+    <label for="description">{{t 'After Order Message'}}</label>
+    <Textarea
+      @value={{this.data.event.afterOrderMessage}} />
+  </div>
 </form>
 
 <Modals::TaxInfoModal

--- a/app/templates/components/orders/after-order-message.hbs
+++ b/app/templates/components/orders/after-order-message.hbs
@@ -1,0 +1,10 @@
+<div class="ui segments">
+    <div class="ui green inverted segment center aligned">
+      <div class="ui inverted mini statistic horizontal">
+        <div class="value">
+          {{t 'After Order Message'}}
+        </div>
+      </div>
+    </div>
+    <div class="ui padded segment">{{@event.afterOrderMessage}}</div>
+</div>

--- a/app/templates/components/orders/after-order-message.hbs
+++ b/app/templates/components/orders/after-order-message.hbs
@@ -2,7 +2,7 @@
     <div class="ui green inverted segment center aligned">
       <div class="ui inverted mini statistic horizontal">
         <div class="value">
-          {{t 'After Order Message'}}
+          {{t 'Organizer Message'}}
         </div>
       </div>
     </div>

--- a/app/templates/orders/pending.hbs
+++ b/app/templates/orders/pending.hbs
@@ -20,7 +20,12 @@
           @data={{this.model.order}}
           @event={{this.model.event}}
           @eventCurrency={{this.model.order.event.paymentCurrency}} />
+        <br/>
+        {{#if this.model.event.afterOrderMessage}}
+          <Orders::AfterOrderMessage
+            @event={{this.model.event}} />
           <br/>
+        {{/if}}
         <Forms::Orders::AttendeeList
           @save="save"
           @data={{this.model.order}}

--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -20,6 +20,11 @@
         @event={{this.model.event}}
         @eventCurrency={{this.model.order.event.paymentCurrency}} />
       <br/>
+      {{#if this.model.event.afterOrderMessage}}
+        <Orders::AfterOrderMessage
+          @event={{this.model.event}} />
+        <br/>
+      {{/if}}
       <Forms::Orders::AttendeeList
         @save="save"
         @data={{this.model.order}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5560

required #https://github.com/fossasia/open-event-server/pull/7611


#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
