### PR TITLE
fix: changed registeredComany to organization

### DIFF
--- a/app/templates/components/orders/company-info.hbs
+++ b/app/templates/components/orders/company-info.hbs
@@ -9,13 +9,13 @@
   <div class="ui padded segment">
     <table class="ui very basic compact unstackable table company-info">
       <tbody>
-        {{#if @tax.organization}}
+        {{#if @tax.registeredCompany}}
           <tr>
             <td>
-              <strong>{{t 'Name'}}:</strong>
+              <strong>{{t 'Organization'}}:</strong>
             </td>
             <td>
-              {{@tax.organization}}
+              {{@tax.registeredCompany}}
             </td>
           </tr>
         {{/if}}

--- a/app/templates/components/orders/company-info.hbs
+++ b/app/templates/components/orders/company-info.hbs
@@ -9,13 +9,13 @@
   <div class="ui padded segment">
     <table class="ui very basic compact unstackable table company-info">
       <tbody>
-        {{#if @tax.registeredCompany}}
+        {{#if @tax.organization}}
           <tr>
             <td>
               <strong>{{t 'Name'}}:</strong>
             </td>
             <td>
-              {{@tax.registeredCompany}}
+              {{@tax.organization}}
             </td>
           </tr>
         {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7883 

#### Short description of what this resolves:
The order company information box shows the "Name" instead of "Organisation" in the left column of the box. Please correct this and show "Organisation" in all company boxes in the order process and final order page.

#### Changes proposed in this pull request:
change variable from registered company to organization

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
