### PR TITLE
fix tabbedNavigation and UiDropDown at Admin Sales Page.

### DIFF
--- a/app/templates/admin/sales.hbs
+++ b/app/templates/admin/sales.hbs
@@ -1,5 +1,5 @@
 <TabbedNavigation>
-  <LinkTo @route="admin.sales.index" @model="live" class="item">
+  <LinkTo @route="admin.sales.index" @model="live" class={{if (eq this.session.currentRouteName 'admin.sales.index') 'active item' 'item'}}>
     {{t 'Orders'}}
   </LinkTo>
   <LinkTo @route="admin.sales.invoices" class="item">

--- a/app/templates/admin/sales/index.hbs
+++ b/app/templates/admin/sales/index.hbs
@@ -6,7 +6,7 @@
     <div class="ten wide column right aligned">
       <UiDropdown class="labeled icon button mb-2 mr-2">
         <i class="sort amount down icon"></i>
-        <span class="default text">{{t 'Live'}}</span>
+        <span class="default text" style="text-transform: capitalize">{{this.router.currentRoute.params.event_status}}</span>
         <div class="menu">
           <LinkTo @route="admin.sales.index" @model="live" class="item">{{t 'Live'}}</LinkTo>
           <LinkTo @route="admin.sales.index" @model="past" class="item">{{t 'Past'}}</LinkTo>


### PR DESCRIPTION
Fixes #7650

fix tabbedNavigation and UiDropDown at Admin Sales Page.

![1](https://user-images.githubusercontent.com/72552281/128351412-ec28eecf-4db8-4383-89c6-ea8617ab83bb.png)
