### PR TITLE
fix-9004: Speakers page lazy loading gets stuck and does not load fro…

### DIFF
--- a/app/templates/public/speakers.hbs
+++ b/app/templates/public/speakers.hbs
@@ -10,7 +10,7 @@
     </div>
   {{/each}}
   <div class="sixteen wide column">
-    <InfinityLoader @infinityModel={{this.model.speakers}} @triggerOffset={{1000}} @eventDebounce={{50}}>
+    <InfinityLoader @infinityModel={{this.model.speakers}} @triggerOffset={{100}} @eventDebounce={{50}}>
       <div class="ui loading very padded basic segment">
       </div>
       {{this.infintyModel.reachedInfinity}}


### PR DESCRIPTION
…m cache

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9004

#### Short description of what this resolves:
- Speakers page lazy loading gets stuck and does not load from cache

#### Changes proposed in this pull request:
- Speakers page lazy loading gets stuck and does not load from cache

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
