### PR TITLE
fix: Display number of speakers in event overview page

### DIFF
--- a/app/templates/components/events/view/overview/speaker-session.hbs
+++ b/app/templates/components/events/view/overview/speaker-session.hbs
@@ -57,7 +57,7 @@
         <td><strong>{{t 'No. of Speakers'}}</strong></td>
         <td>
           {{#if this.data.event.isSessionsSpeakersEnabled}}
-            {{this.data.statistics.speakers}}
+            {{this.data.statistics.speakers.total}}
           {{else}}
             {{t 'Sessions and Speakers not enabled.'}}
           {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6509 

![new pr](https://user-images.githubusercontent.com/72552281/106162208-dc686e00-61ad-11eb-8017-d84af00a8fbe.png)
