### PR TITLE
fix:View Group Button Issue

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -201,7 +201,7 @@ Router.map(function() {
     this.route('list');
     this.route('following');
   });
-  this.route('group-public', { path: '/g/:group_id' });
+  this.route('group-public', { path: '/groups/:group_id' });
   // this.route('notifications', function() {
   //   this.route('all', { path: '/:notification_state' });
   // });


### PR DESCRIPTION
Fixes #7736

It resolves the routing issue when clicked on the view group button

Changes proposed in this pull request:
-The view group button was routing to path: '/g/:group_id' and hence displaying a 404 Error Page
-Changed the route to point to path: '/groups/:group_id'
-This route correctly to group details page.

![ss1](https://user-images.githubusercontent.com/11796708/131459538-98bcbab4-8cf5-4019-a62c-f3b1c16f3b89.JPG)
![Screenshot (179)](https://user-images.githubusercontent.com/11796708/131459544-224a3c35-3d50-475a-8584-b9c1c459229c.png)
![Screenshot (178)](https://user-images.githubusercontent.com/11796708/131459549-273d4820-0961-4681-9e74-319b62cf2fa6.png)
![Screenshot (177)](https://user-images.githubusercontent.com/11796708/131459555-fb2985b5-2b03-4ab1-8450-f49f87192f1e.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
