### PR TITLE
fix-9085: When creating a speaker sort the option to add sessions alp…

### DIFF
--- a/app/components/forms/session-speaker-form.js
+++ b/app/components/forms/session-speaker-form.js
@@ -415,6 +415,10 @@ export default Component.extend(FormMixin, {
     return this.sessions.length === 1;
   }),
 
+  getSessions: computed('sessions', function() {
+    return orderBy(this.sessions.toArray(), 'title');
+  }),
+
   shouldShowNewSessionDetails: computed('sessionDetails', 'newSessionSelected', function() {
     return this.newSessionSelected && !this.sessionDetails;
   }),

--- a/app/routes/events/view/chat.js
+++ b/app/routes/events/view/chat.js
@@ -21,6 +21,8 @@ export default class extends Route.extend(EmberTableRouteMixin) {
       'page[size]'   : params.per_page || 25,
       'page[number]' : params.page || 1
     };
+    params.sort_by = 'position';
+    params.sort_dir = 'ASC';
     queryString = this.applySortFilters(queryString, params);
 
     const rooms = this.asArray(event.query('microlocations', queryString));

--- a/app/templates/components/forms/session-speaker-form.hbs
+++ b/app/templates/components/forms/session-speaker-form.hbs
@@ -104,7 +104,7 @@
         {{t 'Select Session'}}
       </div>
       <div class="menu">
-        {{#each this.sessions as |session|}}
+        {{#each this.getSessions as |session|}}
           {{#if session.id}}
             <div data-value="{{map-value mapper session}}" class="item">
               {{session.title}}


### PR DESCRIPTION
…habetically

fix-9087: On the organizer chat configuration page sort rooms according to the definition in the wizard

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9085 #9087 

#### Short description of what this resolves:
- On the organizer chat configuration page sort rooms according to the definition in the wizard
- When creating a speaker sort the option to add sessions alphabetically

#### Changes proposed in this pull request:

- On the organizer chat configuration page sort rooms according to the definition in the wizard
- When creating a speaker sort the option to add sessions alphabetically

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
