### PR TITLE
fix: adding Without session filter to speaker

### DIFF
--- a/app/components/events/view/overview/speaker-session.js
+++ b/app/components/events/view/overview/speaker-session.js
@@ -8,11 +8,11 @@ import { computed } from '@ember/object';
 export default class SpeakerSession extends Component {
 
 	@computed('data.event.speakers.[]')
-	get noSessionSpeaker() {
-		let count = 0;
-		this.data.event.speakers.map(x => {
-		if (x.get('sessions').length === 0) {count += 1}
-		});
-		return count;
-	}
+  get noSessionSpeaker() {
+    let count = 0;
+    this.data.event.speakers.map(x => {
+      if (x.get('sessions').length === 0) {count += 1}
+    });
+    return count;
+  }
 }

--- a/app/components/events/view/overview/speaker-session.js
+++ b/app/components/events/view/overview/speaker-session.js
@@ -1,7 +1,18 @@
 import classic from 'ember-classic-decorator';
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 @classic
 @classNames('ui', 'fluid', 'card')
-export default class SpeakerSession extends Component {}
+export default class SpeakerSession extends Component {
+
+	@computed('data.event.speakers.[]')
+	get noSessionSpeaker() {
+		let count = 0;
+		this.data.event.speakers.map(x => {
+		if (x.get('sessions').length === 0) {count += 1}
+		});
+		return count;
+	}
+}

--- a/app/components/events/view/overview/speaker-session.js
+++ b/app/components/events/view/overview/speaker-session.js
@@ -1,18 +1,7 @@
 import classic from 'ember-classic-decorator';
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 
 @classic
 @classNames('ui', 'fluid', 'card')
-export default class SpeakerSession extends Component {
-
-	@computed('data.event.speakers.[]')
-  get noSessionSpeaker() {
-    let count = 0;
-    this.data.event.speakers.map(x => {
-      if (x.get('sessions').length === 0) {count += 1}
-    });
-    return count;
-  }
-}
+export default class SpeakerSession extends Component {}

--- a/app/models/event-statistics-general.js
+++ b/app/models/event-statistics-general.js
@@ -16,5 +16,6 @@ export default ModelBase.extend({
   identifier        : attr('string'),
   sessionsAccepted  : attr('number'),
   sessionsDraft     : attr('number'),
+  speakerWithoutSession: attr('number'),
   event             : belongsTo('event')
 });

--- a/app/models/event-statistics-general.js
+++ b/app/models/event-statistics-general.js
@@ -4,18 +4,18 @@ import { belongsTo } from 'ember-data/relationships';
 
 export default ModelBase.extend({
 
-  speakers          : attr(''),
-  sessions          : attr('number'),
-  sessionsPending   : attr('number'),
-  sponsors          : attr('number'),
-  sessionsSubmitted : attr('number'),
-  sessionsRejected  : attr('number'),
-  sessionsConfirmed : attr('number'),
-  sessionsWithdrawn : attr('number'),
-  sessionsCanceled  : attr('number'),
-  identifier        : attr('string'),
-  sessionsAccepted  : attr('number'),
-  sessionsDraft     : attr('number'),
-  speakerWithoutSession: attr('number'),
-  event             : belongsTo('event')
+  speakers              : attr(''),
+  sessions              : attr('number'),
+  sessionsPending       : attr('number'),
+  sponsors              : attr('number'),
+  sessionsSubmitted     : attr('number'),
+  sessionsRejected      : attr('number'),
+  sessionsConfirmed     : attr('number'),
+  sessionsWithdrawn     : attr('number'),
+  sessionsCanceled      : attr('number'),
+  identifier            : attr('string'),
+  sessionsAccepted      : attr('number'),
+  sessionsDraft         : attr('number'),
+  speakerWithoutSession : attr('number'),
+  event                 : belongsTo('event')
 });

