### PR TITLE
fix-8850:  Schedule displays sessions twice

### DIFF
--- a/app/routes/public/sessions.js
+++ b/app/routes/public/sessions.js
@@ -220,7 +220,7 @@ export default class SessionsRoute extends Route {
       session : await this.infinity.model('sessions', {
         include      : 'track,speakers,session-type,favourite,microlocation.video-stream',
         filter       : filterOptions,
-        sort         : params.sort || 'starts-at',
+        sort         : params.sort ? params.sort + ',id' : 'starts-at,id',
         perPage      : 6,
         startingPage : 1,
         perPageParam : 'page[size]',


### PR DESCRIPTION

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #https://github.com/fossasia/open-event-server/issues/8850

#### Short description of what this resolves:
Schedule displays sessions twice

#### Changes proposed in this pull request:
Schedule displays sessions twice
-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
