### PR TITLE
fix-7984:Show test/live key of Stripe under Payments section

### DIFF
--- a/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
+++ b/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
@@ -31,7 +31,6 @@
           @current={{this.stripeMode}}
           @onChange={{action (mut this.stripeMode)}} />
       </div>
-    
       <div class="field">
         <label>
           {{t 'Client Test ID'}}

--- a/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
+++ b/app/templates/components/forms/admin/settings/payment-gateway-form.hbs
@@ -22,15 +22,16 @@
     <h5 class="ui header">
       {{t 'Stripe Integration Mode'}}
     </h5>
-    <div class="field">
-      <UiRadio
-        @label={{t "Test mode - Used during development and testing"}}
-        @name="stripe_integration_mode"
-        @value="debug"
-        @current={{this.stripeMode}}
-        @onChange={{action (mut this.stripeMode)}} />
-    </div>
     {{#if (eq this.stripeMode 'debug')}}
+      <div class="field">
+        <UiRadio
+          @label={{t "Test mode - Used during development and testing"}}
+          @name="stripe_integration_mode"
+          @value="debug"
+          @current={{this.stripeMode}}
+          @onChange={{action (mut this.stripeMode)}} />
+      </div>
+    
       <div class="field">
         <label>
           {{t 'Client Test ID'}}
@@ -71,6 +72,7 @@
           @value={{this.settings.stripeTestPublishableKey}} />
       </div>
     {{/if}}
+    {{#if (eq this.stripeMode 'production')}}
     <div class="ui hidden divider"></div>
     <div class="field">
       <UiRadio
@@ -80,7 +82,6 @@
         @current={{this.stripeMode}}
         @onChange={{action (mut this.stripeMode)}} />
     </div>
-    {{#if (eq this.stripeMode 'production')}}
       <div class="field">
         <label>
           {{t 'Client ID'}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7984

#### Short description of what this resolves:
Show test/live key of Stripe under Payments section

#### Changes proposed in this pull request:
Load the key for Stripe under the Payments section, depending on the environment.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
