### PR TITLE
fix: default calendar view on public page

### DIFF
--- a/app/components/schedule.hbs
+++ b/app/components/schedule.hbs
@@ -12,7 +12,7 @@
     @header={{this.header}}
     @timezone={{this.timezone}}
     @views={{this.views}}
-    @viewName="agendaDay"
+    @viewName="timelineThreeDays"
     @defaultView="timelineDay"
     @validRange={{this.validRange}}
     @now={{moment-format (now) "YYYY-MM-DD"}}

--- a/app/components/schedule.ts
+++ b/app/components/schedule.ts
@@ -136,8 +136,8 @@ export default class Schedule extends Component<ScheduleArgs> {
     } else {
       min_time = '0:00:00';
     }
-    let minTime = min_time;
-    let maxTime = '24:00:00';
+    const minTime = min_time;
+    const maxTime = '24:00:00';
 
     // To prevent infinite render loop
     if (minTime !== view.options.minTime) {

--- a/app/components/schedule.ts
+++ b/app/components/schedule.ts
@@ -124,7 +124,7 @@ export default class Schedule extends Component<ScheduleArgs> {
    * @param calendar Calendar JQuery element
    */
   adjustMinTime(view: FullCalendarView, calendar: JQuery<HTMLElement>): void {
-    if (isTesting || !(view.type === 'agendaDay' || view.type === 'timelineDay')) {return}
+    if (isTesting || !(view.type === 'agendaDay' || view.type === 'timelineDay' || view.type === 'timelineThreeDays')) {return}
     let min_time = '24:00:00';
     if (this.args.isPublic === true) {
       this.args.sessions.map(x => {
@@ -138,12 +138,6 @@ export default class Schedule extends Component<ScheduleArgs> {
     }
     let minTime = min_time;
     let maxTime = '24:00:00';
-    if (view.start.isSame(this.args.event.startsAt, 'day')) {
-      ({ minTime } = this);
-    }
-    if (view.start.isSame(this.args.event.endsAt, 'day')) {
-      ({ maxTime } = this);
-    }
 
     // To prevent infinite render loop
     if (minTime !== view.options.minTime) {

--- a/app/components/schedule.ts
+++ b/app/components/schedule.ts
@@ -124,7 +124,7 @@ export default class Schedule extends Component<ScheduleArgs> {
    * @param calendar Calendar JQuery element
    */
   adjustMinTime(view: FullCalendarView, calendar: JQuery<HTMLElement>): void {
-    if (isTesting || !(view.type === 'agendaDay' || view.type === 'timelineDay' || view.type === 'timelineThreeDays')) {return}
+    if (isTesting || !(view.type === 'timelineDay' || view.type === 'timelineThreeDays')) {return}
     let min_time = '24:00:00';
     if (this.args.isPublic === true) {
       this.args.sessions.map(x => {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes  `from the technical meeting`

- Starting time of calendar min session time
- Default - event days view instead of single day view


https://user-images.githubusercontent.com/56407566/109747608-7718fa00-7bfd-11eb-9261-d8e2f97c87d0.mp4


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
