### PR TITLE
Fixed the alignment of image and event card on the event search page

### DIFF
--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -9,7 +9,7 @@
       </div>
     {{/unless}}
   {{/if}}
-  <div style="height: 100%;"
+  <div style="height: auto;"
     class="ui card {{this.eventClass}}">
     {{#unless this.isWide}}
       <a class="image" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.id}}">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7156

#### Initially the event card  on the event search page was having improper alignment as the size of the image was larger than that of the card.
![image](https://user-images.githubusercontent.com/56474333/117045304-fb3a4b80-ad2c-11eb-9081-6c51341ab858.png)


#### Which has been fixed to 
![image](https://user-images.githubusercontent.com/56474333/117045437-23c24580-ad2d-11eb-8d8c-b8ea426fd6a9.png)

####Test
Test cases were run using: 
`yarn test`
`yarn test --server `

Following result was obtained and all the test cases were passed:
![image](https://user-images.githubusercontent.com/56474333/117053422-8e2bb380-ad36-11eb-8646-e38c4648693b.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
