### PR TITLE
fix: Event Dashboard Overview Box: Fix location and online info

### DIFF
--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -14,12 +14,18 @@
   <table class="ui very basic table">
     <tbody>
       <tr>
-        <td><strong>{{t 'Location'}}</strong></td>
+        <td><strong>{{t 'Setting'}}</strong></td>
         <td>
-          {{#if this.data.event.locationName}}
-            {{this.data.event.locationName}}
-          {{else}}
+          {{#if this.data.event.online}}
+            {{#if this.data.event.locationName}}
+              {{t 'Online and in-person event at '}}{{this.data.event.locationName}}
+            {{else}}
+              {{t 'Online event'}}
+            {{/if}}
+          {{else if this.data.event.locationName}}
             <a href="{{href-to 'events.view.edit.basic-details'}}">{{t 'Click to add location.'}}</a>
+          {{else}}
+            {{t 'To be announced.'}}
           {{/if}}
         </td>
       </tr>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6396

#### Short description of what this resolves:
On the left-hand site shows "Setting" instead of "Location"
On the right-hand side show:
If the event is location based only show same as now.
If the event is online only show "Online evevent"
If the event is a hybrid event show "Online and in-person event at [address]."
If the event is "To be announced" show "To be announced".

Screenshots -
**To be announced-**

![yy](https://user-images.githubusercontent.com/61330148/104821931-5838f100-5865-11eb-880b-662a8b439458.PNG)

**Online and in person -**
![xx](https://user-images.githubusercontent.com/61330148/104821934-5c650e80-5865-11eb-8031-c07a3ae66f6d.PNG)

**Online -**
![ss](https://user-images.githubusercontent.com/61330148/104821935-5f5fff00-5865-11eb-92ca-eb9849ead179.PNG)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
