### PR TITLE
feature-8884:Form answers are in English instead of the local languag…

### DIFF
--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -48,7 +48,7 @@
                         {{#if (is-url-field field.fieldIdentifier)}}
                           <a href="{{get holder field.identifierPath}}">{{get holder field.identifierPath}}</a>
                         {{else}}
-                          <span class="word-break">{{get holder field.identifierPath}}</span>
+                          <span class="word-break">{{t (get holder field.identifierPath) }}</span>
                         {{/if}}
                       {{else}}
                         <Input type="text" placeholder={{t-var field.name}}  @value={{get holder field.identifierPath}}/>
@@ -56,7 +56,7 @@
                     {{else if (eq field.type 'paragraph')}}
                     <span class="line-break">{{get holder field.identifierPath}}</span>
                     {{else if (eq field.type 'select')}}
-                      <span class="word-break">{{get holder field.identifierPath}}</span>
+                      <span class="word-break">{{t (get holder field.identifierPath)}}</span>
                     {{else if (eq field.type 'checkbox')}}
                       {{#if (or (eq field.fieldIdentifier "native_language") (eq field.fieldIdentifier "fluent_language") (eq field.fieldIdentifier "language_form_1") (eq field.fieldIdentifier "language_form_2") (eq field.fieldIdentifier "gender"))}}
                         <span class="word-break">{{get holder (concat field.fieldIdentifier '_name_mapping')}}</span>
@@ -71,7 +71,7 @@
                       {{/if}}
                     {{else}}
                       {{#if (not field.isComplex)}}
-                        <span class="word-break">{{sanitize (get holder field.identifierPath)}}</span>
+                        <span class="word-break">{{ sanitize (get holder field.identifierPath)}}</span>
                       {{else}}
                         <span class="word-break">{{t (get holder field.identifierPath)}}</span>
                       {{/if}}

--- a/app/templates/components/forms/orders/attendee-list.hbs
+++ b/app/templates/components/forms/orders/attendee-list.hbs
@@ -59,7 +59,7 @@
                       <span class="word-break">{{t (get holder field.identifierPath)}}</span>
                     {{else if (eq field.type 'checkbox')}}
                       {{#if (or (eq field.fieldIdentifier "native_language") (eq field.fieldIdentifier "fluent_language") (eq field.fieldIdentifier "language_form_1") (eq field.fieldIdentifier "language_form_2") (eq field.fieldIdentifier "gender"))}}
-                        <span class="word-break">{{get holder (concat field.fieldIdentifier '_name_mapping')}}</span>
+                        <span class="word-break">{{t (get holder (concat field.fieldIdentifier '_name_mapping'))}}</span>
                       {{else}}
                         <span class="word-break">
                           {{#if (get holder field.identifierPath)}}

--- a/translations/ar.po
+++ b/translations/ar.po
@@ -12286,3 +12286,23 @@ msgstr "تحديثات البريد الإلكتروني Wikimania"
 #: app/templates/components/forms/orders/order-form.hbs:259:26
 msgid "I want to receive email updates about future Wikimania editions."
 msgstr "أرغب في تلقي تحديثات عبر البريد الإلكتروني حول إصدارات Wikimania المستقبلية."
+
+#: app/components/forms/orders/order-form.js:256:19
+msgid "Please enter your wiki scholarship."
+msgstr "الرجاء إدخال منحة ويكي الخاصة بك."
+
+#: app/models/custom-form.js:115:30
+msgid "Have you received a Wikimania scholarship?"
+msgstr "هل حصلت على منحة ويكيمانيا؟"
+
+#: app/utils/dictionary/wiki-scholarship.ts:5:10
+msgid "No, I haven't"
+msgstr "لا ، لم أفعل"
+
+#: app/utils/dictionary/wiki-scholarship.ts:9:10
+msgid "Yes, from the Wikimedia Foundation"
+msgstr "نعم ، من مؤسسة ويكيميديا"
+
+#: app/utils/dictionary/wiki-scholarship.ts:13:10
+msgid "Yes, from a Wikimedia affiliate"
+msgstr "نعم ، من شركة تابعة لويكيميديا"

--- a/translations/bn.po
+++ b/translations/bn.po
@@ -2192,7 +2192,7 @@ msgstr ""
 msgid "Facebook"
 msgstr "ফেসবুক"
 
-#: app/components/public/session-item.hbs:131:113
+#: app/components/public/session-item.hbs:131:119
 #: app/models/custom-form.js:100:27
 msgid "LinkedIn"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 #: app/templates/components/public/exhibition-view.hbs:65:132
 #: app/templates/components/public/exhibition-view.hbs:68:136
 msgid "Email"
-msgstr ""
+msgstr "ইমেইল"
 
 #: app/controllers/admin/users/list.js:49:26
 #: app/routes/admin/permissions/system-roles.js:9:11
@@ -3647,7 +3647,7 @@ msgstr ""
 
 #: app/models/custom-form.js:104:27
 msgid "Photo & video & text consent"
-msgstr ""
+msgstr "ফটো এবং ভিডিও এবং পাঠ্য সম্মতি"
 
 #: app/models/custom-form.js:105:27
 msgid "Partner contact consent"
@@ -7042,7 +7042,7 @@ msgstr ""
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:3:4
 #: app/utils/dictionary/boolean-complex.ts:5:15
 msgid "Yes"
-msgstr ""
+msgstr "হ্যাঁ"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:51:26
 #: app/templates/components/modals/confirm-modal.hbs:32:75
@@ -7050,7 +7050,7 @@ msgstr ""
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:5:4
 #: app/utils/dictionary/boolean-complex.ts:9:15
 msgid "No"
-msgstr ""
+msgstr "না"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:71:12
 #: app/templates/components/forms/orders/order-form.hbs:191:10

--- a/translations/hi.po
+++ b/translations/hi.po
@@ -3680,7 +3680,7 @@ msgstr ""
 
 #: app/models/custom-form.js:104:27
 msgid "Photo & video & text consent"
-msgstr ""
+msgstr "फ़ोटो एवं वीडियो एवं पाठ सहमति"
 
 #: app/models/custom-form.js:105:27
 msgid "Partner contact consent"
@@ -7077,7 +7077,7 @@ msgstr ""
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:3:4
 #: app/utils/dictionary/boolean-complex.ts:5:15
 msgid "Yes"
-msgstr ""
+msgstr "हाँ"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:51:26
 #: app/templates/components/modals/confirm-modal.hbs:32:75
@@ -7085,7 +7085,7 @@ msgstr ""
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:5:4
 #: app/utils/dictionary/boolean-complex.ts:9:15
 msgid "No"
-msgstr ""
+msgstr "नहीं"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:71:12
 #: app/templates/components/forms/orders/order-form.hbs:191:10

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -7219,7 +7219,7 @@ msgstr "Pobierz bilet"
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:3:4
 #: app/utils/dictionary/boolean-complex.ts:5:15
 msgid "Yes"
-msgstr "Yes"
+msgstr "Tak"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:51:26
 #: app/templates/components/modals/confirm-modal.hbs:32:75
@@ -7227,7 +7227,7 @@ msgstr "Yes"
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:5:4
 #: app/utils/dictionary/boolean-complex.ts:9:15
 msgid "No"
-msgstr "No"
+msgstr "NIE"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:71:12
 #: app/templates/components/forms/orders/order-form.hbs:191:10

--- a/translations/zh_Hant.po
+++ b/translations/zh_Hant.po
@@ -7076,14 +7076,14 @@ msgstr "下載門票"
 #: app/templates/components/modals/publish-unpublish-modal.hbs:31:4
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:3:4
 msgid "Yes"
-msgstr "Yes"
+msgstr "是的"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:51:26
 #: app/templates/components/modals/confirm-modal.hbs:32:75
 #: app/templates/components/modals/edit-user-modal.hbs:10:40
 #: app/templates/components/ui-table/cell/events/view/sessions/cell-is-mail-sent.hbs:5:4
 msgid "No"
-msgstr "No"
+msgstr "不"
 
 #: app/templates/components/forms/orders/attendee-list.hbs:71:12
 #: app/templates/components/forms/orders/order-form.hbs:191:10


### PR DESCRIPTION
…e on the overview page

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8884

#### Short description of what this resolves:
Form answers are in English instead of the local language on the overview page

#### Changes proposed in this pull request:

- Form answers are in English instead of the local language on the overview page


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
