### PR TITLE
fix: Removed embed meeting option from toolbar

### DIFF
--- a/app/components/public/stream/jitsi-stream.ts
+++ b/app/components/public/stream/jitsi-stream.ts
@@ -24,7 +24,7 @@ export default class PublicStreamJitsiStream extends Component<Args> {
     const channel = await stream.videoChannel;
 
     const defaultToolbarButtons = [
-      'microphone', 'camera', 'closedcaptions', 'desktop', 'embedmeeting', 'fullscreen',
+      'microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',
       'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
       'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
       'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
@@ -53,7 +53,7 @@ export default class PublicStreamJitsiStream extends Component<Args> {
       },
       interfaceConfigOverwrite: {
         HIDE_INVITE_MORE_HEADER : true,
-        TOOLBAR_BUTTONS         : defaultToolbarButtons.filter(el => el !== 'embedmeeting')
+        TOOLBAR_BUTTONS         : defaultToolbarButtons
       }
     };
     const api = new window.JitsiMeetExternalAPI(domain, options);

--- a/app/components/public/stream/jitsi-stream.ts
+++ b/app/components/public/stream/jitsi-stream.ts
@@ -23,6 +23,14 @@ export default class PublicStreamJitsiStream extends Component<Args> {
     const stream = this.args.videoStream;
     const channel = await stream.videoChannel;
 
+    const defaultToolbarButtons = [
+      'microphone', 'camera', 'closedcaptions', 'desktop', 'embedmeeting', 'fullscreen',
+      'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
+      'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
+      'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
+      'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone', 'security'
+    ];
+
     const root = document.getElementById('jitsi-root');
 
     root!.innerHTML = '';  // eslint-disable-line @typescript-eslint/no-non-null-assertion
@@ -45,13 +53,7 @@ export default class PublicStreamJitsiStream extends Component<Args> {
       },
       interfaceConfigOverwrite: {
         HIDE_INVITE_MORE_HEADER : true,
-        TOOLBAR_BUTTONS         : [
-          'microphone', 'camera', 'closedcaptions', 'desktop', 'security', 'fullscreen',
-          'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
-          'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
-          'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
-          'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone'
-        ]
+        TOOLBAR_BUTTONS         : defaultToolbarButtons.filter(el => el !== 'embedmeeting')
       }
     };
     const api = new window.JitsiMeetExternalAPI(domain, options);

--- a/app/components/public/stream/jitsi-stream.ts
+++ b/app/components/public/stream/jitsi-stream.ts
@@ -44,7 +44,14 @@ export default class PublicStreamJitsiStream extends Component<Args> {
         startWithVideoMuted : true
       },
       interfaceConfigOverwrite: {
-        HIDE_INVITE_MORE_HEADER: true
+        HIDE_INVITE_MORE_HEADER: true,
+        TOOLBAR_BUTTONS: [
+          'microphone', 'camera', 'closedcaptions', 'desktop', 'security', 'fullscreen',
+          'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
+          'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
+          'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
+          'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone'
+        ]
       }
     };
     const api = new window.JitsiMeetExternalAPI(domain, options);

--- a/app/components/public/stream/jitsi-stream.ts
+++ b/app/components/public/stream/jitsi-stream.ts
@@ -44,8 +44,8 @@ export default class PublicStreamJitsiStream extends Component<Args> {
         startWithVideoMuted : true
       },
       interfaceConfigOverwrite: {
-        HIDE_INVITE_MORE_HEADER: true,
-        TOOLBAR_BUTTONS: [
+        HIDE_INVITE_MORE_HEADER : true,
+        TOOLBAR_BUTTONS         : [
           'microphone', 'camera', 'closedcaptions', 'desktop', 'security', 'fullscreen',
           'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
           'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',


### PR DESCRIPTION
Fixes #6487 

#### Short description of what this resolves:
This PR removes embed meeting option from toolbar from the jitsi meeting call.

we can see that option is removed now.
![Screenshot from 2021-01-27 01-06-56](https://user-images.githubusercontent.com/65965202/105896294-9f309e80-603c-11eb-8bfb-381af5c2577d.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
