### PR TITLE
feature-8787: Change the "age" field of the custom form

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -591,7 +591,7 @@ export default Component.extend(FormMixin, {
   }),
 
   genders   : orderBy(genders, 'name'),
-  ageGroups : orderBy(ageGroups, 'age'),
+  ageGroups : orderBy(ageGroups, 'position'),
   countries : orderBy(countries, 'name'),
   years     : orderBy(years, 'year'),
 

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -174,7 +174,7 @@
                     <div class="menu">
                       {{#each this.ageGroups as |ageGroup|}}
                         <div class="item" data-value="{{map-value mapper ageGroup.age}}">
-                          {{ageGroup.age}}
+                          {{t ageGroup.age}}
                         </div>
                       {{/each}}
                     </div>

--- a/app/utils/dictionary/age-groups.ts
+++ b/app/utils/dictionary/age-groups.ts
@@ -1,17 +1,44 @@
+import { tn } from '../text';
+
 export const ageGroups = [
   {
-    age: '19 or less'
+    age: tn.t('Under 18'),
+    position: 1
   },
   {
-    age: '20 to 29'
+    age: '18-24',
+    position: 2
   },
   {
-    age: '30 to 39'
+    age: '25-34',
+    position: 3
   },
   {
-    age: '40 to 49'
+    age: '35-44',
+    position: 4
   },
   {
-    age: '50 or above'
+    age: '45-54',
+    position: 5
+  },
+  {
+    age: '55-64',
+    position: 6
+  },
+  {
+    age: '65-74',
+    position: 7
+  },
+  {
+    age: '75-84',
+    position: 8
+  },
+  {
+    age: '85+',
+    position: 9
+  },
+  {
+    age: tn.t('I prefer not to say'),
+    position: 10
   }
 ];

--- a/translations/ar.po
+++ b/translations/ar.po
@@ -11586,3 +11586,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Menores de 18 años"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/bn.po
+++ b/translations/bn.po
@@ -11150,3 +11150,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Bawah 18 tahun"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/de.po
+++ b/translations/de.po
@@ -12260,3 +12260,11 @@ msgstr "Malaysischer Ringgit"
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr "Schweizer Franken"
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Unter 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/de_DIVEO.po
+++ b/translations/de_DIVEO.po
@@ -11827,3 +11827,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/en.po
+++ b/translations/en.po
@@ -11595,3 +11595,11 @@ msgstr "Malaysian ringgit"
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr "Swiss franc"
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Under 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr "I prefer not to say"

--- a/translations/es.po
+++ b/translations/es.po
@@ -11826,3 +11826,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Menores de 18 años"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -12352,3 +12352,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Moins de 18 ans"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/hi.po
+++ b/translations/hi.po
@@ -11860,3 +11860,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "18 के नीचे"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/id.po
+++ b/translations/id.po
@@ -11831,3 +11831,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Dibawah 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -11838,3 +11838,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "18歳以下"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -11845,3 +11845,11 @@ msgstr "말레이시아 링깃"
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr "스위스 프랑"
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "18세 미만"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -11586,3 +11586,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/nb_NO.po
+++ b/translations/nb_NO.po
@@ -11830,3 +11830,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -11827,3 +11827,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "poniżej 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -11835,3 +11835,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "До 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -11831,3 +11831,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Menores de 18 años"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/th.po
+++ b/translations/th.po
@@ -11827,3 +11827,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "ต่ำกว่า 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/vi.po
+++ b/translations/vi.po
@@ -11827,3 +11827,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "Dưới 18"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/zh_Hans.po
+++ b/translations/zh_Hans.po
@@ -11832,3 +11832,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "18岁以下"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""

--- a/translations/zh_Hant.po
+++ b/translations/zh_Hant.po
@@ -11832,3 +11832,11 @@ msgstr ""
 #: app/utils/dictionary/payment.ts:261:13
 msgid "Swiss franc"
 msgstr ""
+
+#: app/utils/dictionary/age-groups.ts:5:9
+msgid "Under 18"
+msgstr "18歲以下"
+
+#: app/utils/dictionary/age-groups.ts:41:9
+msgid "I prefer not to say"
+msgstr ""


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8787

#### Short description of what this resolves:
- Change the "age" field of the custom form

#### Changes proposed in this pull request:

- Change the age field of the custom form and display the following options:
`
    18-24; 
    25-34;
    35-44;
    45-54;
    55-64;
    65-74;
    75-84;
    85+;
    I prefer not to say;`

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
