### PR TITLE
fix:View Group Button Issue

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -201,7 +201,7 @@ Router.map(function() {
     this.route('list');
     this.route('following');
   });
-  this.route('group-public', { path: '/g/:group_id' });
+  this.route('group-public', { path: '/groups/:group_id' });
   // this.route('notifications', function() {
   //   this.route('all', { path: '/:notification_state' });
   // });


### PR DESCRIPTION
Fixes issue #7736

It resolves the routing issue when clicked on the view group button


#### Changes proposed in this pull request:
-The  view group button was routing to path: '/g/:group_id'  and hence displaying a 404 Error Page
-Changed the route to point to path: '/groups/:group_id' 
-This route correctly to group details page.

#### Checklist

- [ x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ x ] My branch is up-to-date with the Upstream `development` branch.
- [ x ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


![ss1](https://user-images.githubusercontent.com/11796708/131457559-d5f847bf-fb7e-4682-9f88-98c65f8f1e8d.JPG)
![Screenshot (179)](https://user-images.githubusercontent.com/11796708/131457564-058f9344-8f73-4a84-8459-7d501051a971.png)
![Screenshot (178)](https://user-images.githubusercontent.com/11796708/131457567-22941c4a-9226-464e-80f2-e313fe107f05.png)
![Screenshot (177)](https://user-images.githubusercontent.com/11796708/131457574-64f5505f-ac9d-4ef9-8a85-d70fb55af3eb.png)

