### PR TITLE
Reduce area occupied by time and search field on schedule page

### DIFF
--- a/app/components/tables/utilities/expandable-search-box.js
+++ b/app/components/tables/utilities/expandable-search-box.js
@@ -1,0 +1,26 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { debounce } from '@ember/runloop';
+import classic from 'ember-classic-decorator';
+
+@classic
+export default class ExpandableSearchBox extends Component {
+
+  debouncePeriod = 1000 // 1 second
+  isExpanded = false
+
+  setSearchQueryLazily(value) {
+    this.set('searchQuery', value);
+  }
+
+  @action
+  toggleSearch() {
+    this.toggleProperty('isExpanded');
+  }
+
+  @action
+  setSearchQuery(value) {
+    debounce(this, this.setSearchQueryLazily, value, this.debouncePeriod);
+  }
+
+}

--- a/app/styles/libs/_helpers.scss
+++ b/app/styles/libs/_helpers.scss
@@ -1,4 +1,5 @@
 $font-weights: 100 200 300 400 500 600 700 800 900;
+
 @each $font-weight in $font-weights {
   .weight-#{$font-weight} {
     font-weight: $font-weight !important;
@@ -6,6 +7,7 @@ $font-weights: 100 200 300 400 500 600 700 800 900;
 }
 
 $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
+
 @each $spacer-height in $spacer-heights {
   .spacer-#{$spacer-height} {
     min-height: $spacer-height + px !important;
@@ -29,6 +31,7 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
 }
 
 @media only screen and (max-width: 767px) {
+
   .mobile.hidden,
   .tablet.only,
   .small.monitor.only,
@@ -36,7 +39,9 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     display: none !important;
   }
 }
+
 @media only screen and (min-width: 768px) and (max-width: 991px) {
+
   .mobile.only,
   .tablet.hidden,
   .small.monitor.only,
@@ -44,7 +49,9 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     display: none !important;
   }
 }
+
 @media only screen and (min-width: 992px) and (max-width: 1199px) {
+
   .mobile.only,
   .tablet.only,
   .small.monitor.hidden,
@@ -52,7 +59,9 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     display: none !important;
   }
 }
+
 @media only screen and (min-width: 1200px) {
+
   .mobile.only,
   .tablet.only,
   .small.monitor.only,
@@ -189,6 +198,7 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
     color: inherit;
   }
 }