--- a/app/routes/events/view/speakers/list.js
+++ b/app/routes/events/view/speakers/list.js
@@ -4,7 +4,7 @@ import { capitalize } from 'lodash-es';
 
 export default class extends Route.extend(EmberTableRouteMixin) {
   titleToken() {
-    if (['accepted', 'rejected', 'confirmed', 'withdrawn', 'canceled'].includes(this.params.speakers_status)) {
+    if (['accepted', 'rejected', 'confirmed', 'withdrawn', 'canceled', 'without_session'].includes(this.params.speakers_status)) {
       return this.l10n.tVar(capitalize(this.params.speakers_status));
     } else {
       return this.l10n.t('All');
@@ -26,7 +26,7 @@ export default class extends Route.extend(EmberTableRouteMixin) {
     this.set('params', params);
     const searchField = 'name';
     let filterOptions = [];
-    if (params.speakers_status && params.speakers_status !== 'all') {
+    if (params.speakers_status && params.speakers_status !== 'all' && params.speakers_status !== 'without_session') {
       filterOptions = [
         {
           name : 'sessions',
@@ -36,6 +36,14 @@ export default class extends Route.extend(EmberTableRouteMixin) {
             op   : 'eq',
             val  : params.speakers_status
           }
+        }
+      ];
+    } else if (params.speakers_status === 'without_session') {
+      filterOptions = [
+        {
+          name : 'sessions',
+          op   : 'eq',
+          val  : null
         }
       ];
     } else {

--- a/app/templates/components/events/view/overview/speaker-session.hbs
+++ b/app/templates/components/events/view/overview/speaker-session.hbs
@@ -92,6 +92,7 @@
             | {{t 'Pending'}}: {{this.data.statistics.speakers.pending}}
             | {{t 'Rejected'}}: {{this.data.statistics.speakers.rejected}}
             | {{t 'Confirmed'}}: {{this.data.statistics.speakers.confirmed}}
+            | {{t 'Without Session'}}: {{this.data.statistics.speakerWithoutSession}}
           {{else}}
             {{t 'Sessions and Speakers not enabled.'}}
           {{/if}}

--- a/app/templates/components/events/view/overview/speaker-session.hbs
+++ b/app/templates/components/events/view/overview/speaker-session.hbs
@@ -92,7 +92,6 @@
             | {{t 'Pending'}}: {{this.data.statistics.speakers.pending}}
             | {{t 'Rejected'}}: {{this.data.statistics.speakers.rejected}}
             | {{t 'Confirmed'}}: {{this.data.statistics.speakers.confirmed}}
-            | {{t 'Without Session'}}: {{this.noSessionSpeaker}}
           {{else}}
             {{t 'Sessions and Speakers not enabled.'}}
           {{/if}}

--- a/app/templates/components/events/view/overview/speaker-session.hbs
+++ b/app/templates/components/events/view/overview/speaker-session.hbs
@@ -92,6 +92,7 @@
             | {{t 'Pending'}}: {{this.data.statistics.speakers.pending}}
             | {{t 'Rejected'}}: {{this.data.statistics.speakers.rejected}}
             | {{t 'Confirmed'}}: {{this.data.statistics.speakers.confirmed}}
+            | {{t 'Without Session'}}: {{this.noSessionSpeaker}}
           {{else}}
             {{t 'Sessions and Speakers not enabled.'}}
           {{/if}}

--- a/app/templates/events/view/speakers.hbs
+++ b/app/templates/events/view/speakers.hbs
@@ -25,6 +25,9 @@
             <LinkTo @route="events.view.speakers.list" @model="canceled" class="item">
               {{t 'Canceled'}}
             </LinkTo>
+            <LinkTo @route="events.view.speakers.list" @model="without_session" class="item">
+              {{t 'Without Session'}}
+            </LinkTo>
           </TabbedNavigation>
         </div>
         <div class="{{if this.device.isTablet 'sixteen' 'four'}} wide right aligned column">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6549
- [x] Please add a filter "Without Session" in the menu of organizer speaker overview pages therefore.
- [x] Also add this filter to the dashboard session box and calculate all speakers on the dashboard including the speakers without session? 

    - about this do I need to create a attribute on server or on frontend it would be like `this.data.speakers.map(x => if x.sessions.length === 0  {count = count +1;})` (tried this it was not working as expected @iamareebjamal )


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
