### PR TITLE
Fix incorrect test API URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ It consumes the API exposed by master branch deployment of open event server, ho
 #### Development branch
 
 The **development** branch of open-event-frontend gets deployed at [https://open-event-frontend.now.sh/](https://open-event-frontend.now.sh/)
-It consumes the API exposed by development branch of open event server, hosted at [https://test.eventyay.com](https://test.eventyay.com)
+It consumes the API exposed by development branch of open event server, hosted at [https://test-api.eventyay.com](https://test-api.eventyay.com) 
 
 ### Release Cycle
 


### PR DESCRIPTION
Fixes #9192

### What does this PR do?
This PR fixes an incorrect API URL mentioned in the README for the development branch.

### Changes proposed in this pull request
- Updated the development branch API URL from `https://test.eventyay.com`
  to `https://test-api.eventyay.com`


#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
