### PR TITLE
Fix incorrect test API URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ It consumes the API exposed by master branch deployment of open event server, ho
 #### Development branch
 
 The **development** branch of open-event-frontend gets deployed at [https://open-event-frontend.now.sh/](https://open-event-frontend.now.sh/)
-It consumes the API exposed by development branch of open event server, hosted at [https://test.eventyay.com](https://test.eventyay.com)
+It consumes the API exposed by development branch of open event server, hosted at [https://test-api.eventyay.com](https://test-api.eventyay.com)
+
 
 ### Release Cycle
 


### PR DESCRIPTION
Fixes #9192

### What does this PR do?
This PR fixes an incorrect API URL mentioned in the README for the development branch.

### Changes proposed in this pull request
- Updated the development branch API URL from `https://test.eventyay.com`
  to `https://test-api.eventyay.com`

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Summary by Sourcery

Documentation:
- Update the README to point the development branch to https://test-api.eventyay.com instead of the outdated https://test.eventyay.com.