### PR TITLE
fix: make video & audio field in session edit form visible

### DIFF
--- a/app/mixins/custom-form.js
+++ b/app/mixins/custom-form.js
@@ -172,7 +172,7 @@ export default Mixin.create(MutableArray, {
       this.store.createRecord('custom-form', {
         fieldIdentifier : 'videoUrl',
         form            : 'session',
-        type            : 'file',
+        type            : 'text',
         isRequired      : false,
         isPublic        : true,
         isIncluded      : false,
@@ -181,7 +181,7 @@ export default Mixin.create(MutableArray, {
       this.store.createRecord('custom-form', {
         fieldIdentifier : 'audioUrl',
         form            : 'session',
-        type            : 'file',
+        type            : 'text',
         isRequired      : false,
         isPublic        : true,
         isIncluded      : false,


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8201 

To test: **Create a new event and turn on speaker-session forms and turn on audio and video fields**

![Screenshot 2021-12-22 at 12-44-48 Create session Sessions test-video-field Events Open Event](https://user-images.githubusercontent.com/42090582/147051746-aa8910e4-46b4-4821-b0d8-aa8e9e304b97.png)
