### PR TITLE
fix #8965 set no paginaton for tickets to override default server

### DIFF
--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -29,7 +29,9 @@ export default class extends Route.extend(EmberTableRouteMixin) {
     const socialLinksPromise = eventDetails.query('socialLinks', {});
     const statisticsPromise = eventDetails.query('generalStatistics', {});
     const orderStatPromise = eventDetails.query('orderStatistics', {});
-    const ticketsPromise = eventDetails.query('tickets', {});
+    const ticketsPromise = eventDetails.query('tickets', {
+      'page[size]'   : 50
+    });
 
     const [sponsors, roleInvites, sessionTypes, tracks, microlocations, speakersCall, socialLinks,
       statistics, orderStat, tickets, usersEventsRoles] = (await allSettled([sponsorsPromise, roleInvitesPromise, sessionTypesPromise, tracksPromise, microlocationsPromise, speakersCallPromise, socialLinksPromise,

--- a/app/routes/events/view/index.js
+++ b/app/routes/events/view/index.js
@@ -30,7 +30,7 @@ export default class extends Route.extend(EmberTableRouteMixin) {
     const statisticsPromise = eventDetails.query('generalStatistics', {});
     const orderStatPromise = eventDetails.query('orderStatistics', {});
     const ticketsPromise = eventDetails.query('tickets', {
-      'page[size]'   : 50
+      'page[size]'   : 0
     });
 
     const [sponsors, roleInvites, sessionTypes, tracks, microlocations, speakersCall, socialLinks,

--- a/app/routes/public/index.js
+++ b/app/routes/public/index.js
@@ -32,7 +32,8 @@ export default class IndexRoute extends Route {
         }
       ],
       cache  : true,
-      public : true
+      public : true,
+      'page[size]' : 0
     });
     const featuredSpeakersPromise = event.query('speakers', {
       filter: [


### PR DESCRIPTION
Server has page size of 20 if query is empty due to old package not migrated
setting 0 for no pagination

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
