### PR TITLE
fix: Add download icon on the "Downoad invoice" Button

### DIFF
--- a/app/templates/orders/view.hbs
+++ b/app/templates/orders/view.hbs
@@ -49,7 +49,7 @@
           {{/if}}
           <button {{action 'downloadInvoice' this.model.event.name this.model.order.identifier }}
           class="ui labeled icon blue flex-1 {{if this.isLoadingInvoice 'loading'}} {{if this.device.isMobile 'fluid'}} button">
-          <i class="file alternate icon"></i>
+          <i class="download icon"></i>
           {{t 'Download Invoice'}}
           </button>
         </div>


### PR DESCRIPTION
Fixes #7339 

#### Short description of what this resolves:
add download icon in the download invoice button see in the screenshot for the better understanding.

### screenshot before-
![bug 1](https://user-images.githubusercontent.com/65535360/119616645-77045100-be1e-11eb-8bd8-949983d621e4.PNG)

### screenshot after-
![fixed 1](https://user-images.githubusercontent.com/65535360/119616666-7ec3f580-be1e-11eb-97bb-fc624d0ad772.PNG)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
