### PR TITLE
Prevent yarn install on node 16 because it's not supported yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "xgettext-template": "^4.1.1"
   },
   "engines": {
-    "node": ">= 12.x",
+    "node": ">= 12.x <15",
     "yarn": ">= 1.2.0"
   },
   "private": true,


### PR DESCRIPTION
This should prevent the repeated questions of users who try installing the project on node 16. Currently only node <=14 is supported.