### PR TITLE
fix-8882: Ticket Order Page shows correct time with wrong time zone info

### DIFF
--- a/app/templates/orders/new.hbs
+++ b/app/templates/orders/new.hbs
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="column">
         <div class="ui small gray-text">
-          {{general-date this.model.order.event.startsAt 'date-time-long'}} - {{general-date this.model.order.event.endsAt 'date-time-long'}} ({{this.model.order.event.timezone}})
+          {{general-date this.model.order.event.startsAt 'date-time-long'}} - {{general-date this.model.order.event.endsAt 'date-time-long'}} {{general-date this.model.order.event.endsAt 'tz'}}
           <br>
           {{this.model.order.event.locationName}}
         </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8882 

#### Short description of what this resolves:
- Ticket Order Page shows correct time with wrong time zone info

#### Changes proposed in this pull request:
- Ticket Order Page shows correct time with wrong time zone info

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
