### PR TITLE
right padding added to event side panel

### DIFF
--- a/app/styles/components/stream.scss
+++ b/app/styles/components/stream.scss
@@ -52,6 +52,7 @@
   top: 0;
   left: 0;
   padding-top: 0 !important;
+  padding-right: 35px !important;
   background-color: #555;
   color: #fff;
   overflow: hidden;


### PR DESCRIPTION
Fixes #6629 

#### Short description of what this resolves:

As padding added is a little greater than the width of a button so the content of the side panel never gets overlapped by the button. 


#### Changes proposed in this pull request:

- Right padding added to the side panel.

#### Checklist

- [✓] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [✓] My branch is up-to-date with the Upstream `development` branch.
- [✓] The acceptance, integration, unit tests, and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] I have added necessary documentation (if appropriate)
