### PR TITLE
 fix: made same color of status badges on the speakers as well as session pages

### DIFF
--- a/app/helpers/session-color.js
+++ b/app/helpers/session-color.js
@@ -4,11 +4,11 @@ import { stateColorMap } from 'open-event-frontend/utils/dictionary/sessions';
 export function sessionColor(params) {
   switch (params[0]) {
     case 'accepted':
-      return `${stateColorMap['accepted']}`;
+      return stateColorMap.accepted;
     case 'pending':
-      return `${stateColorMap['pending']}`;
+      return stateColorMap.pending;
     case 'confirmed':
-      return `${stateColorMap['confirmed']}`;
+      return stateColorMap.confirmed;
     default:
       return 'red';
   }

--- a/app/helpers/session-color.js
+++ b/app/helpers/session-color.js
@@ -1,13 +1,14 @@
 import Helper from '@ember/component/helper';
+import { stateColorMap } from 'open-event-frontend/utils/dictionary/sessions';
 
 export function sessionColor(params) {
   switch (params[0]) {
     case 'accepted':
-      return 'yellow';
+      return `${stateColorMap['accepted']}`;
     case 'pending':
-      return 'yellow';
+      return `${stateColorMap['pending']}`;
     case 'confirmed':
-      return 'green';
+      return `${stateColorMap['confirmed']}`;
     default:
       return 'red';
   }

--- a/app/helpers/session-color.js
+++ b/app/helpers/session-color.js
@@ -2,16 +2,7 @@ import Helper from '@ember/component/helper';
 import { stateColorMap } from 'open-event-frontend/utils/dictionary/sessions';
 
 export function sessionColor(params) {
-  switch (params[0]) {
-    case 'accepted':
-      return stateColorMap.accepted;
-    case 'pending':
-      return stateColorMap.pending;
-    case 'confirmed':
-      return stateColorMap.confirmed;
-    default:
-      return 'red';
-  }
+  return stateColorMap[`${params[0]}`];
 }
 
 export default Helper.helper(sessionColor);

--- a/app/helpers/session-color.js
+++ b/app/helpers/session-color.js
@@ -2,7 +2,7 @@ import Helper from '@ember/component/helper';
 import { stateColorMap } from 'open-event-frontend/utils/dictionary/sessions';
 
 export function sessionColor(params) {
-  return stateColorMap[`${params[0]}`];
+  return stateColorMap[params[0]];
 }
 
 export default Helper.helper(sessionColor);

--- a/tests/integration/helpers/session-color-test.js
+++ b/tests/integration/helpers/session-color-test.js
@@ -13,7 +13,7 @@ module('Integration | Helper | session-color', function(hooks) {
 
     this.set('inputState', 'accepted');
     await render(hbs`{{session-color inputState}}`);
-    assert.equal(this.element.textContent.trim(), 'yellow');
+    assert.equal(this.element.textContent.trim(), 'teal');
 
     this.set('inputState', 'pending');
     await render(hbs`{{session-color inputState}}`);


### PR DESCRIPTION
Fixes #6521 

#### Short description of what this resolves:
Previously the status badges colors were not matching , but now it is resolved.

#### Changes proposed in this pull request:
I used same source of colors which is stateColorMap for speakers page also, so that if one changes , the other will automatically gets changed.

On speaker page

![Screenshot_2021-02-01 All Speakers brom bones Events Open Event](https://user-images.githubusercontent.com/65965202/106425709-50469700-648a-11eb-92e5-00df9d985b4d.png)

On sessions page

![Screenshot_2021-02-01 Session Sessions brom bones Events Open Event](https://user-images.githubusercontent.com/65965202/106425717-52105a80-648a-11eb-9a62-b1ebe42a21eb.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
