### PR TITLE
feat: Add Contact organizer feature

### DIFF
--- a/app/components/modals/contact-organizer.js
+++ b/app/components/modals/contact-organizer.js
@@ -1,0 +1,32 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import ModalBase from 'open-event-frontend/components/modals/modal-base';
+
+@classic
+export default class EditUserModal extends ModalBase {
+  @tracked message = '';
+  @tracked isLoading = false;
+
+  @action
+  async contactOrganizer() {
+    this.set('isLoading', true);
+    const payload = {};
+    payload.email = this.message;
+    try {
+      const response = await this.loader.post(`/events/${this.event.id}/contact-organizer`, payload);
+      if (!response?.success) {throw response}
+      this.notify.success(this.l10n.t('Organizer contacted successfully'), {
+        id: 'conatct_organizer_succ'
+      });
+      this.close();
+    } catch (e) {
+      console.error('Error while contacting organizer', e);
+      this.notify.error(this.l10n.t('An unexpected error has occurred.'), {
+        id: 'contact_organizer_err'
+      });
+    } finally {
+      this.set('isLoading', false);
+    }
+  }
+}

--- a/app/components/modals/contact-organizer.js
+++ b/app/components/modals/contact-organizer.js
@@ -1,32 +1,50 @@
-import classic from 'ember-classic-decorator';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import ModalBase from 'open-event-frontend/components/modals/modal-base';
+import FormMixin from 'open-event-frontend/mixins/form';
 
