### PR TITLE
fix: switch donation input event argument name from @keyup to @input

### DIFF
--- a/app/templates/components/public/ticket-list.hbs
+++ b/app/templates/components/public/ticket-list.hbs
@@ -44,7 +44,7 @@
                       @min={{ticket.minPrice}}
                       @max={{ticket.maxPrice}}
                       @value={{ticket.price}}
-                      @keyUp={{action "onChangeDonation"}} />
+                      @input={{action "onChangeDonation"}} />
                   </div>
                 </div>
               {{else}}


### PR DESCRIPTION
Fixes #7293 

#### Short description of what this resolves:
Where donation tickets are accepted, a user is allowed to add/change the amount they wish to sponsor through a number input.
 The user can modify the amount either through _typing_ on the input, _scrolling_ while focused on the input, or _step increment_ using input arrows/spinners if available.  
Currently, the input only listens for `keyUp` events to recalculate ticket subtotal which misses _scroll_ & _step increment_ value changes
 
#### Changes proposed in this pull request:

- Switch `keyup` event handler to `input` event

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
