### PR TITLE
fix-8981: Badge form shown as green used even though is deactivated

### DIFF
--- a/app/templates/components/events/view/overview/event-setup-checklist.hbs
+++ b/app/templates/components/events/view/overview/event-setup-checklist.hbs
@@ -48,10 +48,10 @@
         </div>
       </div>
     </a>
-    <a href="{{href-to 'events.view.edit.badge'}}" class="ui segment {{unless this.data.event.isTicketFormEnabled 'secondary'}} grid no margin">
+    <a href="{{href-to 'events.view.edit.badge'}}" class="ui segment {{unless this.data.event.isBadgesEnabled 'secondary'}} grid no margin">
       <div class="ui row">
         <div class="column one wide">
-          <i class="{{if this.data.event.isTicketFormEnabled 'checkmark green' 'warning black'}} big icon"></i>
+          <i class="{{if this.data.event.isBadgesEnabled 'checkmark green' 'warning black'}} big icon"></i>
         </div>
         <div class="column fifteen wide">
           <h4 class="ui header">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8981 

#### Short description of what this resolves:
- Badge form shown as green used even though is deactivated

#### Changes proposed in this pull request:
- Badge form shown as green used even though is deactivated

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
