### PR TITLE
fix:Message when trying to create an event with a non verified account is not helpful.

### DIFF
--- a/app/components/events/view/publish-bar.ts
+++ b/app/components/events/view/publish-bar.ts
@@ -86,7 +86,7 @@ export default class EventsViewPublishBar extends Component<EventsViewPublishBar
     } catch (e) {
       console.error('Error while publishing/unpublishing event', e);
       event.state = state;
-      this.notify.error(this.l10n.t('An unexpected error has occurred.'),
+      this.notify.error(this.l10n.t('Please confirm the verification email before creating an event.'),
         {
           id: 'event_publish_error'
         });

--- a/app/components/events/view/publish-bar.ts
+++ b/app/components/events/view/publish-bar.ts
@@ -23,6 +23,7 @@ interface EventsViewPublishBarArgs {
 export default class EventsViewPublishBar extends Component<EventsViewPublishBarArgs> {
   @service notify: any;
   @service l10n: any;
+  @service errorHandler: any;
 
   @tracked isModalOpen = false;
   @tracked isLoading = false;
@@ -86,10 +87,7 @@ export default class EventsViewPublishBar extends Component<EventsViewPublishBar
     } catch (e) {
       console.error('Error while publishing/unpublishing event', e);
       event.state = state;
-      this.notify.error(this.l10n.t('Please confirm the verification email before creating an event.'),
-        {
-          id: 'event_publish_error'
-        });
+      this.errorHandler.handle(e);
     } finally {
       this.isLoading = false;
     }


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-frontend/issues/7357

#### Short description of what this resolves:
When creating an event with an account that has not verified the email the message shown is:
"Unknown Error has occurred."
-----
message changed to-> "Please confirm the verification email before creating an event"

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
