### PR TITLE
fix-9139: The Expired tab of Access Codes Page has navigated wrong th…

### DIFF
--- a/app/templates/events/view/tickets/access-codes.hbs
+++ b/app/templates/events/view/tickets/access-codes.hbs
@@ -24,7 +24,7 @@
           <LinkTo @route="events.view.tickets.access-codes.list" @model="inactive" class="item">
             {{t 'Inactive'}}
           </LinkTo>
-          <LinkTo @route="events.view.tickets.discount-codes.list" @model="expired" class="item">
+          <LinkTo @route="events.view.tickets.access-codes.list" @model="expired" class="item">
             {{t 'Expired'}}
           </LinkTo>
         </TabbedNavigation>


### PR DESCRIPTION
…rought Discount Codes Page.

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9139

#### Short description of what this resolves:
The "Expired" tab of Access Codes Page has navigated wrong throught Discount Codes Page

#### Changes proposed in this pull request:

-The "Expired" tab of Access Codes Page has navigated wrong throught Discount Codes Page

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
