### PR TITLE
fix: schedules are showing twice when sorting by popularity

### DIFF
--- a/app/controllers/public/sessions.js
+++ b/app/controllers/public/sessions.js
@@ -34,7 +34,7 @@ export default class SessionsController extends Controller {
   get groupByDateSessions() {
     let sessions;
     if (this.sort !== 'starts-at') {
-      sessions = groupBy(this.model.session.toArray(), '');
+      sessions = groupBy([...new Set(this.model.session.toArray())], '');
     } else {
       sessions = groupBy(this.model.session.toArray(), s => moment.tz(s.startsAt, this.timezone).format('dddd, Do MMMM'));
     }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6927
before
https://github.com/fossasia/open-event-frontend/issues/6927#issuecomment-812489418
After
![Screenshot from 2021-04-02 17-11-39](https://user-images.githubusercontent.com/56407566/113412682-8cd53700-93d6-11eb-96fd-b9be5dff2193.png)
![Screenshot from 2021-04-02 17-11-33](https://user-images.githubusercontent.com/56407566/113412686-8e9efa80-93d6-11eb-8bd6-171b17834ef3.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