-@classic
-export default class EditUserModal extends ModalBase {
-  @tracked message = '';
-  @tracked isLoading = false;
+export default ModalBase.extend(FormMixin, {
+  message: '',
+  getValidationRules() {
+    return {
+      inline : true,
+      delay  : false,
+      on     : 'blur',
+      fields : {
+        identification: {
+          identifier : 'message',
+          rules      : [
+            {
+              type   : 'empty',
+              prompt : this.l10n.t('Please enter message')
+            }
+          ]
+        }
+      }
+    };
+  },
 
-  @action
-  async contactOrganizer() {
-    this.set('isLoading', true);
-    const payload = {};
-    payload.email = this.message;
-    try {
-      const response = await this.loader.post(`/events/${this.event.id}/contact-organizer`, payload);
-      if (!response?.success) {throw response}
-      this.notify.success(this.l10n.t('Organizer contacted successfully'), {
-        id: 'contact_organizer_succ'
+  actions: {
+    contactOrganizer() {
+      this.onValid(async() => {
+        const payload = {};
+        payload.email = this.message;
+        try {
+          const response = await this.loader.post(`/events/${this.event.id}/contact-organizer`, payload);
+          if (!response?.success) {throw response}
+          this.notify.success(this.l10n.t('Organizer contacted successfully'), {
+            id: 'contact_organizer_succ'
+          });
+          this.close();
+        } catch (e) {
+          console.error('Error while contacting organizer', e);
+          this.notify.error(this.l10n.t('An unexpected error has occurred.'), {
+            id: 'contact_organizer_err'
+          });
+        }
       });
-      this.close();
-    } catch (e) {
-      console.error('Error while contacting organizer', e);
-      this.notify.error(this.l10n.t('An unexpected error has occurred.'), {
-        id: 'contact_organizer_err'
-      });
-    } finally {
-      this.set('isLoading', false);
+    },
+    close() {
+      this.set('isOpen', false);
+      this.set('message', '');
     }
   }
-}
+});

--- a/app/components/modals/contact-organizer.js
+++ b/app/components/modals/contact-organizer.js
@@ -1,8 +1,15 @@
 import ModalBase from 'open-event-frontend/components/modals/modal-base';
+import { computed } from '@ember/object';
 import FormMixin from 'open-event-frontend/mixins/form';
 
 export default ModalBase.extend(FormMixin, {
-  message: '',
+  message  : '',
+  mailSent : false,
+
+  from: computed('currentUser', function() {
+    return this.currentUser.fullName + ' <' + this.currentUser.email + '>';
+  }),
+
   getValidationRules() {
     return {
       inline : true,
@@ -33,7 +40,7 @@ export default ModalBase.extend(FormMixin, {
           this.notify.success(this.l10n.t('Organizer contacted successfully'), {
             id: 'contact_organizer_succ'
           });
-          this.close();
+          this.set('mailSent', true);
         } catch (e) {
           console.error('Error while contacting organizer', e);
           this.notify.error(this.l10n.t('An unexpected error has occurred.'), {
@@ -45,6 +52,7 @@ export default ModalBase.extend(FormMixin, {
     close() {
       this.set('isOpen', false);
       this.set('message', '');
+      this.set('mailSent', false);
     }
   }
 });

--- a/app/components/modals/contact-organizer.js
+++ b/app/components/modals/contact-organizer.js
@@ -6,8 +6,8 @@ export default ModalBase.extend(FormMixin, {
   message  : '',
   mailSent : false,
 
-  from: computed('currentUser', function() {
-    return this.currentUser.fullName + ' <' + this.currentUser.email + '>';
+  from: computed('authManager.currentUser', function() {
+    return this.authManager.currentUser.fullName + ' <' + this.authManager.currentUser.email + '>';
   }),
 
   getValidationRules() {

--- a/app/components/modals/contact-organizer.js
+++ b/app/components/modals/contact-organizer.js
@@ -17,7 +17,7 @@ export default class EditUserModal extends ModalBase {
       const response = await this.loader.post(`/events/${this.event.id}/contact-organizer`, payload);
       if (!response?.success) {throw response}
       this.notify.success(this.l10n.t('Organizer contacted successfully'), {
-        id: 'conatct_organizer_succ'
+        id: 'contact_organizer_succ'
       });
       this.close();
     } catch (e) {

--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -119,16 +119,7 @@ export default class IndexController extends Controller {
 
   @action
   openContactOrganizerModal() {
-    if (!this.session.isAuthenticated) {
-      this.flashMessages.add({
-        message           : 'In order to buy tickets you need to login. If you have not registered yet, please create an account first. Thank you!',
-        type              : 'info',
-        preventDuplicates : true
-      });
-      this.set('isLoginModalOpen', true);
-    } else {
-      this.set('isContactOrganizerModalOpen', true);
-    }
+    this.set('isContactOrganizerModalOpen', true);
   }
 
   @action

--- a/app/controllers/public/index.js
+++ b/app/controllers/public/index.js
@@ -8,6 +8,7 @@ export default class IndexController extends Controller {
   queryParams = ['code'];
   code = null;
   isLoginModalOpen = false;
+  isContactOrganizerModalOpen = false;
   userExists = false;
 
   @computed('model.event.description')
@@ -114,6 +115,20 @@ export default class IndexController extends Controller {
       return;
     }
     this.send('save');
+  }
+
+  @action
+  openContactOrganizerModal() {
+    if (!this.session.isAuthenticated) {
+      this.flashMessages.add({
+        message           : 'In order to buy tickets you need to login. If you have not registered yet, please create an account first. Thank you!',
+        type              : 'info',
+        preventDuplicates : true
+      });
+      this.set('isLoginModalOpen', true);
+    } else {
+      this.set('isContactOrganizerModalOpen', true);
+    }
   }
 
   @action

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -3,18 +3,45 @@
     {{t 'Contact the Organizer'}}
 </div>
 <div class="ui content">
-    <div class="ui form">
-        <div class="field">
-            <label  for="message">{{t 'Message'}}</label>
-            <Textarea @type="text" @name="message" @value={{this.message}} />
-        </div>
-        <button class="ui positive right labeled icon submit right floated button" {{action 'contactOrganizer'}}>
-            {{t 'Contact'}}
-            <i class="checkmark icon"></i>
-        </button>
+    {{#if this.mailSent}}
+        <h4>
+            {{t 'Your message was sent to the organizers of this event.'}}
+            {{t ' You should receive a copy of the message to your email inbox.'}}
+            {{t ' The organizers will contact you by email.'}}
+        </h4>
         <button class="ui red deny right floated button" {{action 'close'}}>
             {{t 'Close'}}
         </button>
-    </div>
+    {{else}}
+        <div class="ui form">
+            <div class="field">
+                <label>{{t 'From'}}</label>
+                <Input
+                    type="text"
+                    name="from"
+                    value={{this.from}}
+                    disabled />
+            </div>
+            <div class="field">
+                <label>{{t 'To'}}</label>
+                <Input
+                    type="text"
+                    name="cc"
+                    value={{t 'Event Organizer'}}
+                    disabled />
+            </div>   
+            <div class="field">
+                <label  for="message">{{t 'Message'}}</label>
+                <Textarea @type="text" @name="message" @value={{this.message}} />
+            </div>
+            <button class="ui positive right labeled icon submit right floated button" {{action 'contactOrganizer'}}>
+                {{t 'Send Email'}}
+                <i class="checkmark icon"></i>
+            </button>
+            <button class="ui red deny right floated button" {{action 'close'}}>
+                {{t 'Cancel'}}
+            </button>
+        </div>
+    {{/if}}
 </div>
 <div class="ui hidden divider"></div>

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -2,22 +2,19 @@
 <div class="header">
     {{t 'Contact the Organizer'}}
 </div>
-<div class="ui basic {{if this.isLoading 'loading'}} segment">
-    <div class="ui content">
-        <div class="ui form">
-            <h4 class="ui header">{{t 'Message'}}</h4>
-            <div class="field">
-                <Textarea @value={{this.message}} />
-            </div>
+<div class="ui content">
+    <div class="ui form">
+        <div class="field">
+            <label  for="message">{{t 'Message'}}</label>
+            <Textarea @type="text" @name="message" @value={{this.message}} />
         </div>
+        <div class="ui red deny right floated button" {{action 'close'}}>
+            {{t 'Close'}}
+        </div>
+        <button class="ui positive right labeled icon submit right floated button" {{action 'contactOrganizer'}}>
+            {{t 'Contact'}}
+            <i class="checkmark icon"></i>
+        </button>
     </div>
 </div>
-<div class="actions">
-    <div class="ui red deny button">
-        {{t 'Close'}}
-    </div>
-    <button class="ui positive right labeled icon button" {{action 'contactOrganizer'}}>
-        {{t 'Contact'}}
-        <i class="checkmark icon"></i>
-    </button>
-</div>
+<div class="ui hidden divider"></div>

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -8,12 +8,12 @@
             <label  for="message">{{t 'Message'}}</label>
             <Textarea @type="text" @name="message" @value={{this.message}} />
         </div>
-        <div class="ui red deny right floated button" {{action 'close'}}>
-            {{t 'Close'}}
-        </div>
         <button class="ui positive right labeled icon submit right floated button" {{action 'contactOrganizer'}}>
             {{t 'Contact'}}
             <i class="checkmark icon"></i>
+        </button>
+        <button class="ui red deny right floated button" {{action 'close'}}>
+            {{t 'Close'}}
         </button>
     </div>
 </div>

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -16,8 +16,8 @@
     <div class="ui red deny button">
         {{t 'Close'}}
     </div>
-    <div class="ui positive right labeled icon button" {{action 'contactOrganizer'}}>
+    <button class="ui positive right labeled icon button" {{action 'contactOrganizer'}}>
         {{t 'Contact'}}
         <i class="checkmark icon"></i>
-    </div>
+    </button>
 </div>

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -14,7 +14,7 @@
 </div>
 <div class="actions">
     <div class="ui red deny button">
-        {{t 'close'}}
+        {{t 'Close'}}
     </div>
     <div class="ui positive right labeled icon button" {{action 'contactOrganizer'}}>
         {{t 'Contact'}}

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -1,0 +1,23 @@
+<i class="black close icon"></i>
+<div class="header">
+    {{t 'Contact the Organizer'}}
+</div>
+<div class="ui basic {{if this.isLoading 'loading'}} segment">
+    <div class="ui content">
+        <div class="ui form">
+            <h4 class="ui header">{{t 'Message'}}</h4>
+            <div class="field">
+                <Textarea @value={{this.message}} />
+            </div>
+        </div>
+    </div>
+</div>
+<div class="actions">
+    <div class="ui red deny button">
+        {{t 'close'}}
+    </div>
+    <div class="ui positive right labeled icon button" {{action 'contactOrganizer'}}>
+        {{t 'Contact'}}
+        <i class="checkmark icon"></i>
+    </div>
+</div>

--- a/app/templates/components/modals/contact-organizer.hbs
+++ b/app/templates/components/modals/contact-organizer.hbs
@@ -5,9 +5,9 @@
 <div class="ui content">
     {{#if this.mailSent}}
         <h4>
-            {{t 'Your message was sent to the organizers of this event.'}}
-            {{t ' You should receive a copy of the message to your email inbox.'}}
-            {{t ' The organizers will contact you by email.'}}
+            {{t 'Your message was sent to the organizers of this event.'}} 
+            {{t 'You should receive a copy of the message to your email inbox.'}} 
+            {{t 'The organizers will contact you by email.'}}
         </h4>
         <button class="ui red deny right floated button" {{action 'close'}}>
             {{t 'Close'}}

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -213,13 +213,13 @@
     </div>
     <div class="column sixteen wide right floated">
       {{#if this.event.refundPolicy}}
-        <UiPopup @html={{this.event.refundPolicy}} @class="ui mini labeled teal icon right floated button ">
+        <UiPopup @html={{this.event.refundPolicy}} @class="ui mini labeled teal icon right floated button">
           <i class="info icon"></i>
           {{t 'Refund Policy'}}
         </UiPopup>
       {{/if}}
       {{#if (and this.session.isAuthenticated this.authManager.currentUser.isVerified)}}
-        <div style="padding-right: 10rem !important;">
+        <div>
           <button class="ui mini labeled blue icon right floated button" {{action (mut this.isContactOrganizerModalOpen) true}} >
             <i class="envelope icon"></i>
             {{t 'Contact Organizer'}}
@@ -240,4 +240,5 @@
 
 <Modals::ContactOrganizer
   @event={{this.event}}
-  @isOpen={{this.isContactOrganizerModalOpen}} />
+  @isOpen={{this.isContactOrganizerModalOpen}}
+  @currentUser={{this.authManager.currentUser}} />

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -209,20 +209,23 @@
         <button id="total" class="ui primary small button no right margin" disabled={{this.shouldDisableOrderButton}} {{action this.placeOrder this.orderAmountInput}}>
           {{t 'Order Now'}}
         </button>
-        <div class="ui hidden divider"></div>
-        {{#if this.event.refundPolicy}}
-          <UiPopup @html={{this.event.refundPolicy}} @class="ui mini labeled teal icon button" @position="right center">
-            <i class="info icon"></i>
-            {{t 'Refund Policy'}}
-          </UiPopup>
-        {{/if}}
       </div>
     </div>
     <div class="column sixteen wide right floated">
-      <button class="ui mini labeled blue icon right floated button" {{action this.openContactOrganizerModal}}>
-        <i class="envelope icon"></i>
-        {{t 'Contact Organizer'}}
-      </button>
+      {{#if this.event.refundPolicy}}
+        <UiPopup @html={{this.event.refundPolicy}} @class="ui mini labeled teal icon right floated button ">
+          <i class="info icon"></i>
+          {{t 'Refund Policy'}}
+        </UiPopup>
+      {{/if}}
+      {{#if (and this.session.isAuthenticated this.authManager.currentUser.isVerified)}}
+        <div style="padding-right: 10rem !important;">
+          <button class="ui mini labeled blue icon right floated button" {{action (mut this.isContactOrganizerModalOpen) true}} >
+            <i class="envelope icon"></i>
+            {{t 'Contact Organizer'}}
+          </button>
+        </div>
+      {{/if}}
     </div>
   </div>
 </form>

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -218,6 +218,12 @@
         {{/if}}
       </div>
     </div>
+    <div class="column sixteen wide right floated">
+      <button class="ui mini labeled blue icon right floated button" {{action this.openContactOrganizerModal}}>
+        <i class="envelope icon"></i>
+        {{t 'Contact Organizer'}}
+      </button>
+    </div>
   </div>
 </form>
 
@@ -228,4 +234,7 @@
   @loginExistingUser={{this.loginExistingUser}}
   @userExists={{this.userExists}}
   @errorMessage={{this.errorMessage}} />
-  
+
+<Modals::ContactOrganizer
+  @event={{this.event}}
+  @isOpen={{this.isContactOrganizerModalOpen}} />

--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -238,7 +238,9 @@
   @userExists={{this.userExists}}
   @errorMessage={{this.errorMessage}} />
 
-<Modals::ContactOrganizer
-  @event={{this.event}}
-  @isOpen={{this.isContactOrganizerModalOpen}}
-  @currentUser={{this.authManager.currentUser}} />
+{{#if (and this.session.isAuthenticated this.authManager.currentUser.isVerified)}}
+  <Modals::ContactOrganizer
+    @event={{this.event}}
+    @isOpen={{this.isContactOrganizerModalOpen}} />
+{{/if}}
+

--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -24,7 +24,9 @@
             @currentEventIdentifier={{this.model.event.identifier}}
             @createNewUserViaEmail={{action "createNewUserViaEmail"}}
             @loginExistingUser={{action "loginExistingUser"}}
+            @openContactOrganizerModal={{action "openContactOrganizerModal"}}
             @isLoginModalOpen={{this.isLoginModalOpen}}
+            @isContactOrganizerModalOpen={{this.isContactOrganizerModalOpen}}
             @placeOrder={{action "placeOrder"}}
             @isLoading={{this.isLoading}}
             @userExists={{this.userExists}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5811 

#### Short description of what this resolves:


**What functions do we need for the implementation**
- [x] Add a **button “Contact Organizers”** next to “Refund button” below ticketing on any event page, e.g. https://eventyay.com/e/3dbaaa50 (the contact button should only be viewable by logged in users)
- [x] Provide a **contact form** as a pop up following the design of the system.
- [x] **Send an email** 
  - [x] to the **owner** and all **organizers** of the event 
     - [x] show all emails in “To” field, so the organizers can see who received the email
     - [x] define user (sender) email as a reply, so a response does not go to the eventyay email
  - [x] Show **“{name of user} via eventyay”** as the the sender (do not show the emails of the organizers in email header), use “no-reply” address and start email as follows: “Hello, you have contacted the organisers of the event {event name}. Below you find a copy of your email. Organisers have received your message and will follow up with you. This is a system message. Please do not reply to this message. Replies are not monitored. Thank you.”
- [x] Send a **copy of the email to the sender**. Above the copy add the message "This is a copy of your message to the organizers of {event name}. Show eventyay as the sender.
- [ ] **After sending show a message to the sender** “Your message was sent to the organizers of this event. You should receive a copy of the message to your email inbox. The organizers will contact you by email.”