### PR TITLE
fix: remove HTML tags from calendar description text

### DIFF
--- a/app/components/public/add-to-calender.ts
+++ b/app/components/public/add-to-calender.ts
@@ -27,14 +27,12 @@ export default class AddToCalender extends Component<Args> {
 
   get description(): string {
     const { event } = this.args;
-    let desc = `Join the event at ${event.url} `;
+    let desc = `Join the event at <a href = "${event.url}">${event.url}</a>\n `;
     if (event.description) {
-      const text = event.description.replace(/<[^>]+>/g, '');
-      desc = desc + `Event Description: ${text}`;
+      desc = desc + `<section><h3>Event Description </h3>\n${event.description}\n</section>`;
     }
     if (event.ownerDescription) {
-      const text = event.ownerDescription.replace(/<[^>]+>/g, '');
-      desc = desc +  `Organizer Message: ${text}`;
+      desc = desc +  `<section><h3>Organizer Message </h3>\n${event.ownerDescription}\n</section>`;
     }
     return desc;
   }
@@ -79,7 +77,7 @@ export default class AddToCalender extends Component<Args> {
     const { event } = this.args;
     const startTime = this.startsAt.format('YYYYMMDD[T]HHmmSS');
     const endTime = this.endsAt.format('YYYYMMDD[T]HHmmSS');
-    return `https://calendar.yahoo.com/?v=60&title=${event.name}&st=${startTime}&et=${endTime}&desc=${this.description}&in_loc=${this.calendarLocation}`;
+    return `https://calendar.yahoo.com/?v=60&title=${event.name}&st=${startTime}&et=${endTime}&desc=${this.description.replace(/<[^>]+>/g, '')}&in_loc=${this.calendarLocation}`;
   }
 
   get outlookUrl(): string {

--- a/app/components/public/add-to-calender.ts
+++ b/app/components/public/add-to-calender.ts
@@ -27,18 +27,14 @@ export default class AddToCalender extends Component<Args> {
 
   get description(): string {
     const { event } = this.args;
-    let desc = `Join the event at <a href = "${event.url}">${event.url}</a> \n `;
+    let desc = `Join the event at ${event.url} `;
     if (event.description) {
-      desc = desc + `<section>
-                        <h3>Event Description </h3>\n
-                        ${event.description}\n
-                    </section>`;
+      const text = event.description.replace(/<[^>]+>/g, '');
+      desc = desc + `Event Description: ${text}`;
     }
     if (event.ownerDescription) {
-      desc = desc +  `<section>
-                          <h3>Organizer Message</h3>\n
-                           ${event.ownerDescription}\n
-                      </section>`;
+      const text = event.ownerDescription.replace(/<[^>]+>/g, '');
+      desc = desc +  `Organizer Message: ${text}`;
     }
     return desc;
   }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8179 

**Yahoo**
![Screenshot 2021-12-09 at 15-37-46 https calendar yahoo com](https://user-images.githubusercontent.com/42090582/145381953-119b5fee-fdd3-4e32-9931-11e2b05dadb4.png)

**Outlook**
![Screenshot 2021-12-09 at 15-38-38 Calendar - Shubham Upreti - Outlook](https://user-images.githubusercontent.com/42090582/145382008-d9c0c215-f248-4d5a-b393-c12690186e53.png)
