### PR TITLE
fix #8844 make dates translatable

### DIFF
--- a/app/services/l10n.js
+++ b/app/services/l10n.js
@@ -72,6 +72,15 @@ export default class L10nService extends L10n {
 
     this.setLocale(locale);
     if (locale !== 'en') {
+
+      if(locale === 'zh_Hans') {
+        locale = 'zh-cn'
+      } else if(locale === 'zh_Hant') {
+        locale = 'zh-tw'
+      } else if(locale === 'nb_NO') {
+        locale = 'nb'
+      }
+
       getScript(`/assets/moment-locales/${locale}.js`)
         .then(() => {
           moment.locale(locale);


### PR DESCRIPTION
Fixed issue #8844 

#### Short description of what this resolves:
The date is not translate for Chinese and Bokmål because of `moment.js` translation file name.

#### Changes proposed in this pull request:

- Add logic to modify translation file name to match with `moment.js` library.

#### Checklist

- [X ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
