### PR TITLE
fix: "Get in touch" heading should only show up if there is actually a button "contact" or "email"

### DIFF
--- a/app/controllers/public/exhibition/view.js
+++ b/app/controllers/public/exhibition/view.js
@@ -42,7 +42,7 @@ export default class extends Controller {
 
   @computed('model.exhibitor')
   get contactExhibitor() {
-    return this.session.isAuthenticated;
+    return this.session.isAuthenticated && (this.model.exhibitor.contactEmail || this.model.exhibitor.contactLink);
   }
 
   @action


### PR DESCRIPTION
Fixes #6946 

#### Short description of what this resolves:
![Screenshot from 2021-03-09 20-46-13](https://user-images.githubusercontent.com/61561415/110492929-8675d700-8118-11eb-90be-92ad132545e3.png)

-
-
-

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
