### PR TITLE
fix-9120: Event is still saved when an invalid value is entered in 'F…

### DIFF
--- a/app/components/forms/wizard/sessions-speakers-step.js
+++ b/app/components/forms/wizard/sessions-speakers-step.js
@@ -53,6 +53,16 @@ export default Component.extend(EventWizardMixin, FormMixin, {
             }
           ]
         },
+        floor: {
+          identifier : 'floor',
+          rules      : [
+            {
+              type   : 'regExp',
+              value  : '/^\d+$/',
+              prompt : this.l10n.t('Please enter a valid floor number.')
+            }
+          ]
+        },
         privateLink: {
           identifier : 'private_link',
           rules      : [

--- a/app/components/side-bar.js
+++ b/app/components/side-bar.js
@@ -1,7 +1,7 @@
 import classic from 'ember-classic-decorator';
 import $ from 'jquery';
 import Component from '@ember/component';
-import { action, computed} from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 @classic

--- a/app/templates/components/forms/wizard/sessions-speakers-step.hbs
+++ b/app/templates/components/forms/wizard/sessions-speakers-step.hbs
@@ -83,11 +83,11 @@
       {{#each this.microlocations as |microlocation index|}}
         <div class="{{if this.device.isMobile 'grouped'}} fields">
           <div class="{{unless this.device.isMobile 'three wide'}} field">
-            <Input @type="text" @value={{microlocation.name}} placeholder={{t "Name"}} />
+            <Input @type="text" @name="microlocation" @value={{microlocation.name}} placeholder={{t "Name"}} />
           </div>
           <div class="{{unless this.device.isMobile 'four wide'}} field">
             <div class="ui action input fluid">
-              <Input @type="number" @value={{microlocation.floor}} placeholder={{t "Floor"}} />
+              <Input @type="number" @name="floor" @value={{microlocation.floor}} placeholder={{t "Floor"}} />
               {{#if (gt this.microlocations.length 1)}}
                 <button class="ui icon red button" type="button" {{action 'removeRoom' microlocation 'microlocation' index}}>
                   <i class="minus icon"></i>


### PR DESCRIPTION
…loor' in the 'Sessions & Speakers' page

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9120

#### Short description of what this resolves:
- Event is still saved when an invalid value is entered in "Floor" in the "Sessions & Speakers" page

#### Changes proposed in this pull request:
- Event is still saved when an invalid value is entered in "Floor" in the "Sessions & Speakers" page

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
