### PR TITLE
feature-8787:add translate for the age field of the custom form

### DIFF
--- a/translations/ar.po
+++ b/translations/ar.po
@@ -11589,7 +11589,7 @@ msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:5:9
 msgid "Under 18"
-msgstr "Menores de 18 años"
+msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"

--- a/translations/bn.po
+++ b/translations/bn.po
@@ -11153,8 +11153,8 @@ msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:5:9
 msgid "Under 18"
-msgstr "Bawah 18 tahun"
+msgstr "18 এর নিচে"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "আমি না বলতে পছন্দ করি"

--- a/translations/de.po
+++ b/translations/de.po
@@ -12267,4 +12267,4 @@ msgstr "Unter 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Ich sage es lieber nicht"

--- a/translations/de_DIVEO.po
+++ b/translations/de_DIVEO.po
@@ -11830,8 +11830,8 @@ msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:5:9
 msgid "Under 18"
-msgstr ""
+msgstr "Unter 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Ich sage es lieber nicht"

--- a/translations/es.po
+++ b/translations/es.po
@@ -11833,4 +11833,4 @@ msgstr "Menores de 18 años"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "prefiero no decir"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -12359,4 +12359,4 @@ msgstr "Moins de 18 ans"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Je préfère ne pas dire"

--- a/translations/hi.po
+++ b/translations/hi.po
@@ -11867,4 +11867,4 @@ msgstr "18 के नीचे"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "मैं न कहना पसंद करता हूँ"

--- a/translations/id.po
+++ b/translations/id.po
@@ -11838,4 +11838,4 @@ msgstr "Dibawah 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Saya lebih suka tidak mengatakannya"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -11845,4 +11845,4 @@ msgstr "18歳以下"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "言わない方がいいです"

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -11852,4 +11852,4 @@ msgstr "18세 미만"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "나는 말하지 않는 것을 선호한다"

--- a/translations/nb_NO.po
+++ b/translations/nb_NO.po
@@ -11833,8 +11833,8 @@ msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:5:9
 msgid "Under 18"
-msgstr ""
+msgstr "Under 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Jeg foretrekker å ikke si"

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -11834,4 +11834,4 @@ msgstr "poniżej 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "wolę nie mówić"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -11842,4 +11842,4 @@ msgstr "До 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "я предпочитаю не говорить"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -11834,8 +11834,8 @@ msgstr ""
 
 #: app/utils/dictionary/age-groups.ts:5:9
 msgid "Under 18"
-msgstr "Menores de 18 años"
+msgstr "Under 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Jag föredrar att inte säga"

--- a/translations/th.po
+++ b/translations/th.po
@@ -11834,4 +11834,4 @@ msgstr "ต่ำกว่า 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "ฉันไม่ต้องการพูด"

--- a/translations/vi.po
+++ b/translations/vi.po
@@ -11834,4 +11834,4 @@ msgstr "Dưới 18"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "Tôi không muốn nói"

--- a/translations/zh_Hans.po
+++ b/translations/zh_Hans.po
@@ -11839,4 +11839,4 @@ msgstr "18岁以下"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "我宁愿不说"

--- a/translations/zh_Hant.po
+++ b/translations/zh_Hant.po
@@ -11839,4 +11839,4 @@ msgstr "18歲以下"
 
 #: app/utils/dictionary/age-groups.ts:41:9
 msgid "I prefer not to say"
-msgstr ""
+msgstr "我寧願不說"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8787

#### Short description of what this resolves:
Add translate for the age field of the custom form
#### Changes proposed in this pull request:
Add translate for the age field of the custom form

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
