### PR TITLE
Run CI actions with Node 18 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-node@v1
       if: steps.cache.outputs.cache-hit != 'true'
       with:
-        node-version: 14.x
+        node-version: 18.x
     - run: yarn
       if: steps.cache.outputs.cache-hit != 'true'
   
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - uses: actions/cache@v2
         id: cache
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - uses: actions/cache@v2
         id: cache
         with:
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - uses: actions/cache@v2
         id: cache
         with:


### PR DESCRIPTION

Fixes #8705 

#### Short description of what this resolves:

Use Node 18 LTS for running CI actions

#### Changes proposed in this pull request:

- select higher node version for CI runner

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