+
 @media only screen and (max-width: 767px) {
   .menu-fixed {
     position: fixed !important;
@@ -214,4 +224,142 @@ $spacer-heights: 50 100 200 300 400 500 600 700 800 900;
   .hide-detail {
     display: none;
   }
+}
+
+.w-1-2 {
+  width: 50% !important;
+}
+
+.w-1-3 {
+  width: 33.3333333333% !important;
+}
+
+.w-2-3 {
+  width: 66.6666666667% !important;
+}
+
+.w-1-4 {
+  width: 25% !important;
+}
+
+.w-3-4 {
+  width: 75% !important;
+}
+
+.w-1-5 {
+  width: 20% !important;
+}
+
+.w-2-5 {
+  width: 40% !important;
+}
+
+.w-3-5 {
+  width: 60% !important;
+}
+
+.w-4-5 {
+  width: 80% !important;
+}
+
+.max-w-1-2 {
+  max-width: 50% !important;
+}
+
+.max-w-1-3 {
+  max-width: 33.3333333333% !important;
+}
+
+.max-w-2-3 {
+  max-width: 66.6666666667% !important;
+}
+
+.max-w-1-4 {
+  max-width: 25% !important;
+}
+
+.max-w-3-4 {
+  max-width: 75% !important;
+}
+
+.max-w-1-5 {
+  max-width: 20% !important;
+}
+
+.max-w-2-5 {
+  max-width: 40% !important;
+}
+
+.max-w-3-5 {
+  max-width: 60% !important;
+}
+
+.max-w-4-5 {
+  max-width: 80% !important;
+}
+
+.expanded {
+  width: 100%;
+  transition: width .3s ease-in-out;
+}
+
+.half-collapsed {
+  width: 50%;
+  transition: width .3s ease-in-out;
+}
+
+.min-w-1-2 {
+  min-width: 50% !important;
+}
+
+.min-w-1-3 {
+  min-width: 33.3333333333% !important;
+}
+
+.min-w-2-3 {
+  min-width: 66.6666666667% !important;
+}
+
+.min-w-1-4 {
+  min-width: 25% !important;
+}
+
+.min-w-3-4 {
+  min-width: 75% !important;
+}
+
+.min-w-1-5 {
+  min-width: 20% !important;
+}
+
+.min-w-2-5 {
+  min-width: 40% !important;
+}
+
+.min-w-3-5 {
+  min-width: 60% !important;
+}
+
+.min-w-4-5 {
+  min-width: 80% !important;
+}
+
+.min-w-1-6 {
+  min-width: 16.6666666667% !important;
+}
+
+.min-w-5-6 {
+  min-width: 83.3333333333% !important;
+}
+
+.gap {
+  gap: .25rem;
+}
+
+.gap-2 {
+  gap: .5rem;
+}
+
+.gap-3 {
+  gap: .75rem;
 }

--- a/app/templates/components/tables/utilities/expandable-search-box.hbs
+++ b/app/templates/components/tables/utilities/expandable-search-box.hbs
@@ -1,0 +1,16 @@
+<div
+  ...attributes
+  class="ui icon input transition
+    {{if (eq @size 'large') '' 'small'}}
+    {{if isExpanded 'expanded' 'half-collapsed'}}"
+>
+  <Input
+    @type="text"
+    @value={{readonly this.searchQuery}}
+    @keyUp={{action "setSearchQuery" value="target.value"}}
+    placeholder="{{t 'Search'}} ..."
+    @focusOut={{action "toggleSearch"}}
+    @focusIn={{action "toggleSearch"}}
+  />
+  <i class="search icon"></i>
+</div>

--- a/app/templates/public/sessions.hbs
+++ b/app/templates/public/sessions.hbs
@@ -1,84 +1,152 @@
-<div class="{{if this.device.isMobile 'mt--8' 'd-flex'}}" style="align-items: center;">
+<div
+  class="{{if this.device.isMobile 'mt--8' 'd-flex'}}"
+  style="align-items: center;"
+>
   <div class="d-flex wrap mb-4 items-center">
-    <h1 class="m-0 mr-4 ui header" id="session-heading">{{t 'Schedule'}}</h1>
+    <h1 class="m-0 mr-4 ui header" id="session-heading">{{t "Schedule"}}</h1>
     <div>
       <LinkTo @route="public.schedule" class="ui button">
-        {{t 'Calendar View'}}
+        {{t "Calendar View"}}
       </LinkTo>
     </div>
   </div>
-    {{#if this.session.isAuthenticated}}
-      <LinkTo
-        class="{{if this.device.isMobile '' 'right floated ml-auto mb-4'}} rounded-default link-item ui p-1 mr-4 {{if (not (or this.my_schedule this.my_speaker_sessions)) 'active'}}"
-        @route="public.sessions"
-        @models={{array this.model.event.id}}
-        @query={{hash my_schedule=null my_speaker_sessions=null}}>
-        <h4>{{t 'Public Schedule'}}</h4>
-      </LinkTo>
-      <LinkTo
-        class="rounded-default link-item ui right floated p-1 mr-4 {{if this.device.isMobile '' 'mb-4'}} {{if this.my_schedule 'active'}}"
-        @route="public.sessions"
-        @models={{array this.model.event.id}}
-        @query={{hash my_schedule=true my_speaker_sessions=null}}>
-        <h4>{{t 'My Schedule'}}</h4>
-      </LinkTo>
-      <LinkTo
-        class="rounded-default link-item ui right floated p-1 mb-4 {{if (eq this.params.my_speaker_sessions true) 'active'}}"
-        @route="public.sessions"
-        @models={{array this.model.event.id}}
-        @query={{hash my_speaker_sessions=true my_schedule=null}}>
-        <h4>{{t 'My Speaker Sessions'}}</h4>
-      </LinkTo> 
-    {{/if}}
+  {{#if this.session.isAuthenticated}}
+    <LinkTo
+      class="{{if this.device.isMobile '' 'right floated ml-auto mb-4'}}
+        rounded-default link-item ui p-1 mr-4
+        {{if (not (or this.my_schedule this.my_speaker_sessions)) 'active'}}"
+      @route="public.sessions"
+      @models={{array this.model.event.id}}
+      @query={{hash my_schedule=null my_speaker_sessions=null}}
+    >
+      <h4>{{t "Public Schedule"}}</h4>
+    </LinkTo>
+    <LinkTo
+      class="rounded-default link-item ui right floated p-1 mr-4
+        {{if this.device.isMobile '' 'mb-4'}}
+        {{if this.my_schedule 'active'}}"
+      @route="public.sessions"
+      @models={{array this.model.event.id}}
+      @query={{hash my_schedule=true my_speaker_sessions=null}}
+    >
+      <h4>{{t "My Schedule"}}</h4>
+    </LinkTo>
+    <LinkTo
+      class="rounded-default link-item ui right floated p-1 mb-4
+        {{if (eq this.params.my_speaker_sessions true) 'active'}}"
+      @route="public.sessions"
+      @models={{array this.model.event.id}}
+      @query={{hash my_speaker_sessions=true my_schedule=null}}
+    >
+      <h4>{{t "My Speaker Sessions"}}</h4>
+    </LinkTo>
+  {{/if}}
 </div>
 <div class="d-flex wrap">
-  <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=null}} class="ui button mb-2">{{t 'All'}}</LinkTo>
+  <LinkTo
+    @route="public.sessions"
+    @models={{array this.model.event.id}}
+    @query={{hash date=null}}
+    class="ui button mb-2"
+  >{{t "All"}}</LinkTo>
   {{#each this.allDates as |date|}}
-    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash date=(moment-format date "YYYY-MM-DD")}} class="ui button mb-2">{{general-date date 'date-short'}}</LinkTo>
+    <LinkTo
+      @route="public.sessions"
+      @models={{array this.model.event.id}}
+      @query={{hash date=(moment-format date "YYYY-MM-DD")}}
+      class="ui button mb-2"
+    >{{general-date date "date-short"}}</LinkTo>
   {{/each}}
-  <div class={{if this.device.isMobile "" "d-flex content-end wrap ml-auto"}}>
-    <Widgets::TimeZonePicker
-      class="mb-2 mr-2 {{if this.device.isMobile 'w-140' 'w-90'}}"
-      @defaultLocal={{this.model.event.online}}
-      @eventTimezone={{this.model.event.timezone}}
-      @timezone={{this.timezone}} />
+  <div
+    class={{if this.device.isMobile "w-full" "d-flex content-end wrap ml-auto"}}
+  >
+    <div
+      class="d-flex mb-2 mr-2 gap
+        {{if this.device.isMobile 'w-full space-between' 'content-end wrap'}}"
+    >
+      <Tables::Utilities::ExpandableSearchBox
+        @searchQuery={{this.search}}
+        @size="large"
+        class="d-flex {{if this.device.isMobile '' 'content-end'}}"
+      />
 
-    <Tables::Utilities::SearchBox
-      class="mb-2 mr-2 {{if this.device.isMobile 'w-140' 'w-90'}}"
-      @searchQuery={{this.search}}
-      @size="large"
-    />
+      <Widgets::TimeZonePicker
+        class="{{if this.device.isMobile 'max-w-1-5 min-w-1/2' 'w-90'}}"
+        @defaultLocal={{this.model.event.online}}
+        @eventTimezone={{this.model.event.timezone}}
+        @timezone={{this.timezone}}
+      />
+
+    </div>
 
     <UiDropdown class="labeled icon button mb-2 mr-2 pb-2">
       <i class="sort amount down icon"></i>
       <span class="default text">{{this.sortTitle}}</span>
       <div class="menu">
-        <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash sort='title'}} class="item">{{t 'By Title'}}</LinkTo>
-        <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash sort='starts-at'}} class="item">{{t 'By Time'}}</LinkTo>
-        <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash sort='-favourite-count'}} class="item">{{t 'By Popularity'}}</LinkTo>
+        <LinkTo
+          @route="public.sessions"
+          @models={{array this.model.event.id}}
+          @query={{hash sort="title"}}
+          class="item"
+        >{{t "By Title"}}</LinkTo>
+        <LinkTo
+          @route="public.sessions"
+          @models={{array this.model.event.id}}
+          @query={{hash sort="starts-at"}}
+          class="item"
+        >{{t "By Time"}}</LinkTo>
+        <LinkTo
+          @route="public.sessions"
+          @models={{array this.model.event.id}}
+          @query={{hash sort="-favourite-count"}}
+          class="item"
+        >{{t "By Popularity"}}</LinkTo>
       </div>
     </UiDropdown>
