### PR TITLE
feature-9046: Order of video rooms should follow setting in wizard

### DIFF
--- a/app/routes/events/view/videoroom/list.js
+++ b/app/routes/events/view/videoroom/list.js
@@ -31,6 +31,8 @@ export default class extends Route.extend(EmberTableRouteMixin) {
       'page[size]'   : params.per_page || 25,
       'page[number]' : params.page || 1
     };
+    params.sort_by = 'position';
+    params.sort_dir = 'ASC';
     queryString = this.applySortFilters(queryString, params);
 
     const rooms = this.asArray(event.query('microlocations', queryString));


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9046 

#### Short description of what this resolves:
- Order of video rooms should follow setting in wizard

#### Changes proposed in this pull request:

- sort microlocation with location filter


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
