### PR TITLE
fix: promote group on front page

### DIFF
--- a/app/models/group.js
+++ b/app/models/group.js
@@ -27,7 +27,7 @@ export default class Group extends ModelBase.extend({
   user              : belongsTo('user'),
   events            : hasMany('event'),
   roles             : hasMany('users-groups-role'),
-  follower          : belongsTo('user-follow-group', { inverse: 'group' }),
+  // follower          : belongsTo('user-follow-group', { inverse: 'group' }),
   followers         : hasMany('user-follow-group'),
 
   url: computed('identifier', function() {

--- a/app/serializers/groups.js
+++ b/app/serializers/groups.js
@@ -14,8 +14,13 @@ export default ApplicationSerializer.extend(CustomPrimaryKeyMixin, {
     const json = this._super(...arguments);
 
     const { relationships } = json.data;
+
     try {
       delete relationships.follower;
+    } catch {} // eslint-disable-line no-empty
+
+    try {
+      delete relationships.followers;
     } catch {} // eslint-disable-line no-empty
 
     try {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/7926

- fixing serialization issue 
- remove some junk code
- able to promote group with followers too

```
index.js:175 Uncaught Error: Assertion Failed: Ember Data expected the data for the follower relationship on a <group:9> to be in a JSON API format and include an `id` and `type` property but it found [ { id: "37", type: "user-follow-group" } ]. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.
    at Object.assert (index.js:175)
    at BelongsToRelationship.updateData (-private.js:10749)
    at BelongsToRelationship.push (-private.js:10109)
    at RecordDataDefault._setupRelationships (-private.js:11030)
    at RecordDataDefault.pushData (-private.js:10914)
    at InternalModel.setupData (-private.js:5392)
    at Store._load (-private.js:13817)
    at Store._pushInternalModel (-private.js:14064)
    at -private.js:14002
    at Backburner._run (backburner.js:1097)

```
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
