### PR TITLE
Fixed the alignment of image and event card on the event search page

### DIFF
--- a/app/templates/components/event-card.hbs
+++ b/app/templates/components/event-card.hbs
@@ -9,7 +9,7 @@
       </div>
     {{/unless}}
   {{/if}}
-  <div style="height: 100%;"
+  <div style="height: auto;"
     class="ui card {{this.eventClass}}">
     {{#unless this.isWide}}
       <a class="image" href="{{href-to (if this.isCFS 'public.cfs' 'public') this.event.id}}">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7156 

Initially the event card on the event search page was having improper alignment as the size of the image was larger than that of the card.
![image](https://user-images.githubusercontent.com/56474333/117055030-54f44300-ad38-11eb-8eaa-90742fb20c9b.png)

#### Which has been fixed to
![image](https://user-images.githubusercontent.com/56474333/117055083-61789b80-ad38-11eb-94bf-dc77b6675509.png)

#### Changes proposed in this pull request:

- Changing the height property of the div card element from '100%' to 'auto'

#### Local Testing:
Following result was obtained and all the test cases were passed:
![image](https://user-images.githubusercontent.com/56474333/117055624-faa7b200-ad38-11eb-923b-57634cba165f.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
