### PR TITLE
dropdown menu top fixed

### DIFF
--- a/app/components/side-bar.js
+++ b/app/components/side-bar.js
@@ -58,3 +58,22 @@ export default class SideBar extends Component {
     }
   }
 }
+
+$(function() {
+
+  $(window).bind('scroll', function() {
+    const menuPosition = $('#col-content').offset().top;
+
+    if ($(window).scrollTop() > menuPosition) {
+      $('#public-event-content').addClass('fixed');
+    } else {
+      $('#public-event-content').removeClass('fixed');
+    }
+    const ticketPosition = $('#tickets').offset().top;
+    if ($(window).scrollTop() > ticketPosition) {
+      $('#public-event-content .text').html('<i class="mr-4  ticket icon"></i>Tickets');
+    } else {
+      $('#public-event-content .text').html('<i class="mr-4  info icon"></i>Info');
+    }
+  });
+});

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -177,4 +177,11 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     color: inherit;
   }
 }
-
+@media only screen and (max-width: 767px) {
+  .fixed {
+    position: fixed !important;
+    top: 0;
+    background-color: #fff;
+    z-index: 9999;
+  }
+}

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -24,7 +24,7 @@
       </div>
     </div>
   </div>
-  <div class="sixteen wide column content {{if this.smallLead 'with small lead'}}">
+  <div class="sixteen wide column content {{if this.smallLead 'with small lead'}}" id="col-content">
     <div class="ui stackable grid">
       <div class="three wide column" id="public-event-content">
         {{#if this.device.isMobile}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
![Screenshot 2021-06-16 234834](https://user-images.githubusercontent.com/76563860/122271837-8185a800-cefd-11eb-8308-af975c5c42aa.jpg)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6122

#### Short description of what this resolves:
Many pages have this feature where a special menu stays on top of the page when a user scrolls down. Please implement the same thing for the drop-down event menu on public event pages.

When the user scrolls down keep the menu on top of the screen. When the user reaches the area "Tickets" show the menu item "Tickets" in the menu and so forth. Implement this on all public event pages for the mobile view.

#### Changes proposed in this pull request:

- Now the menu sticks at the top when the user scrolls down for the mobile view. 
- When the user reaches the area "Tickets", the menu sticked at the top shows the menu item  "Tickets" from the menu for mobile view.

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
