### PR TITLE
fix: Sort events by descending in admin

### DIFF
--- a/app/controllers/admin/events/list.js
+++ b/app/controllers/admin/events/list.js
@@ -7,8 +7,6 @@ import EmberTableControllerMixin from 'open-event-frontend/mixins/ember-table-co
 export default class extends Controller.extend(EmberTableControllerMixin) {
   sort_by = 'starts-at';
 
-  sort_dir = 'DSC';
-
    @or('authManager.currentUser.isSuperAdmin', 'authManager.currentUser.isAdmin') hasRestorePrivileges;
 
    get columns() {


### PR DESCRIPTION
Fixes #6306 