### PR TITLE
fix: error in regex for instagram profile url

### DIFF
--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -72,7 +72,7 @@ export const validGithubProfileUrlPattern = new RegExp(
 
 export const validInstagramProfileUrlPattern = new RegExp(
   '^(https?:\\/\\/)' // compulsory protocol
-  + '?(?:www.)?(instagram|instagr.am)\\.com\\/([a-zA-Z0-9_.]+)$'
+  + '?(?:www.)?(instagram.com|instagr.am)\/([a-zA-Z0-9_.]+)$'
 );
 
 export const validLinkedinProfileUrlPattern = new RegExp(


### PR DESCRIPTION
I suggested these changes on PR #6414  after it got merged.

Fixes PR #6414

#### Short description of what this resolves:

the regex was also passing this url but it is not correct
https://instagr.am.com/username 

![Screenshot_2021-01-20 instagram profile - Regex Tester Debugger(3)](https://user-images.githubusercontent.com/65965202/105339444-ae5db980-5c02-11eb-8cd1-e69e0aa9091a.png)

After the changes everything will work fine

![Screenshot_2021-01-20 instagram profile - Regex Tester Debugger(1)](https://user-images.githubusercontent.com/65965202/105339440-ad2c8c80-5c02-11eb-8db4-908eb13c355f.png)

#### Changes proposed in this pull request:

![Screenshot_2021-01-21 New Order - 81865ced-77dd-40e8-b71f-df2ab225f803 Orders eventyay](https://user-images.githubusercontent.com/65965202/105340941-88391900-5c04-11eb-8807-336c23dca5a0.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
