### PR TITLE
 Mobile navbar bug #9177 

### DIFF
--- a/app/templates/components/side-bar.hbs
+++ b/app/templates/components/side-bar.hbs
@@ -1,4 +1,4 @@
-<div class="ui left inverted vertical menu sidebar {{if this.sidebarVisible 'visible'}}">
+<div class="ui left overlay inverted vertical menu sidebar {{if this.sidebarVisible 'visible'}}">
   {{#if (not this.isEventPageRoute)}}
   <div class="search-bar d-flex items-center space-between m-2 p-2">
       <Input @class="prompt" @type="text" @key-up={{action "handleKeyPress"}} @value={{this.event_name}} placeholder={{t "Search"}} />

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ember-cli-dotenv": "^3.1.0",
     "ember-cli-fastboot": "^4.1.1",
     "ember-cli-flash": "^2.2.0",
+    "ember-cli-github-pages": "^0.2.2",
     "ember-cli-head": "^2.0.0",
     "ember-cli-html-minifier": "^1.1.0",
     "ember-cli-htmlbars": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8006,6 +8006,14 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
 
+ember-cli-github-pages@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-github-pages/-/ember-cli-github-pages-0.2.2.tgz#cef01ed1de9ddd82863b310fef05e7f5b55beb9e"
+  integrity sha512-pFtruVBZ5OW1O1MiGQRQSQewW9DSBx6ZbRcbVpcpTlZqeDyWs5nyvhOm4qRFwK6m+jQPe2l52cYtf1rUAkBNxA==
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+    rsvp "^4.7.0"
+
 ember-cli-head@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-2.0.0.tgz#ce294341026fd643067712a438008d6139f5208d"


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #9177

#### Short description of what this resolves:
The mobile navbar which shifts content in x axis rather than overlapping on it now overlays above the content with no more x-axis content shift happening.

#### Changes proposed in this pull request:
- Fixes #9177 : by applying a CSS class called "overlay" which seems  to be coming from Semantic UI, a popular front-end framework.
- Changes have been made in a file called side-bar.hbs under /components
- The first line of code is where the change was made.
- Screenshot of the fix
![Screenshot 2024-01-28 at 15-57-42 eventyay](https://github.com/fossasia/open-event-frontend/assets/26376179/7eac0113-791b-48ed-ac0f-96634f167367)


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
