### PR TITLE
fix: show all available tax info everytime

### DIFF
--- a/app/templates/components/forms/wizard/basic-details-step.hbs
+++ b/app/templates/components/forms/wizard/basic-details-step.hbs
@@ -642,25 +642,23 @@
               {{/if}}
               <div class="description">
                 {{this.data.event.tax.rate}}% - {{if this.data.event.tax.isTaxIncludedInPrice 'Tax included in ticket price' 'Tax on top of ticket price'}}
-                {{this.data.event.tax.taxId}}<br>
+                {{this.data.event.tax.taxId}}
+                {{#if this.data.event.tax.registeredCompany}}
+                  <br/>{{this.data.event.tax.registeredCompany}}
+                {{/if}}
+                {{#if this.data.event.tax.address}}
+                  <br/>{{this.data.event.tax.address}}
+                {{/if}}
+                {{#if this.data.event.tax.city}}
+                  <br/>{{this.data.event.tax.city}}
+                {{/if}}
+                {{#if this.data.event.tax.state}}
+                  <br/>{{this.data.event.tax.state}}
+                {{/if}}
+                {{#if this.data.event.tax.zip}}
+                  <br/>{{this.data.event.tax.zip}}
+                {{/if}}
               </div>
-              {{#if this.data.event.tax.shouldSendInvoice}}
-                <div class="description">
-                  {{this.data.event.tax.registeredCompany}}
-                  {{#if this.data.event.tax.address}}
-                    <br/>{{this.data.event.tax.address}}
-                  {{/if}}
-                  {{#if this.data.event.tax.city}}
-                    <br/>{{this.data.event.tax.city}}
-                  {{/if}}
-                  {{#if this.data.event.tax.state}}
-                    <br/>{{this.data.event.tax.state}}
-                  {{/if}}
-                  {{#if this.data.event.tax.zip}}
-                    <br/>{{this.data.event.tax.zip}}
-                  {{/if}}
-                </div>
-              {{/if}}
             </div>
             <div class="ui bottom attached small buttons">
               <button class="ui button" type="button" {{action 'openTaxModal'}}>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7882 

#### Short description of what this resolves:
Info will show regardless of user selecting send invoice to attendees.
