### PR TITLE
fix: take out https from video source URL

### DIFF
--- a/app/components/ui-table/cell/events/view/videoroom/cell-video-url.js
+++ b/app/components/ui-table/cell/events/view/videoroom/cell-video-url.js
@@ -4,6 +4,6 @@ export default class CellVideoUrl extends Component {
 
   get link() {
     const { record } = this.args;
-    return record.get('url').replace(/^https?\:\/\//, "");
+    return record.get('url').replace(/^https?\:\/\//, '');
   }
 }

--- a/app/components/ui-table/cell/events/view/videoroom/cell-video-url.js
+++ b/app/components/ui-table/cell/events/view/videoroom/cell-video-url.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class CellVideoUrl extends Component {
+
+  get link() {
+    const { record } = this.args;
+    return record.get('url').replace(/^https?\:\/\//, "");
+  }
+}

--- a/app/templates/components/ui-table/cell/events/view/videoroom/cell-video-url.hbs
+++ b/app/templates/components/ui-table/cell/events/view/videoroom/cell-video-url.hbs
@@ -4,7 +4,7 @@
       {{t 'Auto-Generated'}}
     {{else}}
     <div class="ui input" style="width: 100%; height: 36px">
-      <input class="truncate" type="text" value={{@record.url}} placeholder={{@record.url}} readonly>
+      <input class="truncate" type="text" value={{this.link}} placeholder={{this.link}} readonly>
     </div>
     {{/if}}
   </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6190
> Clicking on the table heading, e.g. in the video source URL area results in an ember error and moves the "Additional Information" content to the "Password" column

this is an ember table issue so we can't de much about it.

- taking out https

![Screenshot from 2021-04-28 09-48-08](https://user-images.githubusercontent.com/56407566/116345977-d9aa0300-a806-11eb-95ed-1091585b3c2e.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
