### PR TITLE
fix: overlapping of minimise button of side_panel

### DIFF
--- a/app/components/public/stream/side-panel.hbs
+++ b/app/components/public/stream/side-panel.hbs
@@ -3,16 +3,19 @@
 </button>
 {{#if this.shown}}
   <div class="d-flex flex-column p-4 stream-side-panel" >
-    <button class="ui icon button stream-side-panel-button right" {{action (mut this.shown) false}}>  
-      <i class="angle left icon pr-2"></i>
-    </button>
-    
     <div class="ui header inverted mt-4">
       <a href={{href-to 'public' @event (query-params side_panel='true')}}>
         <p class="text-white">{{@event.name}}</p>
       </a>
     </div>
-    <Public::EventDateTime @event={{@event}} />
+    <div>
+      <div class="mr-4 pt-1">
+        <Public::EventDateTime @event={{@event}} />
+      </div>
+      <button class="ui icon button stream-side-panel-button right" {{action (mut this.shown) false}}>  
+        <i class="angle left icon pr-2"></i>
+      </button>
+    </div>
     
     <div class="d-flex mt-2 mb-2 w-full space-between wrap">
       {{#if (and @event.isSchedulePublished this.showSessions)}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6629 

#### Short description of what this resolves:
The minimise side panel button overlaps the date and speakers button. This PR ensure the right side of the date does not overlap.


![1](https://user-images.githubusercontent.com/72552281/109703035-05b85780-7bbb-11eb-83db-5e1150845cb0.png)
