### PR TITLE
fix: error when accessing group page

### DIFF
--- a/app/controllers/group-public.js
+++ b/app/controllers/group-public.js
@@ -11,6 +11,6 @@ export default class GroupPublicController extends Controller {
 
   @computed('model.group.followers')
   get followers() {
-    return  this.model.group.followers ? this.model.group.followers.toArray() : [];
+      return  (this.session.isAuthenticated && this.model.group.followers) ? this.model.group.followers.toArray() : [];
   }
 }

--- a/app/templates/components/forms/group/group-view.hbs
+++ b/app/templates/components/forms/group/group-view.hbs
@@ -83,7 +83,7 @@
             {{@group.followerCount}}
           </div>
         </button>
-        {{#if (and this.followers this.session.isAuthenticated)}}
+        {{#if (and this.session.isAuthenticated this.followers)}}
           <div class="d-flex content-center items-center wrap mt-4">
             {{#each this.followers as |follower index|}}
               {{#if (lt index 6)}}

--- a/app/templates/components/forms/group/group-view.hbs
+++ b/app/templates/components/forms/group/group-view.hbs
@@ -83,7 +83,7 @@
             {{@group.followerCount}}
           </div>
         </button>
-        {{#if (and this.session.isAuthenticated this.followers)}}
+        {{#if this.followers}}
           <div class="d-flex content-center items-center wrap mt-4">
             {{#each this.followers as |follower index|}}
               {{#if (lt index 6)}}

--- a/app/templates/components/forms/group/group-view.hbs
+++ b/app/templates/components/forms/group/group-view.hbs
@@ -83,7 +83,7 @@
             {{@group.followerCount}}
           </div>
         </button>
-        {{#if this.followers}}
+        {{#if (and this.followers this.session.isAuthenticated)}}
           <div class="d-flex content-center items-center wrap mt-4">
             {{#each this.followers as |follower index|}}
               {{#if (lt index 6)}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8131 

#### Short description of what this resolves:
As discussed in the meeting, user thumbnails removed when the user is not logged in.

![image](https://user-images.githubusercontent.com/56963647/144232647-b4bf509d-daec-4049-946e-e60e9b6a493e.png)

