### PR TITLE
fix for #8842: genders are displayed in the ticket confirmation

### DIFF
--- a/app/components/forms/orders/attendee-list.js
+++ b/app/components/forms/orders/attendee-list.js
@@ -25,6 +25,9 @@ export default class AttendeeList extends Component {
       if (attendee.language_form_2) {
         this.languageFormMapCodeToName(attendee, 'language_form_2');
       }
+      if (attendee.gender) {
+        this.genderAddSpaces(attendee);
+      }
     });
     return this.data.attendees;
   }
@@ -40,6 +43,10 @@ export default class AttendeeList extends Component {
       });
     });
     return attendee.set(key.concat('_name_mapping'), languageFormMap.map(select => select).join(', '));
+  }
+
+  genderAddSpaces(attendee) {
+    return attendee.set('gender'.concat('_name_mapping'), attendee.gender.split(',').join(', '));
   }
 
   @or('event.isBillingInfoMandatory', 'data.isBillingEnabled')

--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -701,8 +701,8 @@ export default Component.extend(FormMixin, {
     updateLanguageFormsSelection(checked, changed, selectedOptions, holder, field) {
       holder.set(field.fieldIdentifier, selectedOptions.map(select => select.value).join(','));
     },
-    updateGendersSelection(checked, changed, selectedOptions, entity, field) {
-      entity.set(field.fieldIdentifier, selectedOptions.map(select => select.value).join(','));
+    updateGendersSelection(checked, changed, selectedOptions, holder, field) {
+      holder.set(field.fieldIdentifier, selectedOptions.map(select => select.value).join(','));
     }
   }
 });

--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -383,7 +383,7 @@ export default Component.extend(FormMixin, {
 
   languages: orderBy(languages, 'name'),
 
-  genders: orderBy(genders, 'name'),
+  genders: orderBy(genders, 'position'),
 
   levels: orderBy(levels, 'position'),
 

--- a/app/components/forms/speaker-section.js
+++ b/app/components/forms/speaker-section.js
@@ -6,5 +6,5 @@ import { orderBy } from 'lodash-es';
 
 export default Component.extend(FormMixin, {
   countries : orderBy(countries, 'name'),
-  genders   : orderBy(genders, 'name')
+  genders   : orderBy(genders, 'position')
 });

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -125,7 +125,7 @@
                   <Widgets::Forms::UiCheckboxGroup 
                     @options={{genders}}
                     @onChange={{action "updateGendersSelection"}}
-                    @entity={{holder}}
+                    @holder={{holder}}
                     @field={{field}}
                   />
                 {{else if (eq field.fieldIdentifier 'country')}}


### PR DESCRIPTION
Closes #8842 

The bug described by @lthanhhieu that got caused by a merge conflict with some other changes in attendee-list.js is resolved now. The selected genders are again displayed correctly. This time even better: with spaces after the commas.

![Screenshot_20230630_185942](https://github.com/fossasia/open-event-frontend/assets/127369686/460700b8-54b4-49bf-b204-3fee35bad24d)

Additionally, the genders in the speaker section are now displayed in logical order, not ordered by alphabet, which makes the selection a lot easier & faster (same was already done to the gender selection in the attendee section before).

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
