### PR TITLE
fix: Show event link if event is online event in "Location Field" in calenders(other than ical)

### DIFF
--- a/app/controllers/public.js
+++ b/app/controllers/public.js
@@ -49,7 +49,7 @@ export default class PublicController extends Controller {
     if (this.model.locationName && this.model.online) {
       return this.l10n.t('Online and In-Person Event at') + ' ' + this.model.locationName;
     } else if (this.model.online) {
-      return this.l10n.t('Online Event');
+      return this.model.url;
     } else if (this.model.locationName) {
       return this.model.locationName;
     } else {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7184 

![1](https://user-images.githubusercontent.com/72552281/117130937-5ec08980-adbe-11eb-8f67-a37a972f3c0b.png)
