### PR TITLE
feat: added url box on public event pages

### DIFF
--- a/app/styles/components/all.scss
+++ b/app/styles/components/all.scss
@@ -11,3 +11,4 @@
 @import 'stream';
 @import 'extras';
 @import 'company-info';
+@import 'events/view/overview/general-info';

--- a/app/styles/components/events/view/overview/general-info.scss
+++ b/app/styles/components/events/view/overview/general-info.scss
@@ -1,0 +1,18 @@
+.public-url {
+  align-items: baseline;
+
+  &--text {
+    margin-right: 5px !important;
+    margin-bottom: 6px !important;
+    padding-left: .5em !important;
+  }
+
+  &--box {
+    flex-grow: 1;
+    margin-left: 5px !important;
+
+    @media screen and (max-width: 395px) {
+      width: 99%;
+    }
+  }
+}

--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -1,17 +1,28 @@
 <div class="content">
   <div class="header">{{t 'Overview'}}</div>
 </div>
-<div class="content">
-  <div class="ui {{if this.device.isMobile 'small' 'medium'}} header">
-    {{#if (eq this.data.event.state 'published')}}
-      {{t 'Your event is live at'}} <a href="{{this.data.event.url}}" rel="noopener noreferrer">{{this.data.event.url}}</a>
-    {{else}}
-      {{t 'Your event is not live yet. Make it live now'}}
-    {{/if}}
+
+{{#if (eq this.data.event.state 'published')}}
+  <div class="content" style="padding: .5em .5em;">
+    <div class="public-url d-flex wrap">
+      <div class="public-url--text ui {{if this.device.isMobile 'small' 'medium'}} header">
+        {{t 'Your event is live at'}}
+      </div>
+      <div class="public-url--box">
+        <UrlBox @url={{this.data.event.url}} />
+      </div>
+    </div>
   </div>
-</div>
+  {{else}}
+  <div class="content">
+    <div class="ui {{if this.device.isMobile 'small' 'medium'}} header">
+      {{t 'Your event is not live yet. Make it live now'}}
+    </div>
+  </div>
+{{/if}}
+
 <div class="content">
-  <table class="ui very basic table">
+  <table class="ui very basic table compact unstackable">
     <tbody>
       <tr>
         <td><strong>{{t 'Location'}}</strong></td>
@@ -51,3 +62,5 @@
   </table>
 </div>
 <Modals::EventRevision @isOpen={{this.isEventRevisionModalOpen}} />
+
+{{!-- @extraStyles="color:#4183C4;font-weight:bold;{{if this.device.isMobile 'font-size:small;' 'font-size:medium;'}}" --}}

--- a/app/templates/components/events/view/overview/general-info.hbs
+++ b/app/templates/components/events/view/overview/general-info.hbs
@@ -62,5 +62,3 @@
   </table>
 </div>
 <Modals::EventRevision @isOpen={{this.isEventRevisionModalOpen}} />
-
-{{!-- @extraStyles="color:#4183C4;font-weight:bold;{{if this.device.isMobile 'font-size:small;' 'font-size:medium;'}}" --}}


### PR DESCRIPTION
Fixes #6331 

#### Short description of what this resolves:

This PR adds url box over public url's

If the event is not live
![Screenshot_2021-01-21 bro code Events Open Event(2)](https://user-images.githubusercontent.com/65965202/105333792-22489380-5bfc-11eb-8608-e9d8bbe3f1ac.png)

it the event is live , also check the height remains same as previous
![Screenshot_2021-01-21 bro code Events Open Event](https://user-images.githubusercontent.com/65965202/105333870-3ab8ae00-5bfc-11eb-8725-2afa1fcf2c2e.png)

on smaller screens
![Screenshot_2021-01-21 bro code Events Open Event(1)](https://user-images.githubusercontent.com/65965202/105333898-41472580-5bfc-11eb-83a0-077ea9468834.png)

@iamareebjamal  @mariobehling I have also tested this feature with multiple languages and it is working just fine, you can test it out , thanks

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
