### PR TITLE
fix: schedule page cut off in mobile view

### DIFF
--- a/app/components/side-bar.js
+++ b/app/components/side-bar.js
@@ -63,9 +63,9 @@ $(function() {
   $(window).on('scroll', function() {
     const menuPosition = $('#event-contents').offset().top;
     if ($(window).scrollTop() > menuPosition) {
-      $('#public-event-content').addClass('fixed');
+      $('#public-event-content').addClass('menu-fixed');
     } else {
-      $('#public-event-content').removeClass('fixed');
+      $('#public-event-content').removeClass('menu-fixed');
     }
   });
 });

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -178,7 +178,7 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   }
 }
 @media only screen and (max-width: 767px) {
-  .fixed {
+  .menu-fixed {
     position: fixed !important;
     top: 0;
     background-color: #fff;

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -100,7 +100,7 @@
       {{/if}}
     </h3>
     <table class="ui very basic fixed table">
-      <thead>
+      <thead class="full-width">
         <tr>
           <th class="two wide" style="border: none;"></th>
           <th style="border: none;"></th>

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -89,7 +89,7 @@
   </InfinityLoader>
 {{/if}}
 
-<div class="mt-8">
+<div class="mt-8 y-scrollable" style="display: block">
   {{#if this.model.session}}
   {{#each this.groupByDateSessions as |group|}}
     <h3 class="ui header {{if this.device.isMobile 'mb--8' 'mb--4'}}">

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -89,7 +89,7 @@
   </InfinityLoader>
 {{/if}}
 
-<div class="mt-8 y-scrollable" style="display: block">
+<div class="mt-8">
   {{#if this.model.session}}
   {{#each this.groupByDateSessions as |group|}}
     <h3 class="ui header {{if this.device.isMobile 'mb--8' 'mb--4'}}">
@@ -99,8 +99,8 @@
         {{t 'Not yet scheduled'}}
       {{/if}}
     </h3>
-    <table class="ui very basic table">
-      <thead class="full-width">
+    <table class="ui very basic fixed table">
+      <thead>
         <tr>
           <th class="two wide" style="border: none;"></th>
           <th style="border: none;"></th>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6761
also contains some changes in https://github.com/fossasia/open-event-frontend/pull/7456

#### Short description of what this resolves:
![localhost_4200_e_fa96ae2c_schedule_date=2021-03-13(iPhone X)](https://user-images.githubusercontent.com/56407566/122738776-eba4a100-d29f-11eb-802e-96d41ce4fad1.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
