### PR TITLE
fix: Jitsi: Hide invite button

### DIFF
--- a/app/components/public/stream/jitsi-stream.ts
+++ b/app/components/public/stream/jitsi-stream.ts
@@ -27,7 +27,7 @@ export default class PublicStreamJitsiStream extends Component<Args> {
       'microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',
       'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
       'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
-      'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
+      'videoquality', 'filmstrip', 'feedback', 'stats', 'shortcuts',
       'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone', 'security'
     ];
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

as mentioned in meeting notes - 
Jitsi shows “invite button” in new version on eventyay - Meghal


#### Short description of what this resolves:
![Screenshot from 2021-04-13 04-52-02](https://user-images.githubusercontent.com/61330148/114474690-61dbb600-9c14-11eb-8005-8ed8ffc9e767.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
