### PR TITLE
feature-8818: Custom field in Attendee form should have the include value is True as default

### DIFF
--- a/app/components/forms/wizard/custom-form-input.ts
+++ b/app/components/forms/wizard/custom-form-input.ts
@@ -77,7 +77,7 @@ export default class CustomFormInput extends Component<Args> {
       form            : this.args.form,
       type            : this.type,
       isRequired      : false,
-      isIncluded      : false,
+      isIncluded      : true,
       isComplex       : true,
       event           : this.args.event,
       formID          : this.args.formIdentifier,


### PR DESCRIPTION
Custom field in Attendee form should have the include value is True as default

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8818

#### Short description of what this resolves:
- Custom field in Attendee form should have the include value is True as default

#### Changes proposed in this pull request:

- Set isIncluded for customer field is true.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
