### PR TITLE
Fix access code ticket disappearing 

### DIFF
--- a/app/components/public/ticket-list.js
+++ b/app/components/public/ticket-list.js
@@ -56,6 +56,11 @@ export default Component.extend(FormMixin, {
       });
     }
 
+    // since this.data only contains the initial tickets
+    // we need to make sure that the tickets added via access code
+    // are added to the list.
+    // We do that below once with this.tickets.addObject(ticket),
+    // but this value will be overwritten here on recomputation
     return this.data.sortBy('position').map(ticket => {
       const ticketExtra = ticketMap[ticket.id];
 
@@ -65,7 +70,7 @@ export default Component.extend(FormMixin, {
       }
 
       return ticket;
-    });
+    }).concat(this.accessCodeTickets);
   }),
 
   hasTicketsInOrder: computed('tickets.@each.orderQuantity', function() {


### PR DESCRIPTION
Fixes #8919 

#### Short description of what this resolves:

When a ticket is shown via access code, it disappears when a ticket number is selected

#### Changes proposed in this pull request:

Fix for the original issue: `this.tickets` is a computed property that is initialized from `this.data` which
only contains the tickets that are shown by default. During the toggling of promo code, the access
code related ticket is added to `this.tickets` via `.addObject`, but when the cache is invalidated by
changing the property `orderAmount`, `this.tickets` is recomputed and falls back to the initial set
of tickets without the access code ticket.

Solution is to always add `this.accessCodeTickets` which contains the additional tickets.

Another fix proposed is to make the logic about promotional code handling correct.
As of now, if a promotional code is passed in, the code checks both access code and
discount code, and if one of those is not valid, lists the code as invalid.
Since access codes are checked first, the later check for discount code will disable the promotional code.

Use two separate booleans to check for these two cases.


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
