### PR TITLE
Fix : Dynamically set html lang attribute based on selected language (#9193)

### DIFF
--- a/app/initializers/set-html-lang.js
+++ b/app/initializers/set-html-lang.js
@@ -1,0 +1,16 @@
+export function initialize(appInstance) {
+  try {
+    const intl = appInstance.lookup('service:intl');
+
+    if (intl && typeof document !== 'undefined') {
+      const lang = intl?.locale?.[0] || 'en';
+      document.documentElement.lang = lang;
+    }
+  } catch (e) {
+    console.error('Failed to set lang attribute:', e);
+  }
+}
+
+export default {
+  initialize
+};


### PR DESCRIPTION
Fixes #9193

#### Short description of what this resolves:

This resolves an issue where the `<html lang="en">` attribute was hardcoded, preventing proper accessibility and locale-based styling. It sets the `lang` attribute dynamically based on the active language in the app.

#### Changes proposed in this pull request:

- Added a new Ember initializer `set-html-lang`
- Used `appInstance.lookup('service:intl')` to get the current locale
- Set `document.documentElement.lang` dynamically at app boot
- Added error handling for robustness

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- Not required for this PR -->
- [ ] I have added necessary documentation (if appropriate)

## Summary by Sourcery

Initialize the HTML lang attribute dynamically from the Ember Intl service on application boot

Bug Fixes:
- Fix hardcoded HTML lang attribute by setting it based on the active locale from the Ember Intl service

Enhancements:
- Add error handling in the initializer to log any failures when setting the lang attribute