### PR TITLE
fix: Error on submitting order form while consent options are ticked

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -29,6 +29,9 @@ export default Component.extend(FormMixin, {
       attendee.set('firstname', '');
       attendee.set('lastname', '');
       attendee.set('email', '');
+      attendee.set('acceptVideoRecording', true);
+      attendee.set('acceptShareDetails', true);
+      attendee.set('acceptReceiveEmails', true);
     });
     return this.data.attendees;
   }),

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -142,19 +142,19 @@
                  {{else if (eq field.fieldIdentifier 'acceptReceiveEmails')}}              
                   <UiCheckbox
                     @label={{t "We would like to share information with you after the event by email for example through personal emails by our team, newsletters or other electronic communications. You can drop out of this agreement at any time. Do you agree to receive electronic mail?"}}
-                    @checked={{true}}         
+                    @checked={{holder.acceptReceiveEmails}}         
                     @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}}       
                     @onChange={{action (mut holder.acceptReceiveEmails)}}/> 
                  {{else if (eq field.fieldIdentifier 'acceptShareDetails')}}              
                   <UiCheckbox
                     @label={{t "We would like to share information among event partners to provide you with the best possible experience and enable partners to contact you with additional information after the event through electronic communications. You can drop out of this agreement at any time. Do you agree to share your information with event partners and receive electronic mail?"}}
-                    @checked={{true}}         
+                    @checked={{holder.acceptShareDetails}}         
                     @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}}       
                     @onChange={{action (mut holder.acceptShareDetails)}}/> 
                  {{else if (eq field.fieldIdentifier 'acceptVideoRecording')}}              
                   <UiCheckbox
                     @label={{t "I agree that the event organizer is allowed to take photo, video and/or audio recordings of me or my profile and also texts created by me in the chats which might be published on the event organizer's websites and/or social media channels."}}
-                    @checked={{true}}         
+                    @checked={{holder.acceptVideoRecording}}         
                     @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}}       
                     @onChange={{action (mut holder.acceptVideoRecording)}}/> 
                 {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Follow up for : #6435 

#### Short description of what this resolves:
Currently order is not processed in the first go due to the consent fields having a value false even while they are ticked.
The bug was generated in the above mentioned PR
![Screenshot from 2021-01-24 01-18-51](https://user-images.githubusercontent.com/61330148/105612514-b5432280-5de2-11eb-884e-4c0a38a98e2f.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
