### PR TITLE
fix #8886: attach sameAsBuyer option to every ticket holder

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -29,8 +29,8 @@ export default Component.extend(FormMixin, {
   buyerHasFirstName : readOnly('data.user.firstName'),
   buyerHasLastName  : readOnly('data.user.lastName'),
   holders           : computed('data.attendees', 'buyer', function() {
-    this.data.attendees.forEach((attendee, index) => {
-      if (index === 0 && this.buyerFirstName && this.buyerLastName) {
+    this.data.attendees.forEach(attendee => {
+      if (this.buyerFirstName && this.buyerLastName) {
         attendee.set('firstname', this.buyerFirstName);
         attendee.set('lastname', this.buyerLastName);
         attendee.set('email', this.buyer.get('email'));
@@ -48,9 +48,6 @@ export default Component.extend(FormMixin, {
       return false;
     }
     return true;
-  }),
-  sameAsBuyer: computed('data', function() {
-    return (this.buyerHasFirstName && this.buyerHasLastName);
   }),
 
   isBillingInfoNeeded: computed('event', 'data.isBillingEnabled', function() {
@@ -687,8 +684,9 @@ export default Component.extend(FormMixin, {
         this.sendAction('save', data);
       });
     },
-    modifyHolder(holder) {
-      if (this.sameAsBuyer) {
+    triggerSameAsBuyerOption(holder) {
+      holder.set('sameAsBuyer', !holder.sameAsBuyer);
+      if (holder.sameAsBuyer) {
         holder.set('firstname', this.buyerFirstName);
         holder.set('lastname', this.buyerLastName);
         holder.set('email', this.buyer.content.email);

--- a/app/models/attendee.js
+++ b/app/models/attendee.js
@@ -7,6 +7,7 @@ export default ModelBase.extend({
   /**
    * Attributes
    */
+  sameAsBuyer                 : attr('boolean', { defaultValue: true }),
   city                        : attr('string'),
   firstname                   : attr('string'),
   lastname                    : attr('string'),

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -56,14 +56,6 @@
         {{/if}}
       </h4>
       {{#each this.holders as |holder index|}}
-        {{#if (eq index 0)}}
-          <div class="field">
-            <UiCheckbox
-              @label={{t "Ticket holder is the same person as ticket buyer"}}
-              @checked={{this.sameAsBuyer}}
-              @onChange={{pipe-action (action (mut this.sameAsBuyer)) (action "modifyHolder" holder)}} />
-          </div>
-        {{/if}}
         <div class="inline field">
           <i class="user icon"></i>
           <label>
@@ -74,6 +66,12 @@
             {{/if}}
             {{inc index}}{{t ' -for- '}}{{holder.ticket.name}}
           </label>
+        </div>
+        <div class="field">
+          <UiCheckbox
+            @label={{t "Ticket holder is the same person as ticket buyer"}}
+            @checked={{holder.sameAsBuyer}}
+            @onChange={{action "triggerSameAsBuyerOption" holder}} />
         </div>
         {{#each this.allFields.attendee as |field index|}}
           {{#if field.isIncluded }}
@@ -101,7 +99,7 @@
                       @value={{mut (get holder field.identifierPath)}}
                       @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}} />
                   {{else}}
-                    {{#if (and this.sameAsBuyer (eq index 0) (or (eq field.fieldIdentifier 'firstname') (eq field.fieldIdentifier 'lastname') (eq field.fieldIdentifier 'email')))}}
+                    {{#if (and holder.sameAsBuyer (or (eq field.fieldIdentifier 'firstname') (eq field.fieldIdentifier 'lastname') (eq field.fieldIdentifier 'email')))}}
                       <Input
                         @type={{field.type}}
                         @value={{mut (get holder field.identifierPath)}}
@@ -114,7 +112,6 @@
                         @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}} 
                         @min={{if field.min field.min null}} @max={{if field.max field.max null}}/>
                     {{else}}
-                    
                       <Input
                         @type={{field.type}}
                         @value={{mut (get holder field.identifierPath)}}


### PR DESCRIPTION
Fixes #8886

#### Short description of what this resolves:

There was only one "Ticket holder is the same person as the ticket buyer" box for all the ticket holders when buying multiple tickets at one. This is not only highly impractically (considering that when buying multiple tickets, people often buy one for themselves and some more for others). It was also linked to some other problems, like the e-mail adress fields of the second (,third,...) ticket not being editable, once the user wants to use the buyer's data for the first ticket holder.

![250156690-fadd0a54-ec7d-4ade-af48-39804994eb7a](https://github.com/fossasia/open-event-frontend/assets/127369686/c07adce4-1e10-476b-afb2-9b6e00f44632)

![250156688-fbd3f86c-7e78-4599-8718-5e41ec016a00](https://github.com/fossasia/open-event-frontend/assets/127369686/a771f802-a3b1-469c-9fc3-789d79ce7743)

#### Changes proposed in this pull request:

The bug is fixed by giving each ticket holder a "Ticket holder is the same person as the ticket buyer" option checkbox. This box is initially checked. When checked, the information (i.e.: e-mail, first name and last name) is copied from the buyer. The corresponding fields in this ticket holder's section are therefore in read-only mode (this was earlier only the case for the e-mail field, leading to inconsistent data entries).

![Screenshot_20230701_024528](https://github.com/fossasia/open-event-frontend/assets/127369686/c503ab13-6cfe-4c39-94de-749d08ffb09d)

However, for each of the ticket holders, it is now possible to uncheck this "Ticket holder is the same person as the ticket buyer" box. This clears those information fields (i.e. e-mail, first name and last name) for the ticket holder and makes them editable.

![Screenshot_20230701_024625](https://github.com/fossasia/open-event-frontend/assets/127369686/4ac2d289-66e7-4afb-8d52-001f243d0aa7)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
