### PR TITLE
fix 9140: The value of the status dropdown list cannot be displayed in full 

### DIFF
--- a/app/styles/pages/events.scss
+++ b/app/styles/pages/events.scss
@@ -266,7 +266,23 @@
 }
 
 .session-list .table tbody  tr {
-  &:nth-last-child(2), &:nth-last-child(3) {
+  &:nth-last-child(2) {
+    .ui.dropdown.button {
+      position: relative;
+    }
+
+    .menu {
+      position: absolute;
+      transform: translateY(-122%);
+      transition: transform .3s ease-in-out;
+    }
+
+    .menu.hidden.transition {
+      position: relative;
+    }
+  }
+
+  &:nth-last-child(3) {
     .ui.dropdown.button {
       position: relative;
     }

--- a/app/styles/pages/events.scss
+++ b/app/styles/pages/events.scss
@@ -256,3 +256,29 @@
     min-width: 7rem;
   }
 }
+
+.reset-overflow {
+  .z-index-0 {
+    div {
+      overflow: visible !important;
+    }
+  }
+}
+
+.session-list .table tbody  tr {
+  &:nth-last-child(2), &:nth-last-child(3) {
+    .ui.dropdown.button {
+      position: relative;
+    }
+
+    .menu {
+      position: absolute;
+      transform: translateY(-122%);
+      transition: transform .3s ease-in-out;
+    }
+
+    .menu.hidden.transition {
+      position: relative;
+    }
+  }
+}

--- a/app/templates/events/view/sessions/list.hbs
+++ b/app/templates/events/view/sessions/list.hbs
@@ -1,4 +1,4 @@
-<div class="sixteen wide column">
+<div class="sixteen wide column session-list {{if (lte this.model.sessions.data.length 1) 'reset-overflow'}}">
   <Tables::Default
     @columns={{this.columns}}
     @rows={{this.model.sessions.data}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9140

#### Short description of what this resolves:
The value of the status dropdown list cannot be displayed in full

#### Changes proposed in this pull request:

-  The value of the status dropdown list cannot be displayed in full
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
