### PR TITLE
wip: Add Event "Documents" to the system

### DIFF
--- a/app/components/widgets/forms/document-upload.js
+++ b/app/components/widgets/forms/document-upload.js
@@ -1,0 +1,36 @@
+import classic from 'ember-classic-decorator';
+import Component from '@ember/component';
+
+@classic
+export default class DocumentUpload extends Component {
+//   init() {
+//     super.init(...arguments);
+//     this.set('selectedFile', this.fileUrl);
+//     if (this.selectedFile) {
+//       this.set('needsConfirmation', true);
+//     }
+//   }
+
+  //   didInsertElement() {
+  //     super.didInsertElement(...arguments);
+  //     $(this.element)
+  //       .on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
+  //         e.preventDefault();
+  //         e.stopPropagation();
+  //       })
+  //       .on('dragover dragenter', () => {
+  //         $('.upload.segment', this.element).addClass('drag-hover');
+  //       })
+  //       .on('dragleave dragend drop', () => {
+  //         $('.upload.segment', this.element).removeClass('drag-hover');
+  //       })
+  //       .on('drop', e => {
+  //         this.processFiles(e.originalEvent.dataTransfer.files);
+  //       });
+  //   }
+
+//   willDestroyElement() {
+//     super.willDestroyElement(...arguments);
+//     $(this.element).off('drag dragstart dragend dragover dragenter dragleave drop');
+//   }
+}

