### PR TITLE
fix: add hidden in scheduler for rooms

### DIFF
--- a/app/components/modals/add-room-modal.hbs
+++ b/app/components/modals/add-room-modal.hbs
@@ -15,6 +15,15 @@
       </label>
       <Input @type="text" @value={{this.room.floor}} />
     </div>
+    <div class="field">
+      <label>
+        {{t "Hidden In Scheduler"}}
+      </label>
+      <UiCheckbox
+        class="toggle"
+        @checked={{this.room.hiddenInScheduler}}
+        @onChange={{action (mut this.room.hiddenInScheduler)}} />
+    </div>     
   </form>
 </div>
 <div class="actions">

--- a/app/controllers/events/view/scheduler.js
+++ b/app/controllers/events/view/scheduler.js
@@ -11,7 +11,7 @@ export default class extends Controller {
 
   @computed('model.microlocations')
   get microlocations() {
-    return this.model.microlocations.sortBy('position');
+    return this.model.microlocations.sortBy('position').filter(x => !x.hiddenInScheduler);
   }
 
   @computed('model.unscheduled', 'filter')

--- a/app/models/microlocation.ts
+++ b/app/models/microlocation.ts
@@ -3,12 +3,12 @@ import ModelBase from 'open-event-frontend/models/base';
 import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default class Microlocation extends ModelBase.extend({
-  name      : attr('string'),
-  floor     : attr('number'),
-  latitude  : attr('number'),
-  hiddenInScheduler: attr('boolean', { defaultValue: false }),
-  longitude : attr('number'),
-  position  : attr('number', { defaultValue: 0 }),
+  name              : attr('string'),
+  floor             : attr('number'),
+  latitude          : attr('number'),
+  hiddenInScheduler : attr('boolean', { defaultValue: false }),
+  longitude         : attr('number'),
+  position          : attr('number', { defaultValue: 0 }),
 
   sessions    : hasMany('session'),
   event       : belongsTo('event'),

--- a/app/models/microlocation.ts
+++ b/app/models/microlocation.ts
@@ -6,6 +6,7 @@ export default class Microlocation extends ModelBase.extend({
   name      : attr('string'),
   floor     : attr('number'),
   latitude  : attr('number'),
+  hiddenInScheduler: attr('boolean', { defaultValue: false }),
   longitude : attr('number'),
   position  : attr('number', { defaultValue: 0 }),
 

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -76,6 +76,12 @@
               </button>
             </div>
           </div>
+          <div class="field mt-2" data-tooltip={{if microlocation.hiddenInScheduler "Hidden In Scheduler" "Hide in Scheduler"}}>
+            <UiCheckbox
+              class="toggle"
+              @checked={{microlocation.hiddenInScheduler}}
+              @onChange={{action (mut microlocation.hiddenInScheduler)}} />
+          </div>
           <div class="ui icon buttons {{if this.device.isLargeMonitor 'right floated'}}">
             {{#if (not-eq index 0)}}
               <button type="button" class="ui button" {{action "moveRoom" microlocation "up"}} data-content="Move room up">

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -96,13 +96,15 @@
                 </LinkTo>
               </h4>
               {{#each this.model.microlocations as |room|}}
-                <LinkTo
-                  class="p-1 mb-1 rounded-default link-item {{if (eq this.params.room room.name) 'active'}}"
-                  @route="public.sessions" 
-                  @models={{array this.model.id}}
-                  @query={{hash room=room.name}}>
-                  {{room.name}}
-                </LinkTo>
+                {{#if (not room.hiddenInScheduler)}}
+                  <LinkTo
+                    class="p-1 mb-1 rounded-default link-item {{if (eq this.params.room room.name) 'active'}}"
+                    @route="public.sessions" 
+                    @models={{array this.model.id}}
+                    @query={{hash room=room.name}}>
+                    {{room.name}}
+                  </LinkTo>
+                {{/if}}
               {{/each}}
               <h4>
                 {{t 'Session Types'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #As discussed in meeting -
Microlocation:
hidden_in_scheduler False
Event Wizard - Switch
Video Room - Switch
It should not show in scheduler, public page
Show all Video Stream Rooms

server pr - https://github.com/fossasia/open-event-server/pull/7813

![Screenshot from 2021-03-09 23-27-17](https://user-images.githubusercontent.com/56407566/110516005-05760a00-812f-11eb-9192-4884b3f53677.png)
![Screenshot from 2021-03-09 23-26-52](https://user-images.githubusercontent.com/56407566/110516010-07d86400-812f-11eb-99a8-738a3d0a979f.png)
![Screenshot from 2021-03-09 23-26-37](https://user-images.githubusercontent.com/56407566/110516019-09099100-812f-11eb-9b85-02c9871f862c.png)
![Screenshot from 2021-03-09 23-26-35](https://user-images.githubusercontent.com/56407566/110516024-0ad35480-812f-11eb-9040-7ede869d9839.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
