### PR TITLE
Update order-summary table on order page

### DIFF
--- a/app/styles/partials/utils.scss
+++ b/app/styles/partials/utils.scss
@@ -101,6 +101,10 @@
   padding-right: .5rem !important;
 }
 
+.pr-4 {
+  padding-right: 1rem !important;
+}
+
 .pb-2 {
   padding-bottom: .5rem !important;
 }

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -49,7 +49,7 @@
               {{else}} 
                 {{t 'Ticket Type'}}
               {{/if}} 
-               </th>
+            </th>
             {{#if this.data.discountCode}}
               <th class="two wide">{{t 'Price'}}</th>
               <th class=" two wide">{{t 'Discount'}}</th>
@@ -69,9 +69,6 @@
               <th class="ui aligned two wide">{{t 'Discount'}}</th>
             {{/if}}
             <th class="three wide">{{t 'Quantity'}}</th>
-            {{#if this.event.tax}}
-              <th class="four wide">{{t 'Tax'}}</th>
-            {{/if}}
             <th class="ui aligned four wide">{{t 'Subtotal'}}</th>
             
           {{/if}}
@@ -109,36 +106,6 @@
                       @ticket={{ticket}}
                       @currency={{this.eventCurrency}}
                       @amount={{ticket.price}} />
-                  </td>
-                  {{#if this.data.discountCode}}
-                    <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.discount}}</td>
-                  {{/if}}
-                  <td>
-                    {{tickets.length}}
-                  </td>
-                  {{#if this.event.tax}}
-                    <td>
-                      {{#if this.event.tax.isTaxIncludedInPrice}}
-                        {{t 'The price is inclusive of all taxes.'}}
-                      {{else}}
-                        {{#if ticket.price}}
-                          <td>
-                            <CurrencyAmount @currency={{this.eventCurrency}} @amount={{sub ticket.ticketPriceWithTax ticket.price}}/>
-                            <small class="ui gray-text small">
-                              ({{this.event.tax.name}} {{this.event.tax.rate}}%)
-                            </small>
-                          </td>
-                        {{else}}
-                          {{t 'N/A'}}
-                        {{/if}}
-                      {{/if}}
-                    </td>
-                  {{/if}}
-                  <td>
-                    <Orders::TicketPrice
-                      @ticket={{ticket}}
-                      @currency={{this.eventCurrency}}
-                      @amount={{mult (sub ticket.price ticket.discount) tickets.length}} />
                     <p>
                       {{#if this.event.tax.isTaxIncludedInPrice}}
                         <small class="ui gray-text small">
@@ -157,6 +124,18 @@
                         </span>
                       {{/if}}
                     </p>
+                  </td>
+                  {{#if this.data.discountCode}}
+                    <td>{{currency-symbol this.eventCurrency}} {{format-money ticket.discount}}</td>
+                  {{/if}}
+                  <td>
+                    {{tickets.length}}
+                  </td>
+                  <td>
+                    <Orders::TicketPrice
+                      @ticket={{ticket}}
+                      @currency={{this.eventCurrency}}
+                      @amount={{mult (sub ticket.price ticket.discount) tickets.length}} />
                   </td> 
                 {{/if}}   
               </tr>
@@ -172,12 +151,6 @@
               <th colspan="2"></th>
             {{else}}
               <th></th>
-            {{/if}}
-            {{#if this.event.tax}}
-              <th></th>
-              {{#if this.data.discountCode}}
-                <th></th>
-              {{/if}}
             {{/if}}
             <th>
               <div class="ui aligned small primary icon">

--- a/app/templates/components/orders/order-summary.hbs
+++ b/app/templates/components/orders/order-summary.hbs
@@ -70,7 +70,6 @@
             {{/if}}
             <th class="three wide">{{t 'Quantity'}}</th>
             <th class="ui aligned four wide">{{t 'Subtotal'}}</th>
-            
           {{/if}}
         </tr>
       </thead>
@@ -147,18 +146,30 @@
         <tfoot class="full-width">
           <tr>
             <th></th>
+            <th></th>
             {{#if this.data.discountCode}}
-              <th colspan="2"></th>
-            {{else}}
               <th></th>
             {{/if}}
-            <th>
-              <div class="ui aligned small primary icon">
-                {{t 'Grand Total'}}:
-              </div>
-            </th>
-            <th colspan="4">
-              {{currency-symbol this.eventCurrency}} {{format-money this.data.amount}}
+            <th colspan="2" class="pr-4">
+              <table class="ui small left aligned" style="float: right;">
+                <tbody>
+                  {{#if this.event.tax}}
+                    <tr><td>{{t 'Total'}}</td><td><CurrencyAmount @currency={{this.eventCurrency}} @amount={{this.total}}/></td></tr>
+                    <tr>
+                      <td>
+                        <div>{{t 'Tax'}} ({{this.event.tax.rate}}% {{this.event.tax.name}})</div>
+                        {{#if this.event.tax.isTaxIncludedInPrice}}
+                          <small class="ui gray-text small">{{t 'Included in Total' }}</small>
+                        {{/if}}
+                      </td>
+                      <td><CurrencyAmount @currency={{this.eventCurrency}} @amount={{sub this.data.amount this.total}}/></td>
+                    </tr>
+                  {{/if}}
+                  <tr><td>{{t 'Grand Total'}}</td>
+                    <td><CurrencyAmount @currency={{this.eventCurrency}} @amount={{this.data.amount}}/></td>
+                  </tr>
+                </tbody>
+              </table>
             </th>
           </tr>
         </tfoot>


### PR DESCRIPTION
Fixes #7813
Fixes #7812

#### Short description of what this resolves:

- [x] Delete "Tax" column and show tax info below ticket price same as on the ticket section of the event page.
- [x] On order pages show Subtotal and Tax line

#### ScreenShots 
Before | After 
----------- | -----------
![Screenshot from 2021-09-20 07-41-57](https://user-images.githubusercontent.com/71120226/133951427-f069bb7a-3f12-44de-ae2f-3c344f235ba9.png) | ![Screenshot from 2021-09-20 08-48-24](https://user-images.githubusercontent.com/71120226/133954012-cbc8b1ba-bced-4737-a8ec-0dc21f3b79a0.png)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
