### PR TITLE
fix-8833:Additional custom form disappears in attendee form setup

### DIFF
--- a/app/routes/events/view/edit/attendee.js
+++ b/app/routes/events/view/edit/attendee.js
@@ -23,7 +23,7 @@ export default class AttendeeRoute extends Route.extend(CustomFormMixin) {
       customForms : (await event.query('customForms', {
         filter       : filterOptions,
         sort         : 'id',
-        'page[size]' : 50
+        'page[size]' : 500
       })).toArray().filter(field => field.form === 'attendee')
     };
     return data;

--- a/app/routes/orders/pending.js
+++ b/app/routes/orders/pending.js
@@ -21,11 +21,32 @@ export default class PendingRoute extends Route {
       reload  : true
     });
     const eventDetails = await order.query('event', { include: 'tax' });
+    const tickets     = await order.query('tickets', {});
+    const filterOptions = [
+      {
+        or: []
+      }
+    ];
+    tickets.forEach(ticket => {
+      filterOptions[0].or.pushObject({
+        name : 'form_id',
+        op   : 'eq',
+        val  : ticket.formID
+      });
+    });
+
+    filterOptions[0].or.pushObject({
+      name : 'is_required',
+      op   : 'eq',
+      val  : true
+    });
+
     return {
       order,
       event : eventDetails,
       form  : await eventDetails.query('customForms', {
-        'page[size]' : 70,
+        filter       : filterOptions,
+        'page[size]' : 700,
         sort         : 'id'
       })
     };


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8833

#### Short description of what this resolves:
Display custom form when adding 2 or more custom

#### Changes proposed in this pull request:
Fix bug "when an organizer creates a second custom the standard and custom questions disappear when the user loads the form again."

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
