### PR TITLE
fix: Revert preselecting same as buyer

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -25,16 +25,10 @@ export default Component.extend(FormMixin, {
   buyerHasFirstName : readOnly('data.user.firstName'),
   buyerHasLastName  : readOnly('data.user.lastName'),
   holders           : computed('data.attendees', 'buyer', function() {
-    this.data.attendees.forEach((attendee, index) => {
-      if (index === 0) {
-        attendee.set('firstname', this.buyerFirstName);
-        attendee.set('lastname', this.buyerLastName);
-        attendee.set('email', this.buyer.get('email'));
-      } else {
-        attendee.set('firstname', '');
-        attendee.set('lastname', '');
-        attendee.set('email', '');
-      }
+    this.data.attendees.forEach(attendee => {
+      attendee.set('firstname', '');
+      attendee.set('lastname', '');
+      attendee.set('email', '');
     });
     return this.data.attendees;
   }),
@@ -45,7 +39,7 @@ export default Component.extend(FormMixin, {
     }
     return true;
   }),
-  sameAsBuyer: true,
+  sameAsBuyer: false,
 
   isBillingInfoNeeded: computed('event', 'data.isBillingEnabled', function() {
     return this.event.isBillingInfoMandatory || this.data.isBillingEnabled;


### PR DESCRIPTION
Fixes #7634
Reverts #5851 

The logic of when to preselect same as buyer is not that straightforward and prevents successful submission of order form