### PR TITLE
Fix: Event image spacing below

### DIFF
--- a/app/styles/partials/overrides.scss
+++ b/app/styles/partials/overrides.scss
@@ -27,6 +27,7 @@ body.dimmable.undetached.dimmed {
 
 .ui.fluid.container {
   padding: 0 20px;
+  margin-top: 0;
 }
 
 @media screen and (min-width: 768px) and (max-width: 992px) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9091 

#### Short description of what this resolves:
Removed the extra spacing above the event image in both the web and mobile view.

![1](https://github.com/fossasia/open-event-frontend/assets/104292766/7477f5c5-4628-4bc7-b220-a53cf1b355c3)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