-    <LinkTo @route="public.sessions" @models={{array this.model.event.id}} @query={{hash sort='starts-at' date=null search=null track=null sessionType=null room=null my_speaker_sessions=null my_schedule=null}} @invokeAction={{action this.removeActiveClass}} data-tooltip="{{t 'Clear All Filters'}}" class="pb-2 pt-2 ui button mb-2">
+    <LinkTo
+      @route="public.sessions"
+      @models={{array this.model.event.id}}
+      @query={{hash
+        sort="starts-at"
+        date=null
+        search=null
+        track=null
+        sessionType=null
+        room=null
+        my_speaker_sessions=null
+        my_schedule=null
+      }}
+      @invokeAction={{action this.removeActiveClass}}
+      data-tooltip="{{t 'Clear All Filters'}}"
+      class="pb-2 pt-2 ui button mb-2"
+    >
       <i><Icons::ClearFilter /></i>
     </LinkTo>
   </div>
 </div>
-{{!-- To be enabled and developed on later --}}
-{{#if this.isTrackVisible}} 
+{{! To be enabled and developed on later }}
+{{#if this.isTrackVisible}}
   {{#each this.model.session as |session|}}
     <div class="ui grid">
       <div class="three wide column">
-        {{general-date session.startsAt 'hh:mm a' tz=session.event.timezone}} - 
-        {{general-date session.endsAt 'hh:mm a' tz=session.event.timezone}}
+        {{general-date session.startsAt "hh:mm a" tz=session.event.timezone}}
+        -
+        {{general-date session.endsAt "hh:mm a" tz=session.event.timezone}}
       </div>
       <div class="thirteen wide column">
         <Public::TrackItem @session={{session}} />
       </div>
     </div>
   {{else}}
-    <div class="ui disabled header">{{t 'No Sessions exist for this time period'}}</div>
+    <div class="ui disabled header">{{t
+        "No Sessions exist for this time period"
+      }}</div>
   {{/each}}
-  <InfinityLoader @infinityModel={{this.model.session}} @triggerOffset={{1000}} @eventDebounce={{50}}>
+  <InfinityLoader
+    @infinityModel={{this.model.session}}
+    @triggerOffset={{1000}}
+    @eventDebounce={{50}}
+  >
     <div class="center aligned five wide column">
       <div class="ui loading very padded basic segment">
       </div>
@@ -87,45 +155,67 @@
 {{/if}}
 <div class="mt-8">
   {{#if this.model.session}}
-  {{#each this.groupByDateSessions key="date" as |group|}}
-    <h3 class="ui header {{if this.device.isMobile 'mb--8' 'mb--4'}}">
-      {{#if (not-eq group.date "Invalid date")}}
-        {{group.date}}
-      {{else}}
-        {{t 'Not yet scheduled'}}
-      {{/if}}
-    </h3>
-    <table class="ui very basic fixed table">
-      <thead class="full-width">
-        <tr>
-          <th class="two wide" style="border: none;"></th>
-          <th style="border: none;"></th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each group.sessions key="createdAt" as |session|}}
+    {{#each this.groupByDateSessions key="date" as |group|}}
+      <h3 class="ui header {{if this.device.isMobile 'mb--8' 'mb--4'}}">
+        {{#if (not-eq group.date "Invalid date")}}
+          {{group.date}}
+        {{else}}
+          {{t "Not yet scheduled"}}
+        {{/if}}
+      </h3>
+      <table class="ui very basic fixed table">
+        <thead class="full-width">
           <tr>
-            <td class="top aligned {{unless this.device.isMobile 'centered text'}}" style="border-top: none;">
-              <h4 class="ui header {{unless this.device.isMobile 'pt-4'}}">
-                {{#if session.startsAt}}
-                  {{general-date session.startsAt 'time-tz-short' tz=this.timezone}}
-                {{else}}
-                  {{t 'Not yet scheduled'}}
-                {{/if}}
-              </h4>
-            </td>
-            <td style="border-top: none; border-left: 1px solid lightgrey; overflow: visible;">
-              <Public::SessionItem @session={{session}} @event={{this.model.event}} @timezone={{this.timezone}} @showFavButton={{true}} @sameTab={{this.side_panel}} />
-            </td>
+            <th class="two wide" style="border: none;"></th>
+            <th style="border: none;"></th>
           </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  {{/each}}
+        </thead>
+        <tbody>
+          {{#each group.sessions key="createdAt" as |session|}}
+            <tr>
+              <td
+                class="top aligned
+                  {{unless this.device.isMobile 'centered text'}}"
+                style="border-top: none;"
+              >
+                <h4 class="ui header {{unless this.device.isMobile 'pt-4'}}">
+                  {{#if session.startsAt}}
+                    {{general-date
+                      session.startsAt
+                      "time-tz-short"
+                      tz=this.timezone
+                    }}
+                  {{else}}
+                    {{t "Not yet scheduled"}}
+                  {{/if}}
+                </h4>
+              </td>
+              <td
+                style="border-top: none; border-left: 1px solid lightgrey; overflow: visible;"
+              >
+                <Public::SessionItem
+                  @session={{session}}
+                  @event={{this.model.event}}
+                  @timezone={{this.timezone}}
+                  @showFavButton={{true}}
+                  @sameTab={{this.side_panel}}
+                />
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{/each}}
   {{else}}
-    <div class="ui disabled header">{{t 'No Sessions exist for this time period'}}</div>
-  {{/if}}    
-  <InfinityLoader @infinityModel={{this.model.session}} @triggerOffset={{100}} @eventDebounce={{200}}>
+    <div class="ui disabled header">{{t
+        "No Sessions exist for this time period"
+      }}</div>
+  {{/if}}
+  <InfinityLoader
+    @infinityModel={{this.model.session}}
+    @triggerOffset={{100}}
+    @eventDebounce={{200}}
+  >
     <div class="center aligned five wide column">
       <div class="ui loading very padded basic segment">
       </div>

--- a/tests/integration/components/expandable-search-box-test.js
+++ b/tests/integration/components/expandable-search-box-test.js
@@ -1,0 +1,39 @@
+import { click, fillIn, find, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | expandable-search-box', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it expands and collapses on search icon click', async function(assert) {
+    await render(hbs`<ExpandableSearchBox />`);
+
+    const containerElement = find('.ui.input');
+    const inputElement = find('input');
+
+    assert.notOk(containerElement.classList.contains('expanded'), 'Input field is initially collapsed');
+
+    await click(inputElement);
+
+    assert.ok(
+      containerElement.classList.contains('expanded')
+      , 'Input field is expanded after click');
+
+    await click('body');
+
+    assert.notOk(containerElement.classList.contains('expanded'), 'Input field is collapsed after out focus');
+  });
+
+  test('it updates the search query', async function(assert) {
+    await render(hbs`<ExpandableSearchBox @searchQuery={{this.searchQuery}} />`);
+
+    const inputElement = find('input');
+    const searchQuery = 'example search query';
+
+    await click('.search.icon');
+    await fillIn(inputElement, searchQuery);
+
+    assert.equal(this.searchQuery, searchQuery, 'Search query is updated');
+  });
+});


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Resolves  #8757 Reduce area occupied by time and search field on schedule page

#### Short description of what this resolves:
- Change Seach box behaviour
- Search and time occupied 1 instead of 2 rows

#### Changes proposed in this pull request:

- Search Box Input which will take whole area to shorter version of it. When use focus, it will expand to original.
- Search Box and Timezone place in 1 row on mobile screen instead of 2. These components is space between each others

**BEFORE**
![image](https://github.com/fossasia/open-event-frontend/assets/77144199/51663402-3635-42b0-b5e7-c77dadd0a6b0)

**AFTER**
![image](https://github.com/fossasia/open-event-frontend/assets/77144199/d96cc16e-5444-42f1-86fa-a8c48d2f5419)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