--- a/app/controllers/events/view/documents.js
+++ b/app/controllers/events/view/documents.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class extends Controller {
+  @action
+  async toggleDocument() {
+    this.set('model.isDocumentEnabled', !this.model.isDocumentEnabled);
+    try {
+      await this.model.save();
+    } catch (error) {
+      console.error('Error while enabling document', error);
+    }
+  }
+}

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -98,6 +98,7 @@ export default class Event extends ModelBase.extend(CustomPrimaryKeyMixin, {
 
   createdAt : attr('moment', { readOnly: true }),
   deletedAt : attr('moment'),
+  // documentLinks: attr('array'),
 
   /**
    * Relationships

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -51,6 +51,7 @@ export default class Event extends ModelBase.extend(CustomPrimaryKeyMixin, {
   isDemoted                 : attr('boolean', { defaultValue: false }),
   isChatEnabled             : attr('boolean', { defaultValue: false }),
   isBillingInfoMandatory    : attr('boolean', { defaultValue: false }),
+  isDocumentEnabled         : attr('boolean', { defaultValue: false }),
 
   isTaxEnabled    : attr('boolean', { defaultValue: false }),
   canPayByPaypal  : attr('boolean', { defaultValue: false }),

--- a/app/router.js
+++ b/app/router.js
@@ -138,6 +138,7 @@ Router.map(function() {
         this.route('view', { path: '/:speaker_id' });
         this.route('edit', { path: '/:speaker_id/edit' });
       });
+      this.route('documents');
       this.route('chat');
       this.route('videoroom', { path: '/video' }, function() {
         this.route('list', { path: '/:status' });

--- a/app/routes/events/view/documents.js
+++ b/app/routes/events/view/documents.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+
+export default class extends Route {
+  titleToken() {
+    return this.l10n.t('Document');
+  }
+
+  model() {
+    return this.modelFor('events.view');
+  }
+}

--- a/app/templates/components/widgets/forms/document-upload.hbs
+++ b/app/templates/components/widgets/forms/document-upload.hbs
@@ -1,0 +1,24 @@
+<div class="">
+     <div class="{{if this.device.isTablet 'sixteen' 'four'}} wide right aligned column">
+          <div class="ui labeled input">
+            <button class="ui blue button right-floated" {{action 'documentUpload'}}>{{t 'save documents'}}</button>
+          </div>
+        </div>
+    <h3>
+        {{t 'Event Documents'}}
+        <UiPopup @content={{t "Add More Documents"}} @class="ui compact icon blue circular button ml-2" style="margin-left: 1rem !important;">
+          <i class="plus icon"></i>
+        </UiPopup>
+      </h3>
+      <div class="ui grid stackable">
+      <Input type="text" name="name"  />
+        <Widgets::Forms::FileUpload
+          @fileUrl={{@exhibitor.slidesUrl}}
+          @label={{t "Slide"}}
+          @id="slidesUrl"
+          @icon="file"
+          @hint={{t "Select a file"}}
+          @maxSizeInKb={{10000}} />
+          
+      </div>
+</div>

--- a/app/templates/components/widgets/forms/file-upload.hbs
+++ b/app/templates/components/widgets/forms/file-upload.hbs
@@ -9,13 +9,13 @@
     </div>
   {{else}}
     <div class="ui grid">
-      <div class="column sixteen wide">
+      {{!-- <div class="column sixteen wide">
         <Input @type="url" @change={{action "fileSelected" "url"}} />
         <span class="text muted">
           ({{t 'Slides uploaded here are not integrated in the video system. For video conferences please upload your slides into the video session directly as well.'}})
         </span>
       </div>
-      <span>{{t 'Or'}}</span>
+      <span>{{t 'Or'}}</span> --}}
       <div class="column sixteen wide">
         <label for="{{this.inputIdGenerated}}" class="ui icon button">
           <i class="file icon"></i>

--- a/app/templates/events/view.hbs
+++ b/app/templates/events/view.hbs
@@ -40,6 +40,9 @@
         <LinkTo @route="events.view.videoroom" class="item">
           {{t 'Video'}}
         </LinkTo>
+        <LinkTo @route="events.view.documents" class="item">
+          {{t 'Documents'}}
+        </LinkTo>
         <LinkTo @route="events.view.chat" class="item">
           {{t 'Chat'}}
         </LinkTo>

--- a/app/templates/events/view/documents.hbs
+++ b/app/templates/events/view/documents.hbs
@@ -17,17 +17,11 @@
           </div>
         </div>
       </div>
-      <div class="sixteen wide column">
-        {{#if this.model.isDocumentEnabled}}
-          <Widgets::Forms::FileUpload
-            @fileUrl={{@exhibitor.slidesUrl}}
-            @label={{t "Documents"}}
-            @id="Documents"
-            @icon="file"
-            @hint={{t "Select a file"}}
-            @maxSizeInKb={{10000}} />
-        {{/if}}
-      </div>
+      {{#if this.model.isDocumentEnabled}}
+        <div class="sixteen wide column">
+          <Widgets::Forms::DocumentUpload />
+        </div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/templates/events/view/documents.hbs
+++ b/app/templates/events/view/documents.hbs
@@ -1,0 +1,33 @@
+<div class="sixteen wide column">
+    <div class="ui centered grid">
+    <div class="column">
+      <div class="ui segment">
+        <div class="center aligned text">
+          <div class=" field">
+            <div class="d-flex" style="justify-content: center;">
+              <UiCheckbox
+                @class="ui slider"
+                @checked={{if this.model.isDocumentEnabled 'active'}}
+                @onChange={{action 'toggleDocument'}} />
+              <label class="weight-300" style="font-size: large">
+                {{if this.model.isDocumentEnabled (t 'Disable') (t 'Enable')}}
+                {{t 'Add Event Documents'}}
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="sixteen wide column">
+        {{#if this.model.isDocumentEnabled}}
+          <Widgets::Forms::FileUpload
+            @fileUrl={{@exhibitor.slidesUrl}}
+            @label={{t "Documents"}}
+            @id="Documents"
+            @icon="file"
+            @hint={{t "Select a file"}}
+            @maxSizeInKb={{10000}} />
+        {{/if}}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #7335 
reqd https://github.com/fossasia/open-event-server/pull/8015

#### Short description of what this resolves:
- [x] Add a "Documents" item in the organizer menu behind "Chat" and in front of "Exhibitors"
- [x] On the page show a switch on/off button to enable or disable the feature
- [ ] When enabled show a) a field to give the document a name and b) show an upload button
Provide the option to upload as many documents as the user wants
Show an x icon behind documents to enable the user to delete the document
- [ ] On the finished orders page of an event show above the "Payee" box show a box "Event Documents" with the documents the organizer uploaded. Only show this box if the organizer has activated that feature and uploaded documents.
 
#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
