### PR TITLE
fix: only allow event owners to add event to group

### DIFF
--- a/app/components/forms/group/group-form.js
+++ b/app/components/forms/group/group-form.js
@@ -40,7 +40,7 @@ export default class GroupForm extends Component.extend(FormMixin) {
 
   @computed('events.[]', 'group.events.[]')
   get remainingEvents() {
-    return this.events.toArray().filter(event => !this.group.events.toArray().includes(event));
+    return this.events.toArray().filter(event => (!this.group.events.toArray().includes(event) && event.hasAccess(this.authManager.currentUser.email)));
   }
 
   @action


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #as per discussion

-  only allow event owners to add event to group

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
