### PR TITLE
Moved search field to top on search pages #7587

### DIFF
--- a/app/templates/components/explore/side-bar.hbs
+++ b/app/templates/components/explore/side-bar.hbs
@@ -6,15 +6,7 @@
     </marker.popup>
   </layers.marker>
 </LeafletMap> --}}
-<div class="item">
-  <div class="ui input">
-    <Input
-      @name="name"
-      @value={{this.event_name}}
-      @type="text"
-      @placeholder={{t "Enter Event Name"}} />
-  </div>
-</div>
+
 {{#if this.showFiltersOnMobile}}
   <div class="item">
     <UiAccordion>

--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -18,6 +18,20 @@
         <i class="search icon"></i>
       </div>
     {{/if}}
+
+         {{#unless this.isNotExplorePageRoute }}
+        
+  <div class="ui input d-flex items-center space-between m-2 p-2" >
+    <Input
+      @name="name"
+      @value={{this.event_name}}
+      @type="text"
+      @placeholder={{t "Enter Event Name"}} />
+  </div>
+
+    {{/unless}}
+
+
     {{#if (and (not this.session.isAuthenticated) this.isNotEventPageRoute)}}
       <LinkTo
         @route="pricing" class="item"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7587

#### Short description of what this resolves:
Moved enter event name search field to top on search pages

#### Changes proposed in this pull request:

-side-bar.hbs
-nav-bar.hbs
-
![previous](https://user-images.githubusercontent.com/72243090/127776298-eb490039-03f7-4798-b602-f450f720c428.png)
![updated](https://user-images.githubusercontent.com/72243090/127776311-454161c3-4b7b-4ab2-b794-b1597bd4c277.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
