### PR TITLE
Added OG Image as a meta property to head tag for templates to use.

### DIFF
--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -5,10 +5,20 @@
 {{else}}
   <meta name="description" content="The front end for the Open Event Server where event organisers can create and manage their event.">
 {{/if}}
+{{#if this.model.openGraphImage}}
+  <meta name="image" content={{this.model.openGraphImage}}>
+{{else}}
+  <meta name="image" content="https://eventyay.com/favicon.ico">
+{{/if}}
 
 <meta property="og:title" content={{this.model.title}}>
 {{#if this.model.description}}
   <meta property="og:description" content={{this.model.description}}>
 {{else}}
   <meta property="og:description" content="The front end for the Open Event Server where event organisers can create and manage their event.">
+{{/if}}
+{{#if this.model.openGraphImage}}
+  <meta property="og:image" content={{this.model.openGraphImage}}>
+{{else}}
+  <meta property="og:image" content="https://eventyay.com/favicon.ico">
 {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7028 

#### Short description of what this resolves:
It adds an image to the metadata of any webpage, which when shared via social media platforms (Whatsapp, Twitter, etc) would display the Image along with the shared link.

#### Changes proposed in this pull request:

- The model for any component or page which wishes to display a particular image when its webpage is shared, should have a property : 'openGraphImage' , which is then put as a meta property in the [head.hbs](https://github.com/fossasia/open-event-frontend/blob/development/app/templates/head.hbs) file.
- For models which don't already have such an image, a default image (The favicon image of eventyay website) will be used.

#### Checklist

- [&#9745;] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [&#9745;] My branch is up-to-date with the Upstream `development` branch.
- [&#9745;] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [&#9745;] I have added tests that prove my fix is effective or that my feature works
- [&#9745;] I have added necessary documentation (if appropriate)
