### PR TITLE
Revert "chore(deps-dev): bump ember-h-captcha from 2.0.6 to 2.0.7"

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "8.0.4",
     "ember-fullcalendar": "^1.8.0",
-    "ember-h-captcha": "^2.0.7",
+    "ember-h-captcha": "^2.0.6",
     "ember-href-to": "4.1.0",
     "ember-infinity": "^2.1.2",
     "ember-l10n": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7252,14 +7252,14 @@ ember-getowner-polyfill@2.2.0, "ember-getowner-polyfill@^1.1.0 || ^2.0.0", ember
     ember-cli-version-checker "^2.1.0"
     ember-factory-for-polyfill "^1.3.1"
 
-ember-h-captcha@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/ember-h-captcha/-/ember-h-captcha-2.0.7.tgz#0fbc32c17936060038662cc48ab08afa13a7d52b"
-  integrity sha512-sAWxzybQha2cVizrFeiy5HloQ98peND3ox+eZG8QWthZxopjRZ4gebJd9Gt0hZEFL1gge6UNkR8A/s2LUXFcFA==
+ember-h-captcha@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/ember-h-captcha/-/ember-h-captcha-2.0.6.tgz#ea528f0656d1e6ceceb0f7f2e69f36fb59a3a310"
+  integrity sha512-iKjYNtK4QINiDuQUvOWxDrkFszb9J4Sw/NLDpniVLQgLKkaIGNQZoCf7sJIF6Nol3na2esFXA+SItxCFDLPOAg==
   dependencies:
     "@ember/render-modifiers" "^1.0.2"
     ember-cached-decorator-polyfill "^0.1.0"
-    ember-cli-babel "^7.23.1"
+    ember-cli-babel "^7.23.0"
     ember-cli-htmlbars "^5.3.1"
 
 ember-href-to@4.1.0:


### PR DESCRIPTION
Reverts fossasia/open-event-frontend#6622