### PR TITLE
fix #8905: initial deactivation of sameAsBuyer

### DIFF
--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -29,17 +29,6 @@ export default Component.extend(FormMixin, {
   buyerHasFirstName : readOnly('data.user.firstName'),
   buyerHasLastName  : readOnly('data.user.lastName'),
   holders           : computed('data.attendees', 'buyer', function() {
-    this.data.attendees.forEach(attendee => {
-      if (this.buyerFirstName && this.buyerLastName) {
-        attendee.set('firstname', this.buyerFirstName);
-        attendee.set('lastname', this.buyerLastName);
-        attendee.set('email', this.buyer.get('email'));
-      } else {
-        attendee.set('firstname', '');
-        attendee.set('lastname', '');
-        attendee.set('email', '');
-      }
-    });
     return this.data.attendees;
   }),
   isPaidOrder: computed('data', function() {

--- a/app/models/attendee.js
+++ b/app/models/attendee.js
@@ -7,7 +7,7 @@ export default ModelBase.extend({
   /**
    * Attributes
    */
-  sameAsBuyer                 : attr('boolean', { defaultValue: true }),
+  sameAsBuyer                 : attr('boolean', { defaultValue: false }),
   city                        : attr('string'),
   firstname                   : attr('string'),
   lastname                    : attr('string'),


### PR DESCRIPTION
Fixes #8905

When starting a new ticket buy submission, the "attendee is same as buyer" option was initially checked and filled in the buyer's credentials into the attendee section. However, this was only the case, if the buyer already had a first and last name given. This caused problems in cases where those names were only added later on. To solve this bug, the "attendee is same as buyer" option is now deactivated by default and the information is only auto-filled in the attendee's section, once that box is checked again.

PS: That also resolves the comment of @norbusan under PR #8891 to adjust the code, in order to treat attendees with only a first or a last name in the same way, as people, who have a first and a last name.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
