### PR TITLE
fix: Only Show Registration tickets which are active

### DIFF
--- a/app/templates/public/index.hbs
+++ b/app/templates/public/index.hbs
@@ -8,11 +8,11 @@
   {{#if (and this.model.event.isOneclickSignupEnabled this.model.tickets)}}
     <h2>{{t 'Registration'}}</h2>
     {{!-- template-lint-disable style-concatenation --}}
-    {{#each (sort-by 'position' this.model.tickets) as |ticket| }}
-    <div role='button' onclick={{action "selectTicket" ticket}} class="ui segment {{if (eq this.selectedRegistration ticket) 'select-ticket'}}" style="cursor:pointer; max-width:{{if device.isMobile '100%' '50%'}}">
-        {{!-- template-lint-disable no-invalid-interactive --}}
-        {{#if (includes ticket.type 'Registration')}}
-          <div class="ui two column grid"  style="align-items: center;">
+     {{#each (sort-by 'position' this.model.tickets) as |ticket| }}
+       {{#if (includes ticket.type 'Registration')}}
+         <div role='button' onclick={{action "selectTicket" ticket}} class="ui segment {{if (eq this.selectedRegistration ticket) 'select-ticket'}}" style="cursor:pointer; max-width:{{if device.isMobile '100%' '50%'}}">
+            {{!-- template-lint-disable no-invalid-interactive --}}
+           <div class="ui two column grid"  style="align-items: center;">
               <div class="two wide column">
                 <div class="custom-registration-checkbox pb-4">
                   <span class="custom-registration-bullet {{if (eq this.selectedRegistration ticket) 'select-custom-registration-checkbox'}}"></span>
@@ -67,10 +67,10 @@
                   </div>
                 </div>
               </div>
-          </div>
-        {{/if}}
-    </div>
-    {{/each}}
+           </div>
+         </div>
+       {{/if}}
+     {{/each}}
     <br/>
     <button class="ui blue button {{if (not this.selectedRegistration) 'disabled'}}" style="height:50px;width:{{if device.isMobile '100%' '50%'}}" onclick={{pipe-action (action "oneClickSignup" this.selectedRegistration) (action this.placeOrder 0)}}> {{t 'Register Now'}} </button>
   {{else}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7822 

#### Short description of what this resolves:
The registration box on the event page currently shows empty boxes for the deleted registration types. Only show boxes of active types.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
