### PR TITLE
Initialize groundwork for PWA support

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,3 +13,10 @@ const App = Application.extend({
 loadInitializers(App, config.modulePrefix);
 
 export default App;
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}
+


### PR DESCRIPTION
This PR adds the initial groundwork for Progressive Web App (PWA) support.

### What this PR does
- Registers a service worker at the application entry point
- Lays the foundation for future PWA features like offline support and caching

### Notes
- This is a minimal, non-breaking change
- No existing functionality is affected

Fixes #9204

## Summary by Sourcery

New Features:
- Register a service worker at the application entry point when supported by the browser.