### PR TITLE
fix: allow editing of event video room name

### DIFF
--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -31,14 +31,9 @@
 <br>
 <form class="ui form {{if this.isLoading 'loading'}}">
   <div class="field">
-    {{#if this.microRoom}}
-      <label class="required">{{t 'Room'}}</label>
-      <input value={{this.microRoom}} readonly>
-    {{else}}
-      <label class="required">{{t 'Room'}}</label>
-      <Input
-        @value={{this.data.stream.name}} />
-    {{/if}}
+    <label class="required">{{t 'Room'}}</label>
+    <Input
+      @value={{this.data.stream.name}} />
   </div>
   {{#if (eq this.data.stream.videoChannel.provider 'bbb')}}
     <div class="field">

--- a/app/components/forms/events/view/videoroom-form.hbs
+++ b/app/components/forms/events/view/videoroom-form.hbs
@@ -31,8 +31,14 @@
 <br>
 <form class="ui form {{if this.isLoading 'loading'}}">
   <div class="field">
-    <label class="required">{{t 'Room'}}</label>
-    <input value={{this.roomName}} readonly>
+    {{#if this.microRoom}}
+      <label class="required">{{t 'Room'}}</label>
+      <input value={{this.microRoom}} readonly>
+    {{else}}
+      <label class="required">{{t 'Room'}}</label>
+      <Input
+        @value={{this.data.stream.name}} />
+    {{/if}}
   </div>
   {{#if (eq this.data.stream.videoChannel.provider 'bbb')}}
     <div class="field">

--- a/app/components/forms/events/view/videoroom-form.js
+++ b/app/components/forms/events/view/videoroom-form.js
@@ -20,11 +20,6 @@ export default class VideoroomForm extends Component.extend(FormMixin) {
     return this.data.stream.rooms.toArray()[0];
   }
 
-  @computed('data.stream')
-  get microRoom() {
-    return this.data.stream.rooms.toArray()[0]?.name;
-  }
-
   @action
   setRoom(room) {
     this.data.stream.rooms = [room];

--- a/app/components/forms/events/view/videoroom-form.js
+++ b/app/components/forms/events/view/videoroom-form.js
@@ -21,8 +21,8 @@ export default class VideoroomForm extends Component.extend(FormMixin) {
   }
 
   @computed('data.stream')
-  get roomName() {
-    return this.data.stream.rooms.toArray()[0]?.name || this.data.stream.name;
+  get microRoom() {
+    return this.data.stream.rooms.toArray()[0]?.name;
   }
 
   @action

--- a/app/controllers/events/view/videoroom/list.js
+++ b/app/controllers/events/view/videoroom/list.js
@@ -55,6 +55,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
   get eventColumns() {
     const { columns } = this;
     columns[0].name = this.l10n.t('Event');
+    columns[0].valuePath = 'videoStream.name';
     columns[0].helperInfo = null;
 
     return columns;

--- a/app/controllers/events/view/videoroom/list.js
+++ b/app/controllers/events/view/videoroom/list.js
@@ -55,7 +55,6 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
   get eventColumns() {
     const { columns } = this;
     columns[0].name = this.l10n.t('Event');
-    columns[0].valuePath = 'videoStream.name';
     columns[0].helperInfo = null;
 
     return columns;

--- a/app/controllers/events/view/videoroom/list.js
+++ b/app/controllers/events/view/videoroom/list.js
@@ -19,6 +19,12 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
         }
       },
       {
+        name       : this.l10n.t('Video Room Name'),
+        valuePath  : 'videoStream.name',
+        helperInfo : 'This column shows the video room name that will be visible to the users on the event page if the original name is changed.',
+        width      : 70
+      },
+      {
         name          : this.l10n.t('Video Source URL'),
         valuePath     : 'videoStream',
         helperInfo    : 'This column shows the original link of the video. We do not recommend to share this link as users can access it without loggin into eventyay.com.',

--- a/app/controllers/events/view/videoroom/list.js
+++ b/app/controllers/events/view/videoroom/list.js
@@ -21,7 +21,7 @@ export default class extends Controller.extend(EmberTableControllerMixin) {
       {
         name       : this.l10n.t('Video Room Name'),
         valuePath  : 'videoStream.name',
-        helperInfo : 'This column shows the video room name that will be visible to the users on the event page if the original name is changed.',
+        helperInfo : 'This column shows the video room name that will be visible to the users on the event page.',
         width      : 70
       },
       {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

as discussed in meeting

from meeting notes - Renaming event video room does not rename video room on sidepanel - Meghal


#### Short description of what this resolves:
![Screenshot from 2021-03-09 22-04-08](https://user-images.githubusercontent.com/61330148/110504713-71527580-8123-11eb-99c5-cf0636f66547.png)
![Screenshot from 2021-03-09 22-03-56](https://user-images.githubusercontent.com/61330148/110504722-73b4cf80-8123-11eb-8672-fca10d209cec.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
