### PR TITLE
fix: Change color of "Order" button on registration events

### DIFF
--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -329,7 +329,7 @@
       </p>
       <div class="center aligned">
         {{#if this.data.event.isOneclickSignupEnabled}}
-          <button type="submit" class="ui violet submit button">{{t 'One Click Signup'}}</button>
+          <button type="submit" class="ui blue submit button">{{t 'One Click Signup'}}</button>
         {{else}}
           <button type="submit" class="ui teal submit button">{{if this.isPaidOrder (t "Proceed to Checkout") (t "Order Now") }}</button>
         {{/if}}


### PR DESCRIPTION
Fixes #7817 

#### Short description of what this resolves:
The order now button on registration events has an usual color. Please change it to the blue color which is used on other buttons.

### Screenshots

Before | After
-------- | ---------
![Screenshot from 2021-09-20 05-12-22](https://user-images.githubusercontent.com/71120226/133946746-abd65c7b-07e0-4094-884d-7f9127bea125.png) | ![Screenshot from 2021-09-20 05-11-55](https://user-images.githubusercontent.com/71120226/133946748-a242fe1a-422c-4f87-ad2e-5edfe2168a8f.png)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
