### PR TITLE
python-dev is not found, changing to python2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-alpine as builder
 
 WORKDIR /app
 
-RUN apk add git python-dev make g++ gettext
+RUN apk add git python2-dev make g++ gettext
 
 COPY package.json yarn.lock ./
 


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@marcogg.>

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:

Failing automated docker build through github actions with the following error:
```
[...]
 #7 [builder 3/7] RUN apk add git python-dev make g++ gettext
#7 0.880 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#7 0.995 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#7 1.213 ERROR: unable to select packages:
#7 1.244   python-dev (no such package):
#7 1.244     required by: world[python-dev]
[...]
```

You can find the full log [here](https://github.com/fossasia/open-event-frontend/runs/4127741393?check_suite_focus=true).

#### Changes proposed in this pull request:

It seems from [here](https://pkgs.alpinelinux.org/packages?name=python-dev&branch=v3.14) that the package `python-dev` is not available on Alpine linux 3.14, the base image used in the `Dockerfile`. Therefore changing it to `python2-dev` since that seems to be the package that was being installed before the error started to appear.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
