### PR TITLE
fix: group name not showing in admin group table

### DIFF
--- a/app/templates/components/ui-table/cell/admin/groups/cell-group-name.hbs
+++ b/app/templates/components/ui-table/cell/admin/groups/cell-group-name.hbs
@@ -1,4 +1,4 @@
-<span>@record</span>
+<span>{{ @record }}</span>
 <div class="ui hidden divider"></div>
 <div class="ui horizontal compact basic buttons">
   <LinkTo @route="groups.edit.settings" @model={{@extraRecords.id}}>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7850 

![image](https://user-images.githubusercontent.com/56963647/134761537-3ecbf030-3ea9-49f2-84b0-6406e93c879b.png)

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
