### PR TITLE
fix-9090: Cursor jumps to front of text paragraph text fields

### DIFF
--- a/app/components/widgets/forms/rich-text-link.js
+++ b/app/components/widgets/forms/rich-text-link.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Component from '@ember/component';
 import { debounce } from '@ember/runloop';
-import { observer, computed } from '@ember/object';
+import { computed } from '@ember/object';
 import { v4 } from 'ember-uuid';
 import { isTesting } from 'open-event-frontend/utils/testing';
 
@@ -33,12 +33,6 @@ export default Component.extend({
       }
     }
   },
-
-  valueObserver: observer('value', function() {
-    if (this.editor && this.editor.getValue() !== this.value) {
-      this.editor.setValue(this.value);
-    }
-  }),
 
   textareaIdGenerated: computed('textareaId', function() {
     return this.textareaId ? this.textareaId : v4();

--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -13,7 +13,7 @@ export const humanReadableBytes = (sizeInKb, absolute = true, si = true) => {
   do {
     bytes /= thresh;
     ++u;
-  } while (Math.round(Math.abs(bytes)*100)/100 >= thresh && u < units.length - 1);
+  } while (Math.round(Math.abs(bytes) * 100) / 100 >= thresh && u < units.length - 1);
   return `${bytes.toFixed(absolute ? 0 : 1)} ${units[u]}`;
 };
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9090

#### Short description of what this resolves:
- Cursor jumps to front of text paragraph text fields

#### Changes proposed in this pull request:
- Cursor jumps to front of text paragraph text fields

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
