### PR TITLE
fix: wrong download option, billing icon and text

### DIFF
--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -13,11 +13,13 @@
           <div class="inline field">
             <i class="user icon"></i>
             <label>{{t 'Ticket Holder '}}{{t ' -for- '}}{{holder.ticket.name}}</label>
+            {{#if (eq this.data.status 'completed')}}
              <button class="ui right floated button {{if this.device.isMobile 'fluid'}} button"
-          {{action this.downloadTicketForAttendee @event.name holder.order.id holder.id }}>
-            <i class="ticket icon"></i>
-            {{t 'Download Ticket'}}
-          </button>
+                {{action this.downloadTicketForAttendee @event.name holder.order.id holder.id }}>
+                <i class="ticket icon"></i>
+                {{t 'Download Ticket'}}
+            </button>
+            {{/if}}
           </div>
          
           {{# each this.allFields.attendee as |field|}}
@@ -45,7 +47,7 @@
       {{#if this.showBillingInfo}}
         <div class="print">
           <h4 class="ui horizontal divider header">
-            <i class='ticket icon'></i>
+            <i class='address card icon'></i>
             {{t 'Billing Information'}}
           </h4>
           <div class="ui two column divided relaxed stackable grid ">

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -148,7 +148,7 @@
 
       {{#if this.isPaidOrder}}
         <h4 class="ui horizontal divider header">
-          <i class="money bill alternate icon"></i>
+          <i class="address card icon"></i>
           {{t 'Billing Information'}}
         </h4>
         {{#unless this.event.isBillingInfoMandatory}}

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -28,9 +28,9 @@
           {{t 'Pending'}}
         </div>
         <div class="label">
-          {{t 'Your order has been placed successfully.'}}
+          {{t 'Your order has been placed.'}}
           <br>
-          {{t 'You can pay for your order to get tickets.'}}
+          {{t 'Please pay for your tickets to complete the order now.'}}
         </div>
       </div>
     </div>


### PR DESCRIPTION

Fixes #6407 

#### Short description of what this resolves:
- [x] There is a non-functional download link for a ticket, that has not been paid for yet on the "Payment Page" of the order. The download link should only be on the final page (after the payment)
- [x] Please change "YOUR ORDER HAS BEEN PLACED SUCCESSFULLY. YOU CAN PAY FOR YOUR ORDER TO GET TICKETS." -> "YOUR ORDER HAS BEEN PLACED. PLEASE PAY FOR YOUR TICKETS TO COMPLETE THE ORDER NOW."
- [x] The billing information has the same ticket icon as other areas. Please find a suitable icon e.g. for address.


#### Screenshot:
![image](https://user-images.githubusercontent.com/61561415/104860488-ef7b7280-5951-11eb-90e0-449fac50d460.png)
---
![image](https://user-images.githubusercontent.com/61561415/104860684-69136080-5952-11eb-84ff-4b3a6ede6992.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
