### PR TITLE
fix: event logo cut off in events with long titles & addresses

### DIFF
--- a/app/styles/pages/public-event.scss
+++ b/app/styles/pages/public-event.scss
@@ -60,7 +60,6 @@
         .info {
           align-items: center;
           bottom: 20%;
-          flex-wrap: wrap;
           position: absolute;
 
           .logo {
@@ -70,6 +69,10 @@
 
           .event {
             font-weight: 300;
+          }
+
+          .event.info {
+            width: 80%;
           }
 
           .event.name {
@@ -86,7 +89,6 @@
             font-size: 1.25rem;
             margin: 0;
           }
-
 
           .event.location {
             font-size: 1.5rem;
@@ -120,16 +122,20 @@
           .logo {
             height: 50px;
             padding-bottom: 4px;
-            }
+          }
         }
         @media (max-width: 470px) {
           .info {
-            bottom: 0;
+            bottom: 0 !important;
             padding: 1rem;
 
             .logo {
-              height: 30px;
+              height: 40px;
               padding-bottom: 4px;
+            }
+
+            .event-info {
+              width: 60%;
             }
 
             .event.name {
@@ -137,15 +143,15 @@
             }
 
             .event.time {
-              font-size: 1rem;
+              font-size: .85rem;
             }
 
             .event.time.ends {
-              font-size: 1rem;
+              font-size: .85rem;
             }
 
             .event.location {
-              font-size: .95rem;
+              font-size: .75rem;
             }
           }
         }
@@ -179,8 +185,9 @@
       }
     }
 
-    > div {
+    > .info > .event-info {
       min-height: 400px;
+      width: 80%;
     }
   }
 

--- a/app/templates/public.hbs
+++ b/app/templates/public.hbs
@@ -6,11 +6,13 @@
       <div class="ui container">
         <div class="ui info d-flex">
           {{#if this.model.logoUrl}}
+          <div>
             <LinkTo @route="public">
               <img src="{{this.model.logoUrl}}" class="logo mr-8" />
             </LinkTo>
+          </div>
           {{/if}}
-          <div>
+          <div class="event-info">
             <h4 class="event time" style={{this.vietnameseFontFamily}}>{{general-date this.model.startsAt 'date-time-tz-long' tz=this.model.timezone}}</h4>
             {{#if this.displayEndDate}}
               <h5 class="event time ends" style={{this.vietnameseFontFamily}}>{{t 'To'}} {{general-date this.model.endsAt 'date-time-tz-long' tz=this.model.timezone}}</h5>


### PR DESCRIPTION
Fixes #8029 
![Screenshot 2022-01-12 at 14-00-14 Speakers Netzwerktag 2021 der OSB Alliance eventyay](https://user-images.githubusercontent.com/42090582/149102270-0beb0de2-c0c4-482f-ad31-ec0d92240ffb.png)
![Screenshot 2022-01-12 at 14-01-14 Speakers OSBA Members Products Special Schweiz eventyay](https://user-images.githubusercontent.com/42090582/149102341-555f0bb6-c1ab-4a2b-a0a6-5699f533fac5.png)

**Mobile view**

![Screen Shot 2022-01-12 at 13 55 46](https://user-images.githubusercontent.com/42090582/149102391-0da24274-ff67-46d5-8900-13d21f42aec0.png)
![Screen Shot 2022-01-12 at 14 01 40](https://user-images.githubusercontent.com/42090582/149102421-fbbcb577-6411-44bd-8eab-35f56079d5d4.png)
