### PR TITLE
fix: CfS: "Edit Speaker Details" button not available after CfS is closed

### DIFF
--- a/app/templates/components/public/call-for-speakers.hbs
+++ b/app/templates/components/public/call-for-speakers.hbs
@@ -44,20 +44,20 @@
     <p>{{t 'You need to login to submit and view sessions.'}}</p>
   {{/if}}
 {{/if}}
+{{#if (and this.data.speakersCall.isOpen this.isNewSpeaker)}}
+  <button class="ui teal {{if this.device.isMobile 'tiny'}} button" {{action 'addSpeaker'}}>
+    {{t 'Add Speaker Details'}}
+  </button>
+{{else}}
+  {{#each this.data.userSpeaker as |speaker|}}
+    {{#if speaker.id}}
+      <LinkTo @route="public.cfs.edit-speaker" @model={{speaker.id}}>
+        <button class="ui teal {{if this.device.isMobile 'tiny'}} button">{{t 'Edit Speaker Details'}}</button>
+      </LinkTo>
+    {{/if}}
+  {{/each}}
+{{/if}}
 {{#if this.data.speakersCall.isOpen}}
-  {{#if this.isNewSpeaker}}
-    <button class="ui teal {{if this.device.isMobile 'tiny'}} button" {{action 'addSpeaker'}}>
-      {{t 'Add Speaker Details'}}
-    </button>
-  {{else}}
-    {{#each this.data.userSpeaker as |speaker|}}
-      {{#if speaker.id}}
-        <LinkTo @route="public.cfs.edit-speaker" @model={{speaker.id}}>
-          <button class="ui teal {{if this.device.isMobile 'tiny'}} button">{{t 'Edit Speaker Details'}}</button>
-        </LinkTo>
-      {{/if}}
-    {{/each}}
-  {{/if}}
   <button class="ui teal {{if this.device.isMobile 'tiny'}} button" {{action 'addSession'}}>
     {{t 'Add New Session'}}
   </button>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6715

#### Short description of what this resolves:
 For speaker that are already in the system the button should still be available.

**Speaker not in the system**
![Screenshot from 2021-02-16 02-22-43](https://user-images.githubusercontent.com/61330148/107992038-e25bad00-6ffd-11eb-9590-97cadd6c9ec5.png)

**Speaker in the system**
![Screenshot from 2021-02-16 02-22-37](https://user-images.githubusercontent.com/61330148/107992043-e4be0700-6ffd-11eb-83ef-504b6c9a24e4.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
