### PR TITLE
fix-8667: Mastodon link is wrong

### DIFF
--- a/app/utils/dictionary/social-media.ts
+++ b/app/utils/dictionary/social-media.ts
@@ -10,7 +10,8 @@ export const socialMediaIdentifiers = socialMediaNames.map(name => {
 
 const prefixOverrides: { [key: string]: string } = {
   'gitter'   : 'https://gitter.im/',
-  'telegram' : 'https://t.me/'
+  'telegram' : 'https://t.me/',
+  'mastodon' : 'https://'
 };
 
 export interface SocialMedia {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8667 

#### Short description of what this resolves:
Mastodon link is wrong

#### Changes proposed in this pull request:
Replace link Mastodon from "https://mastodon.com" to "https;//"

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
