### PR TITLE
feat #8906: updating attendee form questions

### DIFF
--- a/app/components/forms/orders/attendee-list.js
+++ b/app/components/forms/orders/attendee-list.js
@@ -4,7 +4,8 @@ import { action, computed } from '@ember/object';
 import { groupBy } from 'lodash-es';
 import { or } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
-import { languageForms } from 'open-event-frontend/utils/dictionary/language-form';
+import { languageForms1 } from 'open-event-frontend/utils/dictionary/language-form-1';
+import { languageForms2 } from 'open-event-frontend/utils/dictionary/language-form-2';
 
 @classic
 export default class AttendeeList extends Component {
@@ -20,10 +21,10 @@ export default class AttendeeList extends Component {
   get holders() {
     this.data.attendees.forEach(attendee => {
       if (attendee.language_form_1) {
-        this.languageFormMapCodeToName(attendee, 'language_form_1');
+        this.languageFormMapCodeToName(attendee, 'language_form_1', languageForms1);
       }
       if (attendee.language_form_2) {
-        this.languageFormMapCodeToName(attendee, 'language_form_2');
+        this.languageFormMapCodeToName(attendee, 'language_form_2', languageForms2);
       }
       if (attendee.gender) {
         this.genderAddSpaces(attendee);
@@ -32,10 +33,10 @@ export default class AttendeeList extends Component {
     return this.data.attendees;
   }
 
-  languageFormMapCodeToName(attendee, key) {
+  languageFormMapCodeToName(attendee, key, possibleLanguages) {
     const languageFormMap = [];
     const languageFormList = attendee[key].split(',');
-    languageForms.forEach(languageForm => {
+    possibleLanguages.forEach(languageForm => {
       languageFormList.forEach(item => {
         if (item === languageForm.code) {
           languageFormMap.push(languageForm.name);

--- a/app/components/forms/orders/order-form.js
+++ b/app/components/forms/orders/order-form.js
@@ -14,7 +14,8 @@ import { genders } from 'open-event-frontend/utils/dictionary/genders';
 import { ageGroups } from 'open-event-frontend/utils/dictionary/age-groups';
 import { countries } from 'open-event-frontend/utils/dictionary/demography';
 import { years } from 'open-event-frontend/utils/dictionary/year-list';
-import { languageForms } from 'open-event-frontend/utils/dictionary/language-form';
+import { languageForms1 } from 'open-event-frontend/utils/dictionary/language-form-1';
+import { languageForms2 } from 'open-event-frontend/utils/dictionary/language-form-2';
 import { homeWikis } from 'open-event-frontend/utils/dictionary/home-wikis';
 import { booleanComplex } from 'open-event-frontend/utils/dictionary/boolean_complex';
 import { wikiScholarship } from 'open-event-frontend/utils/dictionary/wiki-scholarship';
@@ -651,7 +652,8 @@ export default Component.extend(FormMixin, {
   ageGroups       : orderBy(ageGroups, 'position'),
   countries       : orderBy(countries, 'name'),
   years           : orderBy(years, 'year'),
-  languageForms   : orderBy(languageForms, 'name'),
+  languageForms1  : orderBy(languageForms1, 'name'),
+  languageForms2  : orderBy(languageForms2, 'name'),
   homeWikis       : orderBy(homeWikis, 'item'),
   wikiScholarship : orderBy(wikiScholarship, 'position'),
   booleanComplex  : orderBy(booleanComplex, 'position'),

--- a/app/templates/components/forms/orders/order-form.hbs
+++ b/app/templates/components/forms/orders/order-form.hbs
@@ -230,7 +230,7 @@
                     @checked={{get holder field.identifierPath}}         
                     @name={{if field.isRequired (concat field.fieldIdentifier "_required_" index) (concat field.fieldIdentifier "_" index)}}       
                     @onChange={{action (mut (get holder field.identifierPath))}} />
-                    <span>{{t 'I consent to having my photo taken at Wikimania per the'}} </span>
+                    <span>{{t 'I consent to the Wikimania'}} </span>
                     <a href="https://wikimania.wikimedia.org/wiki/2023:Photography_policy">{{t 'photo policy'}}</a>
                     <span> .</span>
                 {{else if (eq field.fieldIdentifier 'is_consent_form_field_email')}}
@@ -268,9 +268,17 @@
                     </div>
                   </UiDropdown>
                 {{/if}}
-                {{#if (or (eq field.fieldIdentifier "language_form_1") (eq field.fieldIdentifier "language_form_2"))}}
+                {{#if (eq field.fieldIdentifier "language_form_1")}}
                   <Widgets::Forms::UiCheckboxGroup 
-                    @options={{languageForms}}
+                    @options={{languageForms1}}
+                    @onChange={{action "updateLanguageFormsSelection"}}
+                    @holder={{holder}}
+                    @field={{field}}
+                  />
+                {{/if}}
+                {{#if (eq field.fieldIdentifier "language_form_2")}}
+                  <Widgets::Forms::UiCheckboxGroup 
+                    @options={{languageForms2}}
                     @onChange={{action "updateLanguageFormsSelection"}}
                     @holder={{holder}}
                     @field={{field}}

--- a/app/utils/dictionary/language-form-1.ts
+++ b/app/utils/dictionary/language-form-1.ts
@@ -1,0 +1,37 @@
+export const languageForms1 = [
+  {
+    name      : 'English',
+    code      : 'en-US',
+    isChecked : false
+  },
+  {
+    name      : 'Español',
+    code      : 'es-ES',
+    isChecked : false
+  },
+  {
+    name      : 'عربي',
+    code      : 'ar',
+    isChecked : false
+  },
+  {
+    name      : '中文',
+    code      : 'zh-CN',
+    isChecked : false
+  },
+  {
+    name      : 'Français',
+    code      : 'fr-FR',
+    isChecked : false
+  },
+  {
+    name      : 'Bahasa Indonesia',
+    code      : 'id',
+    isChecked : false
+  },
+  {
+    name      : 'Other',
+    code      : 'other',
+    isChecked : false
+  }
+];

--- a/app/utils/dictionary/language-form-2.ts
+++ b/app/utils/dictionary/language-form-2.ts
@@ -1,4 +1,4 @@
-export const languageForms = [
+export const languageForms2 = [
   {
     name      : 'English',
     code      : 'en-US',
@@ -10,7 +10,7 @@ export const languageForms = [
     isChecked : false
   },
   {
-    name      : 'عرب',
+    name      : 'عربي',
     code      : 'ar',
     isChecked : false
   },


### PR DESCRIPTION
Fixes #8906

1. The prompt was changed from "I consent to having my photo taken at Wikimania per the [photo policy](https://wikimania.wikimedia.org/wiki/2023:Photography_policy) ." to "I consent to the Wikimania [photo policy](https://wikimania.wikimedia.org/wiki/2023:Photography_policy)."
2. I added the option "Other" to the question "What is your native language, or what language are you most fluent in?". As this option is not needed in the question "Are you fluent in any other of the following languages?", a separation of the dictionary ```language_form.ts``` was needed into one dictionary with options for language question no. 1 (about the native language) and one dictionary for language question no. 2 (about the other languages).
3. The Arabic word for "Arabic" was corrected from عرب to عربی.

The form now looks like this:

![Screenshot_20230703_122122](https://github.com/fossasia/open-event-frontend/assets/127369686/161dd6f9-e748-443a-b1b7-57f59bb39c5c)

And leads to this overview page:

![Screenshot_20230703_122213](https://github.com/fossasia/open-event-frontend/assets/127369686/a8311843-2a12-4c83-be4d-0e2d22d15769)

#### Open Problems

The new texts "I consent to the Wikimania" and "Other" still need translations. I added this to issue #8883.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
