### PR TITLE
fix: event cards now show up everytime as expected with correct information on group public page

### DIFF
--- a/app/routes/group-public.js
+++ b/app/routes/group-public.js
@@ -12,7 +12,7 @@ export default class IndexRoute extends Route {
   model(params) {
     return hash({
       group: this.store.findRecord('group', params.group_id, {
-        include: 'events,followers,user'
+        include: 'followers,user'
       }),
       followedGroups: this.authManager.currentUser?.email ? this.authManager.currentUser.query('followedGroups', {
         include: 'group,user'


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8005 
Fixes #8007 

#### Short description of what this resolves:

```
WARNING: You requested a record of type 'event' with id '7' but the adapter returned a payload with primary data having an id of 'e9663c48'. Use 'store.findRecord()' when the requested id is the same as the one returned by the adapter. In other cases use 'store.queryRecord()' instead.
```
I enabled my console warnings today and figured out what's the error by seeing this warning message. This was because of ```ember-data``` as we guessed. Now this should work fine. Tested on api.eventyay.com

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
